### PR TITLE
ci: add SGLang N-2 component compatibility matrix

### DIFF
--- a/.github/workflows/compatibility-contract-tests.yml
+++ b/.github/workflows/compatibility-contract-tests.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: Compatibility harness unit tests
+on:
+  pull_request:
+    paths:
+      - 'scripts/compatibility/**'
+      - '.github/workflows/*compatibility*.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/compatibility/**'
+      - '.github/workflows/*compatibility*.yml'
+permissions:
+  contents: read
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Validate the harness without GPUs or registry credentials
+        run: |
+          python3 -m venv "$RUNNER_TEMP/n2-client"
+          "$RUNNER_TEMP/n2-client/bin/pip" install requests==2.32.5
+          "$RUNNER_TEMP/n2-client/bin/python" -m unittest discover -s scripts/compatibility -v
+          "$RUNNER_TEMP/n2-client/bin/python" scripts/compatibility/runner.py \
+            --frontend-image candidate-frontend --worker-image candidate-worker \
+            --output "$RUNNER_TEMP/unused" --plan

--- a/.github/workflows/cross-version-compatibility.yml
+++ b/.github/workflows/cross-version-compatibility.yml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: Cross-version compatibility
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_image:
+        description: Candidate frontend image (tag or digest; resolved once before testing)
+        required: true
+        type: string
+      worker_image:
+        description: Candidate SGLang image (tag or digest; resolved once before testing)
+        required: true
+        type: string
+      release_line:
+        description: Target release line (empty derives it from the checkout)
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      frontend_image:
+        required: true
+        type: string
+      worker_image:
+        required: true
+        type: string
+      release_line:
+        required: false
+        type: string
+        default: ''
+      source_ref:
+        required: false
+        type: string
+        default: ''
+    secrets:
+      HF_TOKEN:
+        required: false
+permissions:
+  contents: read
+jobs:
+  compatibility:
+    # Requires a Docker daemon with NVIDIA runtime, a runner that shares the daemon
+    # network namespace (local Docker or a DinD sidecar), for loopback ports.
+    # Override for installations with a dedicated lane.
+    runs-on: ${{ vars.N2_GPU_RUNNER || 'prod-tester-amd-gpu-v2' }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.source_ref || github.sha }}
+      - name: Log in to candidate registry
+        uses: $/.github/actions/docker-login
+        with:
+          aws_default_region: ${{ vars.AWS_DEFAULT_REGION }}
+          ecr_registry: ${{ vars.ECR_REGISTRY }}
+      - name: Install isolated client dependencies
+        run: |
+          python3 -m venv "$RUNNER_TEMP/n2-client"
+          "$RUNNER_TEMP/n2-client/bin/pip" install requests==2.32.5 huggingface-hub==0.34.4
+      - name: Run CPU contract tests
+        run: "$RUNNER_TEMP/n2-client/bin/python -m unittest discover -s scripts/compatibility -v"
+      - name: Run both scenarios across the N-2 window
+        env:
+          FRONTEND_IMAGE: ${{ inputs.frontend_image }}
+          WORKER_IMAGE: ${{ inputs.worker_image }}
+          RELEASE_LINE: ${{ inputs.release_line }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          "$RUNNER_TEMP/n2-client/bin/python" scripts/compatibility/runner.py \
+            --frontend-image "$FRONTEND_IMAGE" --worker-image "$WORKER_IMAGE" \
+            --release-line "$RELEASE_LINE" --output "$RUNNER_TEMP/n2-results"
+      - name: Upload evidence even on failure
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: n2-compatibility-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/n2-results/report.json
+            ${{ runner.temp }}/n2-results/*/embedding/*
+            ${{ runner.temp }}/n2-results/*/chat/*
+          if-no-files-found: warn

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -896,6 +896,17 @@ jobs:
       image_tag_suffix: '-nightly'
     secrets: inherit
 
+  cross-version-compatibility:
+    name: SGLang N-2 compatibility
+    needs: [sglang-build, frontend-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/cross-version-compatibility.yml
+    with:
+      frontend_image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ needs.resolve-source-sha.outputs.source_sha }}-${{ needs.frontend-build.outputs.target_tag_plain }}-nightly
+      worker_image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ needs.resolve-source-sha.outputs.source_sha }}-${{ needs.sglang-build.outputs.target_tag_plain }}-nightly
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+    secrets: inherit
+
   sglang-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [sglang-build, resolve-source-sha, compute-release-mode]

--- a/scripts/compatibility/README.md
+++ b/scripts/compatibility/README.md
@@ -1,0 +1,120 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cross-version component compatibility
+
+Run real frontend and SGLang worker images independently, with an HTTP client
+from this checkout. No checkout, wheel, or adapter is injected into either
+component. This tests the component boundary used during upgrades; it does not
+perform a Kubernetes rolling upgrade or measure routing capacity.
+
+## Version matrix
+
+For candidate release line N, run these five pairs for **each** scenario:
+
+| Frontend | Worker |
+| --- | --- |
+| candidate | candidate |
+| N-1 | candidate |
+| candidate | N-1 |
+| N-2 | candidate |
+| candidate | N-2 |
+
+`releases.json` selects one published patch per historical minor line. The
+runner defaults N to the checkout's Cargo.toml version. Update this manifest
+when cutting a minor release; missing entries fail, rather than reducing
+coverage. The initial resolver requires two previous minors within the same
+major. A major-version transition needs an explicitly reviewed window policy.
+This samples the listed patch versions, not every historical patch.
+
+Images are pulled once and pinned to their local content IDs before any run.
+The report records input references, content IDs, registry digests, installed
+component versions, and the model revisions. Models are pinned in the manifest
+and copied into both containers at `/model`; this also works with DinD without
+shared host bind paths. Both components run from `/tmp` with offline model
+loading. Every pair/scenario has its own Docker network, etcd, and NATS. Only
+one worker runs at a time, using GPU 0.
+
+## Initial contracts
+
+- **Embedding:** Qwen3-Embedding-0.6B; default encoding, explicit `float`, and
+  a batch. Require JSON float arrays, finite values, expected dimensions,
+  cardinality, and indices. An HTTP error or base64 string for a float request
+  fails. The client never normalizes a string into a vector.
+- **Chat Completions:** Qwen2.5-0.5B-Instruct, aggregated SGLang; unary,
+  streaming, `max_tokens=1`, a repeated request, and `stop`. Check content,
+  token limits, finish reasons, stream errors, and `[DONE]`. The stop string is
+  derived from the prefix of the unary response and repeated at temperature 0;
+  the stopped response must be empty with finish reason `stop`. This avoids
+  assuming that a small model follows a particular instruction. It does assume
+  deterministic greedy output for the same request on the same worker.
+
+The stop case depends on a successful unary baseline; if that baseline fails,
+its failure already fails the scenario. Remaining independent cases still run.
+These are API/protocol checks, not numerical embedding parity or model-quality
+benchmarks. V1 does not cover disaggregation, KV-aware routing, tools,
+multimodal inference, other engines, or simultaneous mixed worker pools.
+
+## Run locally or on a GPU runner
+
+Requires Linux amd64, one NVIDIA GPU with at least 24 GiB VRAM, a driver
+compatible with every selected CUDA image, and Docker with NVIDIA runtime.
+The client and Docker daemon must share the network namespace (local Docker or
+a DinD sidecar), so published loopback ports are reachable. Remote Docker over
+TCP with a separate network namespace is not supported. Allow sufficient disk
+for all runtime images and the two models. Registry authentication is external
+to the runner; log in before invoking it if your candidate images are private.
+
+```bash
+python3 -m venv /tmp/n2-client
+/tmp/n2-client/bin/pip install requests==2.32.5 huggingface-hub==0.34.4
+/tmp/n2-client/bin/python -m unittest discover -s scripts/compatibility -v
+/tmp/n2-client/bin/python scripts/compatibility/runner.py \
+  --frontend-image YOUR_FRONTEND_IMAGE --worker-image YOUR_SGLANG_IMAGE \
+  --output /tmp/n2-results
+```
+
+The output directory must not exist. Add `--plan` to print and validate the
+matrix without Docker, Hugging Face access, or GPUs. Use `--config` to provide
+another reviewed release/model manifest. To exercise the reported historical
+embedding array/string incompatibility, explicitly target the 1.4 window:
+
+```bash
+/tmp/n2-client/bin/python scripts/compatibility/runner.py \
+  --release-line 1.4 \
+  --frontend-image nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.2 \
+  --worker-image nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.2 \
+  --output /tmp/n2-embedding-regression
+```
+
+That includes frontend 1.2.1 with worker 1.4.2. The default main window moves
+with the development version, so it must not be used to imply continued
+coverage of an older regression pair. There are no xfails or skips for known
+protocol incompatibilities. This framework does not fix those incompatibilities.
+
+## CI and evidence
+
+`compatibility-contract-tests.yml` runs the CPU harness checks on relevant PRs.
+`cross-version-compatibility.yml` is callable and manually dispatchable with
+independent candidate image inputs and an optional release line. Nightly CI
+calls it after the actual frontend and SGLang builds, using both SHA-tagged
+runtime artifacts. It authenticates to ECR using the existing registry action.
+A release workflow can call the same workflow with its release candidate images
+and release line, with `secrets: inherit`. V1 does not change release promotion
+gates. The GPU job defaults to `prod-tester-amd-gpu-v2`; `N2_GPU_RUNNER` can select
+a dedicated compatible runner. Its timeout is 120 minutes.
+
+Any startup, request, validation, or resource cleanup failure makes the run
+fail. Cases and later pairs continue after a scenario failure. The artifact
+includes `report.json`, raw HTTP requests/responses or SSE lines, container
+logs/states, and installed versions; model weights are excluded. The report
+separates startup failures from individual contract failures. Use the matching
+candidate/candidate control to identify failures that are not specific to
+version skew. For ambiguous historical failures, repeat the same scenario with
+both candidate image inputs set to that historical release as a same-version
+control before attributing the failure to N-2 compatibility.
+
+To add another scenario, add its immutable model specification and request
+cases/validators, then run it through the same version matrix. Additional
+engines need their own explicit launcher and supported-version configuration;
+keep image orchestration separate from HTTP assertions.

--- a/scripts/compatibility/releases.json
+++ b/scripts/compatibility/releases.json
@@ -1,0 +1,31 @@
+{
+  "releases": {
+    "1.2": {
+      "frontend": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1",
+      "worker": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1"
+    },
+    "1.3": {
+      "frontend": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.1",
+      "worker": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.1"
+    },
+    "1.4": {
+      "frontend": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.2",
+      "worker": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.2"
+    }
+  },
+  "infrastructure": {
+    "etcd": "quay.io/coreos/etcd:v3.5.21",
+    "nats": "nats:2.11.3-alpine"
+  },
+  "models": {
+    "embedding": {
+      "id": "Qwen/Qwen3-Embedding-0.6B",
+      "revision": "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3",
+      "dimensions": 1024
+    },
+    "chat": {
+      "id": "Qwen/Qwen2.5-0.5B-Instruct",
+      "revision": "7ae557604adf67be50417f59c2c2f167def9a775"
+    }
+  }
+}

--- a/scripts/compatibility/runner.py
+++ b/scripts/compatibility/runner.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Black-box N-2 tests. Only the HTTP client runs from the current checkout."""
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import requests
+
+
+def command(*args, timeout=600):
+    return subprocess.check_output(
+        args, text=True, stderr=subprocess.STDOUT, timeout=timeout
+    )
+
+
+def matrix(releases, line, frontend, worker):
+    major, minor = map(int, line.split("."))
+    if minor < 2:
+        raise ValueError("Explicit same-major N-2 window requires minor >= 2")
+    pairs = [("candidate", frontend, worker)]
+    for age in (1, 2):
+        previous = releases[f"{major}.{minor - age}"]
+        pairs.extend(
+            [
+                (f"old-frontend-{age}", previous["frontend"], worker),
+                (f"old-worker-{age}", frontend, previous["worker"]),
+            ]
+        )
+    return pairs
+
+
+def validate_embedding(body, count, dimensions):
+    assert body["object"] == "list", body
+    assert len(body["data"]) == count, body
+    for index, item in enumerate(body["data"]):
+        assert item["index"] == index, item
+        assert item["object"] == "embedding", item
+        vector = item["embedding"]
+        # Do not decode strings here: float requests must return JSON arrays.
+        assert isinstance(
+            vector, list
+        ), f"Expected float array, got {type(vector).__name__}"
+        assert len(vector) == dimensions, len(vector)
+        assert all(type(x) in (int, float) and math.isfinite(x) for x in vector)
+
+
+def validate_chat(body, max_tokens, stop=None):
+    assert "error" not in body, body
+    assert len(body["choices"]) == 1, body
+    choice = body["choices"][0]
+    assert choice["index"] == 0, choice
+    assert choice["finish_reason"] in ("stop", "length"), choice
+    message = choice["message"]
+    assert message["role"] == "assistant", message
+    assert isinstance(message["content"], str), body
+    if max_tokens > 1 and stop is None:
+        assert message["content"].strip(), body
+    assert 0 <= body["usage"]["completion_tokens"] <= max_tokens, body
+    if stop is not None:
+        assert message["content"] == "", body  # Stop is a prefix of the baseline.
+        assert choice["finish_reason"] == "stop", body
+
+
+def validate_stream(lines):
+    content, finished, done = [], False, False
+    for line in lines:
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            assert line.strip() != "event: error", line
+            continue
+        assert line.startswith("data:"), f"Unexpected SSE line: {line}"
+        assert not done, "Data after [DONE]"
+        data = line[5:].strip()
+        if data == "[DONE]":
+            done = True
+            continue
+        chunk = json.loads(data)
+        assert "error" not in chunk, chunk
+        for choice in chunk["choices"]:
+            assert choice["index"] == 0, choice
+            text = choice.get("delta", {}).get("content")
+            if text:
+                assert isinstance(text, str)
+                assert not finished, "Content after finish_reason"
+                content.append(text)
+            if choice.get("finish_reason") is not None:
+                assert choice["finish_reason"] in ("stop", "length"), choice
+                finished = True
+    assert done and finished, "Incomplete SSE response"
+    assert "".join(content).strip(), "Empty streamed content"
+
+
+def probe(base, scenario, model, directory):
+    cases = []
+    if scenario == "embedding":
+        for name, inputs, explicit in [
+            ("default", "hello", False),
+            ("float", "hello", True),
+            ("batch", ["hello", "world"], True),
+        ]:
+            body = {"model": model["id"], "input": inputs}
+            if explicit:
+                body["encoding_format"] = "float"
+            cases.append((name, "/v1/embeddings", body))
+    else:
+        for name, streaming, cap in [
+            ("unary", False, 32),
+            ("stream", True, 32),
+            ("limited", False, 1),
+            ("repeat", False, 32),
+        ]:
+            body = {
+                "model": model["id"],
+                "messages": [
+                    {"role": "user", "content": "Reply with one short greeting."}
+                ],
+                "temperature": 0,
+                "max_tokens": cap,
+                "stream": streaming,
+            }
+            cases.append((name, "/v1/chat/completions", body))
+    results = []
+    for name, endpoint, body in cases:
+        record = {"name": name, "request": body, "status": "failed"}
+        try:
+            with requests.post(
+                base + endpoint,
+                json=body,
+                timeout=(10, 120),
+                stream=body.get("stream", False),
+            ) as response:
+                record["http_status"] = response.status_code
+                if body.get("stream"):
+                    lines = []
+
+                    def capture():
+                        for line in response.iter_lines():
+                            text = line.decode("utf-8")
+                            lines.append(text)
+                            yield text
+
+                    try:
+                        response.raise_for_status()
+                        validate_stream(capture())
+                    finally:
+                        record["response"] = lines
+                else:
+                    record["response"] = response.text
+                    response.raise_for_status()
+                    value = response.json()
+                    if scenario == "embedding":
+                        count = (
+                            len(body["input"]) if isinstance(body["input"], list) else 1
+                        )
+                        validate_embedding(value, count, model["dimensions"])
+                    else:
+                        validate_chat(value, body["max_tokens"], body.get("stop"))
+                        if name == "unary":
+                            # Derive a stop string from this deterministic response.
+                            # No assumption about a small model following an instruction.
+                            content = value["choices"][0]["message"]["content"]
+                            stop = content[: min(len(content), 4)]
+                            cases.append(("stop", endpoint, {**body, "stop": stop}))
+            record["status"] = "passed"
+        except (
+            AssertionError,
+            KeyError,
+            TypeError,
+            ValueError,
+            requests.RequestException,
+        ) as error:
+            record["error"] = str(error)
+        results.append(record)
+        (directory / f"{name}.json").write_text(json.dumps(record, indent=2))
+    return results
+
+
+def wait_ready(base, model, alive, timeout=600):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        alive()
+        try:
+            response = requests.get(base + "/v1/models", timeout=5)
+            if response.ok and any(
+                item["id"] == model for item in response.json()["data"]
+            ):
+                return
+        except (requests.RequestException, ValueError, KeyError):
+            pass
+        time.sleep(2)
+    raise TimeoutError(f"Model {model} was not discovered within {timeout}s")
+
+
+class DockerStack:
+    """Own every container/network, including resources from partial startup."""
+
+    def __init__(self, directory):
+        self.directory = directory
+        self.network = "n2-" + uuid.uuid4().hex[:12]
+        self.containers = []
+
+    def __enter__(self):
+        command("docker", "network", "create", self.network)
+        return self
+
+    def start(
+        self, role, image, args, gpu=False, env=None, model_path=None, publish=False
+    ):
+        name = f"{self.network}-{role}"
+        self.containers.append(name)
+        options = [
+            "docker",
+            "create",
+            "--name",
+            name,
+            "--network",
+            self.network,
+            "--network-alias",
+            role,
+            "--shm-size",
+            "2g",
+            "--workdir",
+            "/tmp",
+        ]
+        if gpu:
+            options += ["--gpus", "device=0"]
+        if publish:
+            # Container-local port; Docker allocates an isolated host port.
+            options += ["-p", "127.0.0.1::8000"]
+        for key, value in (env or {}).items():
+            options += ["-e", f"{key}={value}"]
+        command(*options, "--entrypoint", args[0], image, *args[1:])
+        if model_path:
+            # Works with DinD too: do not assume daemon/runner share bind paths.
+            command("docker", "cp", str(model_path), f"{name}:/model")
+        command("docker", "start", name)
+        return name
+
+    def alive(self):
+        for name in self.containers:
+            state = json.loads(command("docker", "inspect", name))[0]["State"]
+            if not state["Running"]:
+                raise RuntimeError(f"{name} exited: {state}")
+
+    def __exit__(self, *exc):
+        failures = []
+        for name in reversed(self.containers):
+            try:
+                logs = command("docker", "logs", name, timeout=30)
+                (self.directory / f"{name}.log").write_text(logs)
+                metadata = command(
+                    "docker", "inspect", "--format", "{{json .State}}", name, timeout=30
+                )
+                (self.directory / f"{name}-state.json").write_text(metadata)
+            except (subprocess.SubprocessError, OSError) as error:
+                failures.append(str(error))
+            finally:
+                try:
+                    command("docker", "rm", "-f", name, timeout=30)
+                except subprocess.SubprocessError as error:
+                    failures.append(str(error))
+        try:
+            command("docker", "network", "rm", self.network, timeout=30)
+        except subprocess.SubprocessError as error:
+            failures.append(str(error))
+        if failures:
+            (self.directory / "cleanup-errors.json").write_text(json.dumps(failures))
+            if exc[0] is None:
+                raise RuntimeError(
+                    "Container collection/cleanup failed; see cleanup-errors.json"
+                )
+
+
+def resolve_image(reference):
+    command("docker", "pull", reference)
+    image = json.loads(command("docker", "image", "inspect", reference))[0]
+    return {
+        "reference": reference,
+        "id": image["Id"],
+        "digests": image.get("RepoDigests", []),
+    }
+
+
+def execute(frontend, worker, infra, scenario, model, directory):
+    with DockerStack(directory) as stack:
+        stack.start(
+            "etcd",
+            infra["etcd"]["id"],
+            [
+                "etcd",
+                "--advertise-client-urls",
+                "http://etcd:2379",
+                "--listen-client-urls",
+                "http://0.0.0.0:2379",
+            ],
+        )
+        stack.start("nats", infra["nats"]["id"], ["nats-server", "-js"])
+        deadline = time.monotonic() + 60
+        while True:
+            stack.alive()
+            try:
+                command(
+                    "docker",
+                    "exec",
+                    f"{stack.network}-etcd",
+                    "etcdctl",
+                    "endpoint",
+                    "health",
+                    timeout=10,
+                )
+                break
+            except subprocess.SubprocessError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("etcd did not become healthy")
+                time.sleep(1)
+        env = {
+            "ETCD_ENDPOINTS": "http://etcd:2379",
+            "NATS_SERVER": "nats://nats:4222",
+            "DYN_NAMESPACE": stack.network,
+            "DYN_DISCOVERY_BACKEND": "etcd",
+            "DYN_REQUEST_PLANE": "tcp",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "DYN_SYSTEM_PORT": "8081",
+        }
+        path = model["path"]
+        # Start from /tmp: never import a checkout mounted by CI.
+        worker_args = [
+            "python3",
+            "-m",
+            "dynamo.sglang",
+            "--model-path",
+            "/model",
+            "--served-model-name",
+            model["id"],
+            "--tp",
+            "1",
+            "--mem-fraction-static",
+            "0.65",
+            "--enable-metrics",
+        ]
+        if scenario == "embedding":
+            worker_args += [
+                "--embedding-worker",
+                "--use-sglang-tokenizer",
+                "--page-size",
+                "16",
+            ]
+        stack.start(
+            "worker", worker["id"], worker_args, gpu=True, env=env, model_path=path
+        )
+        name = stack.start(
+            "frontend",
+            frontend["id"],
+            ["python3", "-m", "dynamo.frontend", "--http-port", "8000"],
+            env={**env, "DYN_SYSTEM_PORT": "8082"},
+            model_path=path,
+            publish=True,
+        )
+        address = command("docker", "port", name, "8000/tcp").strip()
+        base = "http://" + address
+        for role in ("worker", "frontend"):
+            version = command(
+                "docker",
+                "exec",
+                f"{stack.network}-{role}",
+                "python3",
+                "-c",
+                "import importlib.metadata as m,json; print(json.dumps({"
+                'd.metadata["Name"]:d.version for d in m.distributions() '
+                'if d.metadata["Name"] in ("ai-dynamo", "ai-dynamo-runtime", "sglang")}))',
+            )
+            (directory / f"{role}-versions.json").write_text(version)
+        wait_ready(base, model["id"], stack.alive)
+        return probe(base, scenario, model, directory)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config", type=Path, default=Path(__file__).with_name("releases.json")
+    )
+    parser.add_argument(
+        "--release-line", default="", help="Default: checkout Cargo.toml version"
+    )
+    parser.add_argument("--frontend-image", required=True)
+    parser.add_argument("--worker-image", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--plan", action="store_true", help="Validate/print matrix without Docker"
+    )
+    args = parser.parse_args()
+    config = json.loads(args.config.read_text())
+    if not args.release_line:
+        cargo = Path(__file__).resolve().parents[2] / "Cargo.toml"
+        args.release_line = re.search(
+            r'^version = "(\d+\.\d+)\.', cargo.read_text(), re.M
+        )[1]
+    pairs = matrix(
+        config["releases"], args.release_line, args.frontend_image, args.worker_image
+    )
+    if args.plan:
+        print(json.dumps(pairs, indent=2))
+        return
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {
+        "release_line": args.release_line,
+        "pairs": pairs,
+        "status": "failed",
+        "runs": [],
+    }
+    try:
+        command("docker", "info", timeout=30)
+        refs = {ref for _, frontend, worker in pairs for ref in (frontend, worker)}
+        refs.update(config["infrastructure"].values())
+        images = {ref: resolve_image(ref) for ref in sorted(refs)}
+        report["images"] = images
+        # Freeze model revisions once, then copy the same snapshot in every version.
+        from huggingface_hub import HfApi, snapshot_download
+
+        models = {}
+        for scenario, spec in config["models"].items():
+            revision = HfApi().model_info(spec["id"], revision=spec["revision"]).sha
+            path = args.output.resolve() / "models" / scenario
+            snapshot_download(spec["id"], revision=revision, local_dir=path)
+            models[scenario] = {**spec, "revision": revision, "path": str(path)}
+        report["models"] = models
+        infra = {name: images[ref] for name, ref in config["infrastructure"].items()}
+        for name, frontend, worker in pairs:
+            for scenario, model in models.items():
+                directory = args.output / name / scenario
+                directory.mkdir(parents=True)
+                run = {"pair": name, "scenario": scenario, "status": "failed"}
+                report["runs"].append(run)
+                try:
+                    run["cases"] = execute(
+                        images[frontend],
+                        images[worker],
+                        infra,
+                        scenario,
+                        model,
+                        directory,
+                    )
+                    if all(case["status"] == "passed" for case in run["cases"]):
+                        run["status"] = "passed"
+                except (
+                    subprocess.SubprocessError,
+                    OSError,
+                    RuntimeError,
+                    ValueError,
+                ) as error:
+                    run["error"] = str(error)
+                finally:
+                    (args.output / "report.json").write_text(
+                        json.dumps(report, indent=2)
+                    )
+        if all(run["status"] == "passed" for run in report["runs"]):
+            report["status"] = "passed"
+    except Exception as error:
+        report["error"] = str(error)
+        raise
+    finally:
+        (args.output / "report.json").write_text(json.dumps(report, indent=2))
+    if report["status"] != "passed":
+        raise SystemExit("Cross-version compatibility failed; see report.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compatibility/test_runner.py
+++ b/scripts/compatibility/test_runner.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from runner import (
+    DockerStack,
+    main,
+    matrix,
+    probe,
+    validate_chat,
+    validate_embedding,
+    validate_stream,
+)
+
+
+class CompatibilityTests(unittest.TestCase):
+    def test_both_age_directions(self):
+        releases = {
+            "1.2": {"frontend": "f12", "worker": "w12"},
+            "1.3": {"frontend": "f13", "worker": "w13"},
+        }
+        pairs = matrix(releases, "1.4", "fc", "wc")
+        self.assertEqual(
+            [(f, w) for _, f, w in pairs],
+            [("fc", "wc"), ("f13", "wc"), ("fc", "w13"), ("f12", "wc"), ("fc", "w12")],
+        )
+        with self.assertRaises(KeyError):
+            matrix(releases, "1.5", "fc", "wc")
+
+    def test_float_contract_rejects_base64_and_nonfinite(self):
+        body = {
+            "object": "list",
+            "data": [{"index": 0, "object": "embedding", "embedding": [1.0, 2.0]}],
+        }
+        validate_embedding(body, 1, 2)
+        for value in ("AACAPwAAAEA=", [float("nan"), 2], [True, 2], [1.0]):
+            body["data"][0]["embedding"] = value
+            with self.assertRaises(AssertionError):
+                validate_embedding(body, 1, 2)
+
+    def test_chat_contract(self):
+        body = {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"completion_tokens": 2},
+        }
+        validate_chat(body, 32)
+        with self.assertRaises(AssertionError):
+            validate_chat(body, 1)
+        body["choices"][0]["finish_reason"] = "error"
+        with self.assertRaises(AssertionError):
+            validate_chat(body, 32)
+
+    def test_stop_contract(self):
+        body = {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": ""},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"completion_tokens": 1},
+        }
+        validate_chat(body, 32, "Hello")
+        body["choices"][0]["message"]["content"] = "Hello world"
+        with self.assertRaises(AssertionError):
+            validate_chat(body, 32, "Hello")
+        body["choices"][0]["message"]["content"] = ""
+        body["choices"][0]["finish_reason"] = "length"
+        with self.assertRaises(AssertionError):
+            validate_chat(body, 32, "Hello")
+
+    def test_stream_must_finish_and_not_hide_errors(self):
+        def chunk(delta, finish):
+            return "data: " + json.dumps(
+                {"choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
+            )
+
+        valid = [chunk({"content": "Hello"}, None), chunk({}, "stop"), "data: [DONE]"]
+        validate_stream(valid)
+        for invalid in [
+            valid[:-1],
+            valid[:1] + ["data: [DONE]"],
+            ['data: {"error":"worker failed"}'],
+            ["event: error"],
+            valid + [valid[0]],
+        ]:
+            with self.assertRaises(AssertionError):
+                validate_stream(invalid)
+
+    def test_probe_records_failures_and_runs_remaining_cases(self):
+        class Response:
+            status_code = 200
+            text = json.dumps(
+                {
+                    "object": "list",
+                    "data": [
+                        {"index": 0, "object": "embedding", "embedding": "AACAPwAAAEA="}
+                    ],
+                }
+            )
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return json.loads(self.text)
+
+        with tempfile.TemporaryDirectory() as directory, patch(
+            "runner.requests.post", return_value=Response()
+        ):
+            results = probe(
+                "http://unused",
+                "embedding",
+                {"id": "model", "dimensions": 2},
+                Path(directory),
+            )
+            self.assertEqual(len(results), 3)
+            self.assertTrue(all(r["status"] == "failed" for r in results))
+            self.assertEqual(len(list(Path(directory).glob("*.json"))), 3)
+
+    def test_all_pairs_run_and_failure_is_reported(self):
+        config = {
+            "releases": {
+                line: {"frontend": "f" + line, "worker": "w" + line}
+                for line in ("1.2", "1.3")
+            },
+            "infrastructure": {"etcd": "etcd", "nats": "nats"},
+            "models": {
+                s: {"id": s, "revision": "fixed"} for s in ("embedding", "chat")
+            },
+        }
+        hub = types.ModuleType("huggingface_hub")
+        hub.HfApi = lambda: types.SimpleNamespace(
+            model_info=lambda *a, **kw: types.SimpleNamespace(sha="fixed")
+        )
+        hub.snapshot_download = lambda *a, **kw: None
+        for failed in (False, True):
+            with self.subTest(failed=failed), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                manifest = root / "config.json"
+                manifest.write_text(json.dumps(config))
+                output = root / "output"
+                argv = [
+                    "runner",
+                    "--config",
+                    str(manifest),
+                    "--release-line",
+                    "1.4",
+                    "--frontend-image",
+                    "fc",
+                    "--worker-image",
+                    "wc",
+                    "--output",
+                    str(output),
+                ]
+                effects = [[{"status": "passed"}]] * 10
+                if failed:
+                    effects[1] = RuntimeError("worker startup failed")
+                    effects[2] = [{"status": "failed", "error": "expected float array"}]
+                with patch("sys.argv", argv), patch.dict(
+                    "sys.modules", {"huggingface_hub": hub}
+                ), patch("runner.command"), patch(
+                    "runner.resolve_image", side_effect=lambda r: {"id": r}
+                ) as resolve, patch(
+                    "runner.execute", side_effect=effects
+                ) as execute:
+                    if failed:
+                        with self.assertRaises(SystemExit):
+                            main()
+                    else:
+                        main()
+                    self.assertEqual(execute.call_count, 10)
+                    self.assertEqual(resolve.call_count, 8)
+                report = json.loads((output / "report.json").read_text())
+                self.assertEqual(report["status"], "failed" if failed else "passed")
+                self.assertEqual(len(report["runs"]), 10)
+                if failed:
+                    self.assertIn("startup failed", report["runs"][1]["error"])
+                    self.assertEqual(report["runs"][2]["status"], "failed")
+                    self.assertEqual(report["runs"][-1]["status"], "passed")
+
+    def test_cleanup_after_partial_startup(self):
+        calls = []
+
+        def run(*args, **kwargs):
+            calls.append(args)
+            if args[:2] == ("docker", "create"):
+                raise OSError("startup failed")
+            return "{}"
+
+        with tempfile.TemporaryDirectory() as directory, patch(
+            "runner.command", side_effect=run
+        ):
+            with self.assertRaises(OSError):
+                with DockerStack(Path(directory)) as stack:
+                    stack.start("worker", "image", ["python3"])
+        self.assertTrue(any(c[:3] == ("docker", "rm", "-f") for c in calls))
+        self.assertTrue(any(c[:3] == ("docker", "network", "rm") for c in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Same-version serving tests cannot catch a frontend/worker wire-format regression during a rolling upgrade. This adds an initial black-box SGLang compatibility lane covering embeddings and aggregated Chat Completions with independently selected frontend and worker images.

- Run five pairs for each scenario: candidate/candidate and both directions against N-1 and N-2. The release line defaults to Cargo.toml; an explicit manifest selects historical patch releases. Missing historical entries fail closed.
- Check embedding default/float/batch responses strictly as finite JSON vectors. Check chat unary/streaming responses, max_tokens, stop handling, finish reasons and stream termination. Do not normalize incompatible responses or xfail known regressions.
- Resolve images once, use immutable model revisions and isolated Docker networks, and collect requests/responses, component versions and container logs. Runs use one GPU sequentially. Copy model snapshots into the actual images without injecting current-checkout code; this avoids shared-bind-path assumptions with DinD.
- Add CPU harness checks on PRs and a reusable/manual GPU workflow. Wire nightly CI to the frontend and SGLang runtime images built for that source SHA. Release workflows can reuse the same entry point; release promotion gates are unchanged.

The README includes an explicit 1.4-window invocation for the reported frontend 1.2.1 / SGLang worker 1.4.2 embedding array/string incompatibility. Main is currently 1.5, whose default historical window is 1.4/1.3, so reproducing that older pair requires the explicit window. This PR adds detection, not a protocol fix.

Initial scope is SGLang aggregated serving on Linux amd64. It does not claim coverage of every patch, disaggregation, KV routing, other engines, or live mixed-worker rollout orchestration.

## Validation

- Passed 8 CPU harness tests, including all ten pair/scenario executions under mocked orchestration, startup/contract failure propagation, remaining-case execution, strict response rejection, and partial-startup cleanup.
- Passed Black, isort, flake8, workflow YAML parsing, action pin checks, diff checks, and strict CODEOWNERS coverage.
- New workflows pass actionlint 1.7.12. Nightly integration passes with pre-existing unknown self-hosted runner-label diagnostics excluded.
- Verified all six historical image tags exist in NGC and resolved both public model revisions to immutable commits.
- **GPU E2E has not run:** the authoring environment is macOS without Docker/NVIDIA GPUs. Keeping this PR draft until the GPU lane is exercised on the trusted runner, including its registry access and DinD loopback connectivity. The historical embedding reproduction is expected to fail if the reported protocol incompatibility is present; no GPU pass or reproduced HTTP failure is claimed here.
