### PR TITLE
test(deploy): add N-2 component compatibility matrix

### DIFF
--- a/.github/workflows/cross-version-compatibility.yml
+++ b/.github/workflows/cross-version-compatibility.yml
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: Cross-version compatibility
+on:
+  workflow_dispatch:
+    inputs:
+      frontend_tag:
+        description: Candidate frontend image tag in ACR
+        type: string
+        required: true
+      worker_tag:
+        description: Candidate SGLang image tag in ACR
+        type: string
+        required: true
+      operator_tag:
+        description: Candidate operator tag in ACR
+        type: string
+        required: true
+      release_line:
+        description: Target release line (empty derives it from checkout)
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      frontend_tag:
+        type: string
+        required: true
+      worker_tag:
+        type: string
+        required: true
+      operator_tag:
+        type: string
+        required: true
+      release_line:
+        type: string
+        default: ''
+      source_ref:
+        type: string
+        default: ''
+    secrets:
+      AZURE_ACR_HOSTNAME:
+        required: true
+      AZURE_ACR_USER:
+        required: true
+      AZURE_ACR_PASSWORD:
+        required: true
+      HF_TOKEN:
+        required: true
+      DOCKERHUB_LOGIN_USER:
+        required: false
+      DOCKERHUB_ACCESS_TOKEN:
+        required: false
+permissions:
+  contents: read
+jobs:
+  compatibility:
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.source_ref || github.sha }}
+          persist-credentials: false
+      - name: Require shared model cache
+        env:
+          CACHE_SERVER: ${{ vars.AZURE_MODEL_CACHE_SERVER }}
+          CACHE_PATH: ${{ vars.AZURE_MODEL_CACHE_PATH }}
+        run: test -n "$CACHE_SERVER" && test -n "$CACHE_PATH"
+      - name: Create isolated vCluster with candidate operator
+        uses: $/.github/actions/setup-dynamo-operator
+        with:
+          reset_existing: 'true'
+          model_cache_server: ${{ vars.AZURE_MODEL_CACHE_SERVER }}
+          model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
+          vcluster_name: ci-${{ github.run_id }}-${{ github.run_attempt }}-n2-static
+          vcluster_namespace: gh-id-${{ github.run_id }}-${{ github.run_attempt }}-n2-static-dt
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          repository: ${{ vars.ACR_REPOSITORY }}
+          operator_tag: ${{ inputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Allow the bounded compatibility suite to finish before namespace expiry
+        env:
+          HOST_NAMESPACE: gh-id-${{ github.run_id }}-${{ github.run_attempt }}-n2-static-dt
+        run: kubectl label namespace "$HOST_NAMESPACE" nscleanup/ttl=21600 --overwrite
+      - name: Connect to vCluster
+        id: connect
+        uses: $/.github/actions/connect-vcluster
+        with:
+          vcluster_name: ci-${{ github.run_id }}-${{ github.run_attempt }}-n2-static
+          vcluster_namespace: gh-id-${{ github.run_id }}-${{ github.run_attempt }}-n2-static-dt
+      - name: Prepare fixed model snapshots on the shared cache
+        env:
+          KUBECONFIG_B64: ${{ steps.connect.outputs.kubeconfig_base64 }}
+          WORKER_IMAGE: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.worker_tag }}
+        run: |
+          set -euo pipefail
+          export KUBECONFIG="${RUNNER_TEMP}/n2-kubeconfig"
+          printf '%s' "$KUBECONFIG_B64" | base64 --decode > "$KUBECONFIG"
+          kubectl -n default get pvc model-cache
+          kubectl create -f tests/deploy/n2/model-download.yaml --dry-run=client -o json |
+            jq --arg image "$WORKER_IMAGE" '.spec.template.spec.containers[0].image = $image' |
+            kubectl -n default apply -f -
+          kubectl -n default wait --for=condition=complete job/n2-model-download --timeout=920s
+      - name: Run candidate chat control for manual validation
+        if: github.event_name == 'workflow_dispatch'
+        uses: $/.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ inputs.operator_tag }}
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.worker_tag }}
+          framework: sglang
+          profile: agg
+          model_cache_pvc: model-cache
+          test_name: n2-candidate-chat
+          extra_pytest_args: >-
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.frontend_tag }}
+            -m framework_only -n 0
+          cleanup_deployment: 'false'
+      - name: Run candidate embedding control for manual validation
+        if: github.event_name == 'workflow_dispatch'
+        uses: $/.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ inputs.operator_tag }}
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.worker_tag }}
+          framework: sglang
+          profile: agg_embed
+          model_cache_pvc: model-cache
+          test_name: n2-candidate-embedding
+          extra_pytest_args: >-
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.frontend_tag }}
+            -m framework_only -n 0
+          cleanup_deployment: 'false'
+      - name: Test four mixed version pairs for embedding and chat
+        uses: $/.github/actions/dynamo-deploy-test
+        env:
+          N2_RELEASE_LINE: ${{ inputs.release_line }}
+        with:
+          kubeconfig_base64: ${{ steps.connect.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ inputs.operator_tag }}
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.worker_tag }}
+          model_cache_pvc: model-cache
+          test_name: n2-compatibility
+          test_file: tests/deploy/test_n2_compatibility.py
+          extra_pytest_args: --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.frontend_tag }} -m k8s -n 0
+          # Each parameter owns one Frontend and one GPU Worker. The outer
+          # cleanup also runs on a job timeout or interrupted pytest process.
+          cleanup_deployment: 'false'
+      - name: Collect model preparation evidence
+        if: always() && steps.connect.outcome == 'success'
+        env:
+          KUBECONFIG: ${{ runner.temp }}/n2-kubeconfig
+        run: |
+          mkdir -p test-output/n2-model-download
+          kubectl -n default get job n2-model-download -o yaml > test-output/n2-model-download/job.yaml
+          kubectl -n default logs job/n2-model-download --all-containers > test-output/n2-model-download/download.log
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        if: always()
+        with:
+          name: n2-model-download-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-output/n2-model-download/
+
+  cleanup:
+    needs: compatibility
+    if: always()
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: $/.github/actions/teardown-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-${{ github.run_attempt }}-n2-static
+          vcluster_namespace: gh-id-${{ github.run_id }}-${{ github.run_attempt }}-n2-static-dt

--- a/.github/workflows/cross-version-compatibility.yml
+++ b/.github/workflows/cross-version-compatibility.yml
@@ -99,7 +99,7 @@ jobs:
           export KUBECONFIG="${RUNNER_TEMP}/n2-kubeconfig"
           printf '%s' "$KUBECONFIG_B64" | base64 --decode > "$KUBECONFIG"
           kubectl -n default get pvc model-cache
-          kubectl create -f tests/deploy/n2/model-download.yaml --dry-run=client -o json |
+          kubectl -n default create -f tests/deploy/n2/model-download.yaml --dry-run=client -o json |
             jq --arg image "$WORKER_IMAGE" '.spec.template.spec.containers[0].image = $image' |
             kubectl -n default apply -f -
           kubectl -n default wait --for=condition=complete job/n2-model-download --timeout=920s

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -637,6 +637,18 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
+  cross-version-compatibility:
+    name: SGLang nightly N-2 compatibility
+    needs: [compute-release-mode, resolve-source-sha, deploy-operator, frontend-copy-to-acr, sglang-copy-to-acr, deploy-test-sglang]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' && needs.deploy-test-sglang.result == 'success' }}
+    uses: $/.github/workflows/cross-version-compatibility.yml
+    with:
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
+      worker_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+    secrets: inherit
+
   deploy-cleanup:
     name: Nightly Deploy Cleanup
     if: always()

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -526,6 +526,18 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
+  frontend-copy-to-acr:
+    name: frontend-nightly
+    needs: [compute-release-mode, frontend-build]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-copy.yml
+    with:
+      target_tag_plain: ${{ format('{0}-nightly', needs.frontend-build.outputs.target_tag_plain) }}
+      cuda_version: '[""]'
+      override_arch: amd64
+      copy_timeout_minutes: 10
+    secrets: inherit
+
   sglang-copy-to-acr:
     name: sglang-runtime-nightly
     needs: [compute-release-mode, sglang-build]
@@ -582,13 +594,14 @@ jobs:
 
   deploy-test-vllm:
     name: vLLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: vllm
       profiles: '["agg", "agg_router_kv_approx"]'
       image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -596,13 +609,14 @@ jobs:
 
   deploy-test-sglang:
     name: sglang Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
-      profiles: '["agg", "agg_logging"]'
+      profiles: '["agg", "agg_logging", "agg_embed"]'
       image_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -610,13 +624,14 @@ jobs:
 
   deploy-test-trtllm:
     name: TensorRT-LLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, trtllm-build, trtllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, trtllm-build, trtllm-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: trtllm
       profiles: '["agg"]'
       image_tag: ${{ needs.trtllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -173,6 +173,7 @@ jobs:
       - deploy-operator
       - deploy-test-vllm
       - deploy-test-sglang
+      - cross-version-compatibility
       - deploy-test-trtllm
       - deploy-test-dgdr
       - deploy-operator-checkpoint-vllm
@@ -1411,6 +1412,27 @@ jobs:
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+    secrets: inherit
+
+  cross-version-compatibility:
+    name: SGLang N-2 compatibility
+    needs: [changed-files, operator, frontend-copy-to-acr, sglang-copy-to-acr, deploy-test-sglang]
+    if: |
+      always() && !cancelled() &&
+      needs.changed-files.outputs.run_deploy_tests == 'true' &&
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.deploy == 'true' ||
+       needs.changed-files.outputs.operator == 'true') &&
+      needs.deploy-test-sglang.result == 'success' &&
+      needs.operator.result == 'success' &&
+      needs.frontend-copy-to-acr.result == 'success' &&
+      needs.sglang-copy-to-acr.result == 'success'
+    uses: $/.github/workflows/cross-version-compatibility.yml
+    with:
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
+      worker_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
     secrets: inherit
 
   deploy-test-dgdr:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -216,6 +216,7 @@ jobs:
   operator:
     needs: changed-files
     if: |
+      needs.changed-files.outputs.core == 'true' ||
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.vllm == 'true' ||
       needs.changed-files.outputs.sglang == 'true' ||
@@ -739,6 +740,10 @@ jobs:
     name: frontend
     needs: [changed-files]
     if: |
+      needs.changed-files.outputs.core == 'true' ||
+      needs.changed-files.outputs.vllm == 'true' ||
+      needs.changed-files.outputs.sglang == 'true' ||
+      needs.changed-files.outputs.trtllm == 'true' ||
       needs.changed-files.outputs.frontend == 'true' ||
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.snapshot == 'true' ||
@@ -1120,7 +1125,14 @@ jobs:
     needs: [changed-files, frontend-build]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.snapshot == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.frontend == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
+       needs.changed-files.outputs.deploy == 'true' ||
+       needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
       needs.changed-files.outputs.snapshot_vllm == 'true' ||
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true') &&
@@ -1301,7 +1313,8 @@ jobs:
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.operator == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
@@ -1339,11 +1352,12 @@ jobs:
 
   deploy-test-vllm:
     name: vllm Deploy Test
-    needs: [changed-files, deploy-operator, vllm-copy-to-acr]
+    needs: [changed-files, deploy-operator, vllm-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.vllm == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
@@ -1351,6 +1365,7 @@ jobs:
       framework: vllm
       profiles: '["agg", "agg_router", "disagg", "disagg_router"]'
       image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -1358,18 +1373,20 @@ jobs:
 
   deploy-test-sglang:
     name: sglang Deploy Test
-    needs: [changed-files, deploy-operator, sglang-copy-to-acr]
+    needs: [changed-files, deploy-operator, sglang-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.sglang == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
-      profiles: '["agg", "agg_router"]'
+      profiles: '["agg", "agg_router", "agg_embed"]'
       image_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -1377,11 +1394,12 @@ jobs:
 
   deploy-test-trtllm:
     name: trtllm Deploy Test
-    needs: [changed-files, deploy-operator, trtllm-copy-to-acr]
+    needs: [changed-files, deploy-operator, trtllm-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.trtllm == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
@@ -1389,6 +1407,7 @@ jobs:
       framework: trtllm
       profiles: '["agg", "agg_router"]'
       image_tag: ${{ needs.trtllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -18,6 +18,10 @@ on:
         description: 'Runtime image tag'
         type: string
         required: true
+      frontend_tag:
+        description: 'Standalone frontend image tag'
+        type: string
+        default: ''
       namespace:
         description: 'Host namespace where the vCluster lives'
         type: string
@@ -85,7 +89,9 @@ jobs:
           profile: ${{ matrix.profile }}
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.image_tag }}
           platform_arch: amd64
-          extra_pytest_args: -m framework_only
+          extra_pytest_args: >-
+            -m framework_only
+            ${{ inputs.frontend_tag != '' && format('--frontend-image={0}/{1}:{2}', secrets.AZURE_ACR_HOSTNAME, vars.ACR_REPOSITORY, inputs.frontend_tag) || '' }}
           # Mount the shared model cache only when both endpoint vars are set
           # (matches the PV/PVC creation gate); otherwise workers download from HF.
           model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}

--- a/components/src/dynamo/sglang/health_check.py
+++ b/components/src/dynamo/sglang/health_check.py
@@ -87,6 +87,24 @@ class SglangHealthCheckPayload(HealthCheckPayload):
         super().__init__()
 
 
+class SglangEmbeddingHealthCheckPayload(HealthCheckPayload):
+    """Send an embedding request through the worker's normal encode path."""
+
+    def __init__(
+        self,
+        model_name: str,
+        engine: Optional[sgl.Engine] = None,
+        use_text_input: bool = False,
+    ) -> None:
+        self.default_payload = {
+            "model": model_name,
+            "input": (
+                "Test" if use_text_input else [_get_bos_token_id_from_engine(engine)]
+            ),
+        }
+        super().__init__()
+
+
 class SglangDisaggHealthCheckPayload(HealthCheckPayload):
     """SGLang-specific health check payload for PD-disaggregated mode.
 

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -12,7 +12,7 @@ from dynamo.common.utils.prometheus import register_engine_metrics_callback
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
-from dynamo.sglang.health_check import SglangHealthCheckPayload
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload
 from dynamo.sglang.publisher import (
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
@@ -69,8 +69,10 @@ async def init_embedding(
     ready_event = asyncio.Event()
 
     handler = EmbeddingWorkerHandler(engine, config, publisher, shutdown_event)
-    health_check_payload = SglangHealthCheckPayload(
-        engine, use_text_input=dynamo_args.use_sglang_tokenizer
+    health_check_payload = SglangEmbeddingHealthCheckPayload(
+        server_args.served_model_name,
+        engine,
+        use_text_input=dynamo_args.use_sglang_tokenizer,
     ).to_dict()
 
     register_model_taint_route(runtime, generate_endpoint)

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
+    pytest.mark.timeout(30),
 ]
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -13,6 +13,7 @@ pytest.importorskip(
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput  # noqa: E402
 
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload  # noqa: E402
 from dynamo.sglang.request_handlers.embedding import (  # noqa: E402
     embedding_handler as eh,
 )
@@ -59,6 +60,29 @@ def _handler(*, enable_trace: bool = True) -> eh.EmbeddingWorkerHandler:
     handler.engine = _Engine()
     handler.enable_trace = enable_trace
     return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_text_input", [True, False])
+async def test_health_check_runs_embedding_inference(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    handler = _handler()
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", use_text_input=use_text_input
+    ).to_dict()
+
+    outputs = [output async for output in handler.generate(payload, _Context())]
+
+    assert len(outputs) == 1
+    assert outputs[0]["model"] == "embedding-model"
+    assert len(outputs[0]["data"]) == 1
+    if use_text_input:
+        assert handler.engine.async_encode_calls[0]["prompt"] == "Test"
+        assert handler.engine.tokenizer_manager.requests == []
+    else:
+        [(request, _)] = handler.engine.tokenizer_manager.requests
+        assert request.input_ids == [1]
+        assert handler.engine.async_encode_calls == []
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -9,18 +9,22 @@ no handler reads), and survives DYN_HEALTH_CHECK_PAYLOAD env overrides.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
+    SglangEmbeddingHealthCheckPayload,
     SglangHealthCheckPayload,
 )
+from dynamo.sglang.protocol import EmbeddingRequest
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
+    pytest.mark.fault_tolerance,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -33,6 +37,31 @@ def test_disagg_payload_has_marker():
 def test_decode_payload_has_no_marker():
     # Decode/agg handler doesn't read the marker; payload stays unmarked.
     assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
+
+
+@pytest.mark.parametrize("use_text_input", [True, False])
+def test_embedding_payload_matches_request_schema(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=42))
+    )
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", engine, use_text_input=use_text_input
+    ).to_dict()
+
+    request = EmbeddingRequest(**payload)
+    assert request.model == "embedding-model"
+    assert request.input == ("Test" if use_text_input else [42])
+
+
+def test_embedding_env_override(monkeypatch):
+    override = {"model": "embedding-model", "input": "custom probe"}
+    monkeypatch.setenv("DYN_HEALTH_CHECK_PAYLOAD", json.dumps(override))
+
+    payload = SglangEmbeddingHealthCheckPayload("embedding-model").to_dict()
+
+    assert payload == override
+    assert EmbeddingRequest(**payload).input == "custom probe"
 
 
 def test_disagg_env_override_preserves_marker(monkeypatch):

--- a/docs/fern/pages/recipes/kubernetes-templates/dgd/sglang.mdx
+++ b/docs/fern/pages/recipes/kubernetes-templates/dgd/sglang.mdx
@@ -22,6 +22,9 @@ kubectl apply -f agg.yaml
 <Accordion title="agg.yaml · Baseline aggregated serving">
 <Code src="../../../../../../examples/backends/sglang/deploy/agg.yaml" title="agg.yaml" language="yaml" maxLines={0} />
 </Accordion>
+<Accordion title="agg_embed.yaml · Aggregated embedding serving">
+<Code src="../../../../../../examples/backends/sglang/deploy/agg_embed.yaml" title="agg_embed.yaml" language="yaml" maxLines={0} />
+</Accordion>
 <Accordion title="agg_router.yaml · Aggregated with KV-aware routing">
 <Code src="../../../../../../examples/backends/sglang/deploy/agg_router.yaml" title="agg_router.yaml" language="yaml" maxLines={0} />
 </Accordion>

--- a/examples/backends/sglang/deploy/agg_embed.yaml
+++ b/examples/backends/sglang/deploy/agg_embed.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg-embed
+spec:
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - image: my-registry/sglang-runtime:my-tag
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-Embedding-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-Embedding-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: my-registry/sglang-runtime:my-tag
+          name: main
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
+    replicas: 1
+    type: worker

--- a/examples/backends/sglang/deploy/agg_embed.yaml
+++ b/examples/backends/sglang/deploy/agg_embed.yaml
@@ -20,6 +20,8 @@ spec:
       spec:
         containers:
         - args:
+          - --embedding-worker
+          - --use-sglang-tokenizer
           - --model-path
           - Qwen/Qwen3-Embedding-0.6B
           - --served-model-name

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the public APIs of an already running deployment."""
+
+import json
+import logging
+from pathlib import Path
+
+from tests.deploy.dgd_utils import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_REQUEST_TIMEOUT,
+    MIN_RESPONSE_CONTENT_LENGTH,
+    TEST_PROMPT,
+    validate_chat_response,
+)
+from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.utils.client import send_request
+
+logger = logging.getLogger(__name__)
+
+
+def check_deployment_api(
+    base_url: str, model: str, scenario: str, output: Path
+) -> None:
+    """Run shared API cases and retain raw responses even if a contract fails."""
+    output.mkdir(parents=True, exist_ok=True)
+    if scenario == "embedding":
+        for name, inputs, encoding in (
+            ("default", "Hello", None),
+            ("float", "Hello", "float"),
+            ("batch", ["Hello", "World"], "float"),
+        ):
+            payload = {"model": model, "input": inputs}
+            if encoding:
+                payload["encoding_format"] = encoding
+            data = _request(
+                base_url + "/v1/embeddings", payload, output / f"{name}.json"
+            )
+            assert data["model"] == model, data
+            # The example uses Qwen3-Embedding-0.6B's native 1024 dimensions.
+            validate_embedding(data, 2 if name == "batch" else 1, 1024)
+        return
+
+    assert scenario == "chat", scenario
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": TEST_PROMPT}],
+        "temperature": 0.0,
+        "max_tokens": DEFAULT_MAX_TOKENS,
+        "stream": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    url = base_url + "/v1/chat/completions"
+    unary = _request(
+        url,
+        payload,
+        output / "unary.json",
+        min_content_length=MIN_RESPONSE_CONTENT_LENGTH,
+    )
+    _request(url, {**payload, "stream": True}, output / "stream.json")
+    _request(url, {**payload, "max_tokens": 1}, output / "limited.json")
+    prefix = unary["choices"][0]["message"]["content"][:4]
+    assert prefix, "Cannot derive a stop sequence from empty unary output"
+    _request(url, {**payload, "stop": prefix}, output / "stop.json")
+
+
+def _request(url: str, payload: dict, artifact: Path, min_content_length: int = 0):
+    record = {"request": payload}
+    logger.info("Checking deployment API case %s", artifact.stem)
+    try:
+        with send_request(
+            url,
+            payload,
+            timeout=float(DEFAULT_REQUEST_TIMEOUT),
+            method="POST",
+            stream=payload.get("stream", False),
+        ) as response:
+            record["http_status"] = response.status_code
+            if payload.get("stream"):
+                lines = []
+                record["response"] = lines
+
+                def capture():
+                    for line in response.iter_lines():
+                        text = line.decode("utf-8")
+                        lines.append(text)
+                        yield text
+
+                response.raise_for_status()
+                validate_stream(capture())
+                return None
+            record["response"] = response.text
+            response.raise_for_status()
+            if "messages" in payload:
+                return validate_chat_response(
+                    response,
+                    payload["model"],
+                    min_content_length=min_content_length,
+                    max_tokens=payload["max_tokens"],
+                    stop=payload.get("stop"),
+                )
+            return response.json()
+    finally:
+        artifact.write_text(json.dumps(record, indent=2))

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import re
 from pathlib import Path
 
 from tests.deploy.dgd_utils import (
@@ -14,7 +15,11 @@ from tests.deploy.dgd_utils import (
     TEST_PROMPT,
     validate_chat_response,
 )
-from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.deploy.response_checks import (
+    validate_embedding,
+    validate_stop_response,
+    validate_stream,
+)
 from tests.utils.client import send_request
 
 logger = logging.getLogger(__name__)
@@ -67,9 +72,21 @@ def check_deployment_api(
     )
     _request(url, {**payload, "stream": True}, output / "stream.json")
     _request(url, {**payload, "max_tokens": 1}, output / "limited.json")
-    prefix = unary["choices"][0]["message"]["content"][:4]
-    assert prefix, "Cannot derive a stop sequence from empty unary output"
-    _request(url, {**payload, "stop": prefix}, output / "stop.json")
+    content = unary["choices"][0]["message"]["content"]
+    # Use a later word, avoiding a whitespace boundary at the start of output.
+    match = next(
+        (
+            m
+            for m in re.finditer(r"\S+", content)
+            if 0 < m.start() < len(content) // 2
+            and content.find(m.group()) == m.start()
+        ),
+        None,
+    )
+    assert match is not None, "Cannot derive an interior stop sequence"
+    stop = match.group()
+    stopped = _request(url, {**payload, "stop": stop}, output / "stop.json")
+    validate_stop_response(stopped, unary, stop)
 
 
 def _request(url: str, payload: dict, artifact: Path, min_content_length: int = 0):

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -21,10 +21,20 @@ logger = logging.getLogger(__name__)
 
 
 def check_deployment_api(
-    base_url: str, model: str, scenario: str, output: Path
+    base_url: str,
+    model: str,
+    scenario: str,
+    output: Path,
+    *,
+    endpoint: str | None = None,
 ) -> None:
     """Run shared API cases and retain raw responses even if a contract fails."""
     output.mkdir(parents=True, exist_ok=True)
+    if endpoint is None:
+        endpoint = (
+            "/v1/embeddings" if scenario == "embedding" else "/v1/chat/completions"
+        )
+    url = base_url + endpoint
     if scenario == "embedding":
         for name, inputs, encoding in (
             ("default", "Hello", None),
@@ -34,9 +44,7 @@ def check_deployment_api(
             payload = {"model": model, "input": inputs}
             if encoding:
                 payload["encoding_format"] = encoding
-            data = _request(
-                base_url + "/v1/embeddings", payload, output / f"{name}.json"
-            )
+            data = _request(url, payload, output / f"{name}.json")
             assert data["model"] == model, data
             # The example uses Qwen3-Embedding-0.6B's native 1024 dimensions.
             validate_embedding(data, 2 if name == "batch" else 1, 1024)
@@ -51,7 +59,6 @@ def check_deployment_api(
         "stream": False,
         "chat_template_kwargs": {"enable_thinking": False},
     }
-    url = base_url + "/v1/chat/completions"
     unary = _request(
         url,
         payload,

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--frontend-image",
         type=str,
         default=None,
-        help="Frontend container image (used by GAIE and checkpoint deploy tests).",
+        help="Frontend container image override for deployment tests.",
     )
     parser.addoption(
         "--checkpoint-backend",
@@ -453,6 +453,10 @@ def deployment_spec(
     # Override image if provided
     if image:
         spec.set_image(image)
+
+    frontend_image = request.config.getoption("--frontend-image")
+    if frontend_image:
+        spec.set_image(frontend_image, service_name="Frontend")
 
     # Mount the shared model cache onto workers when a PVC is provided (CI on
     # clusters that provision it); otherwise workers download from HuggingFace.

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -594,6 +594,10 @@ class DeploymentSpec:
         for service in services:
             service.image = image
 
+    def set_runtime_version(self, version: str, service_name: str) -> None:
+        """Keep operator defaults tied to the runtime of a mixed-version component."""
+        self._component_by_name(service_name)["runtimeVersionOverride"] = version
+
     def mount_model_cache_pvc(
         self, pvc_name: str, mount_point: str = "/models"
     ) -> None:
@@ -882,6 +886,10 @@ class PodStatusDetail:
         return result
 
 
+class DeploymentStartupError(RuntimeError):
+    """A deployment cannot recover without changing its configuration."""
+
+
 @dataclass
 class ManagedDeployment:
     log_dir: str
@@ -895,6 +903,8 @@ class ManagedDeployment:
     # this below it, so _wait_for_condition raises with pod-status diagnostics
     # instead of pytest-timeout killing the test mid-wait with a bare traceback.
     readiness_timeout: int = 1800
+    fail_fast_startup: bool = False
+    cleanup_errors: list[Exception] = field(default_factory=list, init=False)
 
     _custom_api: Optional[client.CustomObjectsApi] = None
     _core_api: Optional[client.CoreV1Api] = None
@@ -1046,6 +1056,25 @@ class ManagedDeployment:
                     plural="dynamographdeployments",
                     name=self._deployment_name,
                 )
+                if self.fail_fast_startup and desired_ready_condition_val:
+                    details = await self._get_pod_status_details()
+                    for detail in details:
+                        if detail.reason in (
+                            "InvalidImageName",
+                            "CreateContainerConfigError",
+                            "CreateContainerError",
+                        ) or (
+                            detail.restart_count >= 2
+                            and (
+                                detail.reason == "CrashLoopBackOff"
+                                or (
+                                    detail.state == "Terminated"
+                                    and detail.exit_code is not None
+                                    and detail.exit_code != 0
+                                )
+                            )
+                        ):
+                            raise DeploymentStartupError(detail.format())
                 # Check both conditions:
                 # 1. Ready condition is True
                 # 2. State is successful
@@ -1114,6 +1143,8 @@ class ManagedDeployment:
                             for ev in pod_events:
                                 self._logger.info(f"    {ev}")
 
+            except DeploymentStartupError:
+                raise
             except exceptions.ApiException as e:
                 self._logger.info(
                     f"API Exception while checking deployment status: {e}"
@@ -1158,7 +1189,12 @@ class ManagedDeployment:
                 phase = pod_status.phase if pod_status else "Unknown"
 
                 container_statuses = (
-                    pod_status.container_statuses if pod_status else None
+                    (
+                        (pod_status.init_container_statuses or [])
+                        + (pod_status.container_statuses or [])
+                    )
+                    if pod_status
+                    else None
                 )
                 if not container_statuses:
                     details.append(
@@ -1637,21 +1673,48 @@ class ManagedDeployment:
                 f.write(content)
 
     async def _delete_deployment(self):
-        """
-        Delete the DynamoGraphDeployment CR.
-        """
+        """Wait for the CR and its Pods to disappear before releasing the fixture."""
+        if not self._deployment_name or self._custom_api is None:
+            return
         try:
-            if self._deployment_name and self._custom_api is not None:
-                await self._custom_api.delete_namespaced_custom_object(
+            await self._custom_api.delete_namespaced_custom_object(
+                group="nvidia.com",
+                version=self.deployment_spec.api_version,
+                namespace=self.namespace,
+                plural="dynamographdeployments",
+                name=self._deployment_name,
+                body=client.V1DeleteOptions(propagation_policy="Foreground"),
+            )
+        except exceptions.ApiException as error:
+            if error.status != 404:
+                raise
+        assert self._core_api is not None, "Kubernetes API not initialized"
+        deadline = time.monotonic() + 120
+        while True:
+            exists = True
+            try:
+                await self._custom_api.get_namespaced_custom_object(
                     group="nvidia.com",
                     version=self.deployment_spec.api_version,
                     namespace=self.namespace,
                     plural="dynamographdeployments",
                     name=self._deployment_name,
                 )
-        except exceptions.ApiException as e:
-            if e.status != 404:  # Ignore if already deleted
-                raise
+            except exceptions.ApiException as error:
+                if error.status != 404:
+                    raise
+                exists = False
+            pods = await self._core_api.list_namespaced_pod(
+                self.namespace,
+                label_selector=f"nvidia.com/dynamo-graph-deployment-name={self._deployment_name}",
+            )
+            if not exists and not pods.items:
+                return
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Deployment {self._deployment_name} or its Pods were not deleted within 120s"
+                )
+            await asyncio.sleep(1)
 
     def port_forward(
         self, pod: Pod, remote_port: int, max_connection_attempts: int = 3
@@ -1720,6 +1783,9 @@ class ManagedDeployment:
         try:
             # Collect logs/metrics first; any PFs opened here will be tracked and stopped below.
             self._get_service_logs()
+            events = await self._get_pod_events()
+            with open(os.path.join(self.log_dir, "events.log"), "w") as event_file:
+                event_file.write("\n".join(events))
             self._logger.info(
                 f"Cleaning up {len(self._active_port_forwards)} active port forwards"
             )
@@ -1752,13 +1818,22 @@ class ManagedDeployment:
             await self._create_deployment()
             await self._wait_for_ready(timeout=self.readiness_timeout)
 
-        except:
-            await self._cleanup()
+        except BaseException as error:
+            await self._cleanup_preserving_error(error)
             raise
         return self
 
+    async def _cleanup_preserving_error(self, primary):
+        try:
+            await self._cleanup()
+        except Exception as error:
+            self.cleanup_errors.append(error)
+            if primary is None:
+                raise
+            self._logger.error("Deployment cleanup also failed", exc_info=True)
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self._cleanup()
+        await self._cleanup_preserving_error(exc_val)
 
 
 async def main():

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -291,7 +291,20 @@ class ServiceSpec:
         self._spec["envs"] = value
 
     def add_pvc_mount(self, pvc_name: str, mount_point: str) -> None:
-        """Add a service-level volumeMount for a PVC declared in ``spec.pvcs``. Idempotent."""
+        """Mount an existing PVC using the service's CRD schema. Idempotent."""
+        if self._schema == SCHEMA_V1BETA1:
+            pod = self._spec.setdefault("podTemplate", {}).setdefault("spec", {})
+            volumes = pod.setdefault("volumes", [])
+            if not any(v.get("name") == pvc_name for v in volumes):
+                volumes.append(
+                    {"name": pvc_name, "persistentVolumeClaim": {"claimName": pvc_name}}
+                )
+            container = self._main_container(create=True)
+            assert container is not None
+            mounts = container.setdefault("volumeMounts", [])
+            if not any(m.get("name") == pvc_name for m in mounts):
+                mounts.append({"name": pvc_name, "mountPath": mount_point})
+            return
         mounts = self._spec.setdefault("volumeMounts", [])
         if not any(m.get("name") == pvc_name for m in mounts):
             mounts.append({"name": pvc_name, "mountPoint": mount_point})
@@ -605,6 +618,13 @@ class DeploymentSpec:
         service, with ``HF_HOME`` pointed at it so models come from the shared cache
         instead of HuggingFace. Idempotent; used by CI via --model-cache-pvc.
         """
+        if self._schema == SCHEMA_V1BETA1:
+            for service in self.services:
+                service.add_pvc_mount(pvc_name, mount_point)
+                envs = service.envs
+                if not any(e.get("name") == "HF_HOME" for e in envs):
+                    service.envs = [*envs, {"name": "HF_HOME", "value": mount_point}]
+            return
         spec = self._deployment_spec["spec"]
         pvcs = spec.setdefault("pvcs", [])
         if not any(p.get("name") == pvc_name for p in pvcs):

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -104,10 +104,11 @@ def validate_chat_response(
     if stop is not None and content is None:
         content = ""
     assert isinstance(content, str), f"Expected text content: {message}"
-    assert len(content) >= min_content_length, (
-        f"Response content too short: {len(content)} chars (min: {min_content_length}). "
-        f"Content: {content[:200]}"
-    )
+    if stop is None:
+        assert len(content) >= min_content_length, (
+            f"Response content too short: {len(content)} chars (min: {min_content_length}). "
+            f"Content: {content[:200]}"
+        )
 
     assert "model" in data, f"Response missing 'model' field: {data}"
     assert (

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -20,6 +20,7 @@ from kr8s.objects import Pod, Service
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import exceptions
 
+from tests.deploy.response_checks import validate_chat
 from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,8 @@ def validate_chat_response(
     response: requests.Response,
     expected_model: str,
     min_content_length: int = MIN_RESPONSE_CONTENT_LENGTH,
+    max_tokens: int | None = None,
+    stop: str | None = None,
 ) -> dict[str, Any]:
     """Validate the structure and content of a chat completion response.
 
@@ -62,6 +65,8 @@ def validate_chat_response(
         response: HTTP response from the chat completion endpoint
         expected_model: Expected model name in the response
         min_content_length: Minimum required length for response content
+        max_tokens: Optional requested token cap for the completion contract
+        stop: Prefix stop sequence; permits fully suppressed response content
 
     Returns:
         Parsed response JSON on success
@@ -80,6 +85,9 @@ def validate_chat_response(
     except ValueError as e:
         pytest.fail(f"Response is not valid JSON: {e}. Response: {response.text[:500]}")
 
+    if max_tokens is not None:
+        validate_chat(data, max_tokens, stop)
+
     assert "choices" in data, f"Response missing 'choices' field: {data}"
     assert len(data["choices"]) > 0, f"Response has empty 'choices': {data}"
 
@@ -93,6 +101,9 @@ def validate_chat_response(
     assert "content" in message, f"Message missing 'content' field: {message}"
 
     content = message["content"]
+    if stop is not None and content is None:
+        content = ""
+    assert isinstance(content, str), f"Expected text content: {message}"
     assert len(content) >= min_content_length, (
         f"Response content too short: {len(content)} chars (min: {min_content_length}). "
         f"Content: {content[:200]}"

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -66,7 +66,7 @@ def validate_chat_response(
         expected_model: Expected model name in the response
         min_content_length: Minimum required length for response content
         max_tokens: Optional requested token cap for the completion contract
-        stop: Prefix stop sequence; permits fully suppressed response content
+        stop: Stop sequence; permits empty or shortened response content
 
     Returns:
         Parsed response JSON on success

--- a/tests/deploy/n2/README.md
+++ b/tests/deploy/n2/README.md
@@ -1,0 +1,63 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Component compatibility tests
+
+This suite applies the shared deployment API checks to four SGLang component
+pairs: candidate frontend with N-1/N-2 workers, and N-1/N-2 frontends with a
+candidate worker. Each pair runs chat and embedding, for eight deployments.
+`releases.json` names the latest selected patch release in each historical minor
+line. Update it when the candidate advances to a new minor; an absent release
+fails setup instead of silently shrinking coverage.
+
+## Shared coverage
+
+`test_dgd.py` owns current/current coverage. PR and nightly workflows require the
+ordinary SGLang deployment job to succeed before running this suite; skipped
+controls do not satisfy the dependency. Manual dispatch invokes the same ordinary
+chat and embedding tests first. Both suites call `check_deployment_api` for unary,
+streaming, token limits, stop behavior and embedding default/float/batch responses.
+
+Deployments load the chat or embedding YAML from
+`examples/backends/sglang/deploy/`, then patch component images, runtime versions
+and cache paths with `DeploymentSpec`. `ManagedDeployment` owns readiness,
+port forwarding, Pod manifests (including image IDs), logs and cleanup. There is
+no image digest resolver, Pod exec, injected inference code, private Docker
+runner or per-test ResourceQuota.
+
+## Run
+
+Use Linux amd64 candidate image tags beginning with their runtime version, such
+as `1.5.0-ci-<sha>-...`. The test requires a shared PVC accessible to both
+frontend and worker Pods. Prepare the pinned snapshots in `model-download.yaml`
+using a candidate SGLang image, then run:
+
+```bash
+python -m pytest tests/deploy/test_n2_compatibility.py \
+  --namespace default --image "$WORKER_IMAGE" --frontend-image "$FRONTEND_IMAGE" \
+  --model-cache-pvc model-cache --model-cache-mount /models -m k8s -n 0
+```
+
+The CI workflow prepares the cache with a GPU-free Job. Local invocations must
+prepare it first. The Job writes both pinned snapshots; inference mounts the same
+cache and uses offline snapshot paths. The ordinary deploy controls use the same
+model IDs and request checks, but do not enforce these snapshot revisions, so
+they are functional prerequisites rather than a strict experimental control.
+
+`N2_RELEASE_LINE` overrides the candidate minor line inferred from `Cargo.toml`.
+Image tags supply `runtimeVersionOverride` separately for each component, keeping
+operator health defaults appropriate for historical runtimes. Kubernetes discovery
+and TCP requests are used across the supported window.
+
+CI schedules cases serially to bound GPU use. Each case has its own deployment
+name and fixture; there is no cross-test baseline state. Compatibility failures
+allow later cases to run. A cleanup failure stops the session after reporting the
+current item because resource isolation is no longer established. The outer
+workflow tears down its dedicated vCluster after failure or cancellation.
+
+Raw API responses and a version-pair record accompany the normal deploy logs and
+JUnit report. A skipped workflow or interrupted matrix provides no evidence for
+unexecuted pairs. A successful CPU test run is not GPU compatibility evidence.
+
+This is a static component matrix, not a rolling-upgrade, performance or release
+promotion test. Coverage is currently SGLang aggregated chat and embedding.

--- a/tests/deploy/n2/model-download.yaml
+++ b/tests/deploy/n2/model-download.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: n2-model-download
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 900
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: my-registry/sglang-runtime:my-tag
+          command: [python3, -c]
+          args:
+            - |
+              import json
+              from huggingface_hub import snapshot_download
+              models = {
+                  "Qwen/Qwen3-0.6B": "c1899de289a04d12100db370d81485cdf75e47ca",
+                  "Qwen/Qwen3-Embedding-0.6B": "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3",
+              }
+              for model, revision in models.items():
+                  path = snapshot_download(model, revision=revision, cache_dir='/models/hub')
+                  print(json.dumps({'model': model, 'revision': revision, 'path': path}), flush=True)
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/tests/deploy/n2/releases.json
+++ b/tests/deploy/n2/releases.json
@@ -1,0 +1,4 @@
+{
+  "1.3": {"frontend": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.1", "worker": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.1"},
+  "1.4": {"frontend": "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.2", "worker": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.2"}
+}

--- a/tests/deploy/n2_utils.py
+++ b/tests/deploy/n2_utils.py
@@ -78,4 +78,25 @@ def compatibility_spec(
         spec.set_service_env_var(service, "HF_HUB_OFFLINE", "1")
         spec.set_service_env_var(service, "TRANSFORMERS_OFFLINE", "1")
         spec.set_service_env_var(service, "DYN_REQUEST_PLANE", "tcp")
+    # Check the mounted snapshot before starting the worker. Reading a byte also
+    # catches missing blob targets behind Hugging Face snapshot symlinks.
+    worker = next(c for c in spec.spec()["spec"]["components"] if c["name"] == "decode")
+    worker["podTemplate"]["spec"].setdefault("initContainers", []).append(
+        {
+            "name": "check-model-snapshot",
+            "image": pair.worker,
+            "command": ["python3", "-c"],
+            "args": [
+                "import pathlib, sys\n"
+                "p = pathlib.Path(sys.argv[1])\n"
+                "for name in ('config.json', 'tokenizer.json', 'model.safetensors'):\n"
+                "    print(f'Checking {p / name}', flush=True)\n"
+                "    with (p / name).open('rb') as f:\n"
+                "        if not f.read(1):\n"
+                "            raise RuntimeError(f'Empty model file: {p / name}')\n",
+                snapshot,
+            ],
+            "volumeMounts": [{"name": pvc, "mountPath": mount, "readOnly": True}],
+        }
+    )
     return spec

--- a/tests/deploy/n2_utils.py
+++ b/tests/deploy/n2_utils.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Version selection and example patching for component compatibility tests."""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from tests.deploy.dgd_utils import DeploymentSpec
+
+MODELS = {
+    "chat": ("Qwen/Qwen3-0.6B", "c1899de289a04d12100db370d81485cdf75e47ca"),
+    "embedding": (
+        "Qwen/Qwen3-Embedding-0.6B",
+        "97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class VersionPair:
+    name: str
+    frontend: str
+    worker: str
+
+
+def version_matrix(
+    releases: dict, line: str, frontend: str, worker: str
+) -> list[VersionPair]:
+    major, minor = map(int, line.split("."))
+    if minor < 2:
+        raise ValueError("N-2 requires two preceding minor versions in the same major")
+    pairs = []
+    for age in (1, 2):
+        previous = releases[f"{major}.{minor - age}"]
+        pairs.extend(
+            [
+                VersionPair(f"old-frontend-{age}", previous["frontend"], worker),
+                VersionPair(f"old-worker-{age}", frontend, previous["worker"]),
+            ]
+        )
+    return pairs
+
+
+def runtime_version(image: str) -> str:
+    match = re.search(r":(\d+\.\d+\.\d+)(?:[-.@]|$)", image)
+    if match is None:
+        raise ValueError(f"Image tag must start with its runtime version: {image}")
+    return match[1]
+
+
+def compatibility_spec(
+    root: Path, pair: VersionPair, scenario: str, name: str, pvc: str, mount: str
+) -> DeploymentSpec:
+    if not pvc:
+        raise ValueError("N-2 requires --model-cache-pvc with both models prepared")
+    profile = "agg_embed" if scenario == "embedding" else "agg"
+    spec = DeploymentSpec(str(root / f"examples/backends/sglang/deploy/{profile}.yaml"))
+    spec.name = name
+    spec.disable_grove()
+    spec.spec()["metadata"].setdefault("annotations", {})[
+        "nvidia.com/dynamo-discovery-backend"
+    ] = "kubernetes"
+    spec.mount_model_cache_pvc(pvc, mount)
+    model, revision = MODELS[scenario]
+    snapshot = f"{mount}/hub/models--{model.replace('/', '--')}/snapshots/{revision}"
+    spec.add_arg_to_service("decode", "--model-path", snapshot)
+    spec.add_arg_to_service("decode", "--served-model-name", model)
+    for component in spec.spec()["spec"]["components"]:
+        component["podTemplate"]["spec"].setdefault("nodeSelector", {})[
+            "kubernetes.io/arch"
+        ] = "amd64"
+
+    for service, image in (("Frontend", pair.frontend), ("decode", pair.worker)):
+        spec.set_image(image, service_name=service)
+        spec.set_runtime_version(runtime_version(image), service)
+        spec.set_service_env_var(service, "HF_HUB_OFFLINE", "1")
+        spec.set_service_env_var(service, "TRANSFORMERS_OFFLINE", "1")
+        spec.set_service_env_var(service, "DYN_REQUEST_PLANE", "tcp")
+    return spec

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -41,10 +41,24 @@ def validate_chat(body, max_tokens, stop=None):
     tokens = body["usage"]["completion_tokens"]
     assert type(tokens) is int and 0 <= tokens <= max_tokens, body
     if stop is not None:
-        assert content is None or content == "", body
+        assert content is None or isinstance(content, str), body
+        assert stop not in (content or ""), body
         assert choice["finish_reason"] == "stop", body
         assert not message.get("refusal") and (not message.get("tool_calls")), body
         assert not message.get("function_call"), body
+
+
+def validate_stop_response(body, baseline, stop):
+    """Require a stopped response to end before the baseline's stop sequence."""
+    content = body["choices"][0]["message"]["content"] or ""
+    original = baseline["choices"][0]["message"]["content"]
+    stop_index = original.index(stop)
+    assert content.strip(), "Interior stop suppressed preceding text"
+    assert original.startswith(content), "Stopped output diverged from baseline"
+    assert len(content) <= stop_index, "Output continued past the stop position"
+    assert (
+        body["usage"]["completion_tokens"] < baseline["usage"]["completion_tokens"]
+    ), "Stop did not reduce generated tokens"
 
 
 def validate_stream(lines):

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response contracts shared by deployment and component compatibility tests."""
+
+import json
+import math
+
+
+def validate_embedding(body, count, dimensions):
+    """Require finite float vectors with the requested shape and indices."""
+    assert body["object"] == "list", body
+    assert len(body["data"]) == count, body
+    for index, item in enumerate(body["data"]):
+        assert item["index"] == index, item
+        assert item["object"] == "embedding", item
+        vector = item["embedding"]
+        assert isinstance(
+            vector, list
+        ), f"Expected float array, got {type(vector).__name__}"
+        assert len(vector) == dimensions, len(vector)
+        assert all(
+            (type(x) in (int, float) and math.isfinite(x) for x in vector)
+        ), "Embedding vector must contain finite numbers"
+
+
+def validate_chat(body, max_tokens, stop=None):
+    """Validate unary chat content, token limits, and derived stop semantics."""
+    assert "error" not in body, body
+    assert len(body["choices"]) == 1, body
+    choice = body["choices"][0]
+    assert choice["index"] == 0, choice
+    assert choice["finish_reason"] in ("stop", "length"), choice
+    message = choice["message"]
+    assert message["role"] == "assistant", message
+    content = message["content"]
+    if stop is None:
+        assert isinstance(content, str), body
+        if max_tokens > 1:
+            assert content.strip(), body
+    tokens = body["usage"]["completion_tokens"]
+    assert type(tokens) is int and 0 <= tokens <= max_tokens, body
+    if stop is not None:
+        assert content is None or content == "", body
+        assert choice["finish_reason"] == "stop", body
+        assert not message.get("refusal") and (not message.get("tool_calls")), body
+        assert not message.get("function_call"), body
+
+
+def validate_stream(lines):
+    """Reject stream errors, malformed ordering, and incomplete termination."""
+    content, finished, done = ([], False, False)
+    for line in lines:
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            assert line.strip() != "event: error", line
+            continue
+        assert line.startswith("data:"), f"Unexpected SSE line: {line}"
+        assert not done, "Data after [DONE]"
+        data = line[5:].strip()
+        if data == "[DONE]":
+            done = True
+            continue
+        chunk = json.loads(data)
+        assert "error" not in chunk, chunk
+        choices = chunk["choices"]
+        assert isinstance(choices, list) and len(choices) <= 1, chunk
+        for choice in choices:
+            assert choice["index"] == 0, choice
+            text = choice.get("delta", {}).get("content")
+            if text is not None:
+                assert isinstance(text, str), "Stream content must be a string"
+            if text:
+                assert not finished, "Content after finish_reason"
+                content.append(text)
+            if choice.get("finish_reason") is not None:
+                assert not finished, "Duplicate finish_reason"
+                assert choice["finish_reason"] in ("stop", "length"), choice
+                finished = True
+    assert done and finished, "Incomplete SSE response"
+    assert "".join(content).strip(), "Empty streamed content"

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -54,7 +54,8 @@ def validate_stream(lines):
         if not line or line.startswith(":"):
             continue
         if line.startswith("event:"):
-            assert line.strip() != "event: error", line
+            event = line.partition(":")[2].removeprefix(" ")
+            assert event != "error", line
             continue
         assert line.startswith("data:"), f"Unexpected SSE line: {line}"
         assert not done, "Data after [DONE]"

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from tests.deploy import api_checks
+from tests.deploy.conftest import deployment_spec
+from tests.deploy.dgd_utils import validate_chat_response
+from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.utils import client
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.framework_agnostic,
+    pytest.mark.core,
+    pytest.mark.sglang,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
+]
+
+
+def response(content="hello", finish="stop", tokens=1):
+    result = requests.Response()
+    result.status_code = 200
+    result._content_consumed = True
+    result._content = json.dumps(
+        {
+            "model": "model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": finish,
+                    "message": {"role": "assistant", "content": content},
+                }
+            ],
+            "usage": {"completion_tokens": tokens},
+        }
+    ).encode()
+    return result
+
+
+@pytest.mark.parametrize("content", [None, ""])
+def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
+    validate_chat_response(response(content), "model", 0, max_tokens=30, stop="hello")
+    with pytest.raises(AssertionError):
+        validate_chat_response(
+            response("hello"), "model", 0, max_tokens=30, stop="hello"
+        )
+
+
+def test_token_limit_and_finish_reason():
+    validate_chat_response(response("h", "length"), "model", 0, max_tokens=1)
+    with pytest.raises(AssertionError):
+        validate_chat_response(response(tokens=2), "model", 0, max_tokens=1)
+    with pytest.raises(AssertionError):
+        validate_chat_response(response(finish="tool_calls"), "model", 0, max_tokens=30)
+
+
+def test_stream_requires_one_finish_and_done():
+    content = 'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}'
+    finish = 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
+    validate_stream([content, finish, "data: [DONE]"])
+    for lines in (
+        [content, finish],
+        [content, finish, finish, "data: [DONE]"],
+        [content, finish, content, "data: [DONE]"],
+    ):
+        with pytest.raises(AssertionError):
+            validate_stream(lines)
+
+
+def test_embedding_contract_rejects_wire_base64_and_nonfinite_vectors():
+    body = {
+        "object": "list",
+        "data": [{"index": 0, "object": "embedding", "embedding": [0.1, 0.2]}],
+    }
+    validate_embedding(body, 1, 2)
+    for vector in ("base64", [float("nan"), 0.2], [0.1], [True, 0.2]):
+        body["data"][0]["embedding"] = vector
+        with pytest.raises(AssertionError):
+            validate_embedding(body, 1, 2)
+
+
+def test_api_cases_use_shared_client_and_preserve_invalid_response(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    def send(url, payload, **kwargs):
+        calls.append(payload)
+        if payload.get("stream"):
+            result = response()
+            result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
+            return result
+        if "stop" in payload:
+            return response(None)
+        return response("hello " * 20)
+
+    monkeypatch.setattr(api_checks, "send_request", send)
+    api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    assert len(calls) == 4
+    assert calls[-1]["stop"] == "hell"
+    assert (
+        json.loads((tmp_path / "stop.json").read_text())["response"]
+        == response(None).text
+    )
+    monkeypatch.setattr(
+        api_checks, "send_request", lambda *a, **k: response(tokens=100)
+    )
+    with pytest.raises(AssertionError):
+        api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    assert "100" in json.loads((tmp_path / "unary.json").read_text())["response"]
+
+
+def test_embedding_readiness_uses_embedding_payload(monkeypatch):
+    post = Mock(return_value=response())
+    monkeypatch.setattr(client.requests, "post", post)
+    monkeypatch.setattr(client.time, "sleep", lambda _: None)
+    payload = {"model": "model", "input": "test"}
+    assert client.wait_for_model_availability(
+        "http://test", "/v1/embeddings", "model", client.logger, payload=payload
+    )
+    assert post.call_args.kwargs["json"] == payload
+
+
+def test_deploy_fixture_overrides_frontend_separately():
+    root = Path(__file__).resolve().parents[2]
+    options = {"--frontend-image": "frontend:candidate", "--model-cache-pvc": ""}
+    request = SimpleNamespace(config=SimpleNamespace(getoption=options.__getitem__))
+    spec = deployment_spec.__wrapped__(
+        root / "examples/backends/sglang/deploy/agg_embed.yaml",
+        "worker:candidate",
+        "test",
+        request,
+    )
+    assert spec["Frontend"].image == "frontend:candidate"
+    assert spec["decode"].image == "worker:candidate"
+    assert spec["decode"].model == "Qwen/Qwen3-Embedding-0.6B"

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -49,11 +49,14 @@ def response(content="hello", finish="stop", tokens=1):
 
 @pytest.mark.parametrize("content", [None, ""])
 def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
-    validate_chat_response(response(content), "model", 0, max_tokens=30, stop="hello")
+    validate_chat_response(response(content), "model", max_tokens=30, stop="hello")
     with pytest.raises(AssertionError):
-        validate_chat_response(
-            response("hello"), "model", 0, max_tokens=30, stop="hello"
-        )
+        validate_chat_response(response("hello"), "model", max_tokens=30, stop="hello")
+
+
+def test_chat_keeps_default_minimum_length_without_stop():
+    with pytest.raises(AssertionError, match="Response content too short"):
+        validate_chat_response(response("hello"), "model", max_tokens=30)
 
 
 def test_token_limit_and_finish_reason():
@@ -69,6 +72,8 @@ def test_stream_requires_one_finish_and_done():
     finish = 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
     validate_stream([content, finish, "data: [DONE]"])
     for lines in (
+        ["event:error", content, finish, "data: [DONE]"],
+        ["event: error", content, finish, "data: [DONE]"],
         [content, finish],
         [content, finish, finish, "data: [DONE]"],
         [content, finish, content, "data: [DONE]"],
@@ -89,13 +94,14 @@ def test_embedding_contract_rejects_wire_base64_and_nonfinite_vectors():
             validate_embedding(body, 1, 2)
 
 
+@pytest.mark.parametrize("endpoint", [None, "/custom/chat/completions"])
 def test_api_cases_use_shared_client_and_preserve_invalid_response(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, endpoint
 ):
     calls = []
 
     def send(url, payload, **kwargs):
-        calls.append(payload)
+        calls.append((url, payload))
         if payload.get("stream"):
             result = response()
             result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
@@ -105,9 +111,14 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
         return response("hello " * 20)
 
     monkeypatch.setattr(api_checks, "send_request", send)
-    api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    api_checks.check_deployment_api(
+        "http://test", "model", "chat", tmp_path, endpoint=endpoint
+    )
     assert len(calls) == 4
-    assert calls[-1]["stop"] == "hell"
+    assert all(
+        url == "http://test" + (endpoint or "/v1/chat/completions") for url, _ in calls
+    )
+    assert calls[-1][1]["stop"] == "hell"
     assert (
         json.loads((tmp_path / "stop.json").read_text())["response"]
         == response(None).text
@@ -116,8 +127,38 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
         api_checks, "send_request", lambda *a, **k: response(tokens=100)
     )
     with pytest.raises(AssertionError):
-        api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+        api_checks.check_deployment_api(
+            "http://test", "model", "chat", tmp_path, endpoint=endpoint
+        )
     assert "100" in json.loads((tmp_path / "unary.json").read_text())["response"]
+
+
+def test_embedding_api_uses_default_endpoint(monkeypatch, tmp_path):
+    calls = []
+
+    def send(url, payload, **kwargs):
+        calls.append((url, payload))
+        count = len(payload["input"]) if isinstance(payload["input"], list) else 1
+        result = response()
+        result._content = json.dumps(
+            {
+                "model": "model",
+                "object": "list",
+                "data": [
+                    {"index": i, "object": "embedding", "embedding": [0.1] * 1024}
+                    for i in range(count)
+                ],
+            }
+        ).encode()
+        return result
+
+    monkeypatch.setattr(api_checks, "send_request", send)
+    api_checks.check_deployment_api("http://test", "model", "embedding", tmp_path)
+    assert len(calls) == 3
+    assert all(url == "http://test/v1/embeddings" for url, _ in calls)
+    assert "encoding_format" not in calls[0][1]
+    assert calls[1][1]["encoding_format"] == "float"
+    assert calls[2][1]["input"] == ["Hello", "World"]
 
 
 def test_embedding_readiness_uses_embedding_payload(monkeypatch):

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -12,7 +12,11 @@ import requests
 from tests.deploy import api_checks
 from tests.deploy.conftest import deployment_spec
 from tests.deploy.dgd_utils import validate_chat_response
-from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.deploy.response_checks import (
+    validate_embedding,
+    validate_stop_response,
+    validate_stream,
+)
 from tests.utils import client
 
 pytestmark = [
@@ -44,11 +48,13 @@ def response(content="hello", finish="stop", tokens=1):
     return result
 
 
-@pytest.mark.parametrize("content", [None, ""])
-def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
-    validate_chat_response(response(content), "model", max_tokens=30, stop="hello")
+@pytest.mark.parametrize(
+    "content,stop", [(None, "hello"), ("", "hello"), ("The", "The ")]
+)
+def test_stop_accepts_shortened_content_and_rejects_stop_sequence(content, stop):
+    validate_chat_response(response(content), "model", max_tokens=30, stop=stop)
     with pytest.raises(AssertionError):
-        validate_chat_response(response("hello"), "model", max_tokens=30, stop="hello")
+        validate_chat_response(response(stop), "model", max_tokens=30, stop=stop)
 
 
 def test_chat_keeps_default_minimum_length_without_stop():
@@ -103,9 +109,14 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
             result = response()
             result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
             return result
+        if payload.get("max_tokens") == 1:
+            return response("The", "length", tokens=1)
         if "stop" in payload:
-            return response(None)
-        return response("hello " * 20)
+            return response("The", tokens=2)
+        return response(
+            "The air in the ruins was thick with the scent of damp earth. " * 2,
+            tokens=30,
+        )
 
     monkeypatch.setattr(api_checks, "send_request", send)
     api_checks.check_deployment_api(
@@ -115,10 +126,10 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
     assert all(
         url == "http://test" + (endpoint or "/v1/chat/completions") for url, _ in calls
     )
-    assert calls[-1][1]["stop"] == "hell"
+    assert calls[-1][1]["stop"] == "air"
     assert (
         json.loads((tmp_path / "stop.json").read_text())["response"]
-        == response(None).text
+        == response("The", tokens=2).text
     )
     monkeypatch.setattr(
         api_checks, "send_request", lambda *a, **k: response(tokens=100)
@@ -182,3 +193,36 @@ def test_deploy_fixture_overrides_frontend_separately():
     assert spec["Frontend"].image == "frontend:candidate"
     assert spec["decode"].image == "worker:candidate"
     assert spec["decode"].model == "Qwen/Qwen3-Embedding-0.6B"
+    assert "--embedding-worker" in spec["decode"]._get_args()
+    assert "--use-sglang-tokenizer" in spec["decode"]._get_args()
+
+
+@pytest.mark.parametrize("content", ["The", "The "])
+def test_stop_allows_text_before_stop(content):
+    baseline = response("The air in the ruins", tokens=30).json()
+    stopped = response(content, tokens=2)
+    body = validate_chat_response(stopped, "model", max_tokens=30, stop="air")
+    validate_stop_response(body, baseline, "air")
+
+
+@pytest.mark.parametrize(
+    "content,finish,tokens",
+    [
+        (None, "stop", 2),
+        ("", "stop", 2),
+        ("The air", "stop", 2),
+        ("Other", "stop", 2),
+        ("The ", "length", 2),
+        ("The ", "stop", 30),
+        (False, "stop", 2),
+    ],
+)
+def test_stop_rejects_leaked_stop_divergence_and_no_early_termination(
+    content, finish, tokens
+):
+    baseline = response("The air in the ruins", tokens=30).json()
+    with pytest.raises(AssertionError):
+        body = validate_chat_response(
+            response(content, finish, tokens), "model", max_tokens=30, stop="air"
+        )
+        validate_stop_response(body, baseline, "air")

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -19,11 +19,8 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,
-    pytest.mark.framework_agnostic,
     pytest.mark.core,
-    pytest.mark.sglang,
-    pytest.mark.vllm,
-    pytest.mark.trtllm,
+    pytest.mark.parallel,
 ]
 
 

--- a/tests/deploy/test_dgd.py
+++ b/tests/deploy/test_dgd.py
@@ -14,6 +14,7 @@ import logging
 import os
 import subprocess
 import time
+from pathlib import Path
 from typing import Any
 
 import kr8s
@@ -21,6 +22,7 @@ import pytest
 import requests
 import yaml
 
+from tests.deploy.api_checks import check_deployment_api
 from tests.deploy.conftest import DeploymentTarget
 from tests.deploy.dgd_utils import (
     DEFAULT_MAX_TOKENS,
@@ -33,7 +35,8 @@ from tests.deploy.dgd_utils import (
     _get_workspace_dir,
     validate_chat_response,
 )
-from tests.utils.client import send_request, wait_for_model_availability
+from tests.utils.client import wait_for_model_availability
+from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
 
@@ -194,43 +197,34 @@ async def test_deployment(
         base_url = f"http://localhost:{port_forward.local_port}"
         logger.info(f"Port forwarding established: {base_url}")
 
-        # Wait for model to be available
-        endpoint = deployment_spec.endpoint
-        model_ready = wait_for_model_availability(
-            url=base_url,
-            endpoint=endpoint,
-            model=model,
-            logger=logger,
-            max_attempts=30,
+        scenario = "embedding" if profile == "agg_embed" else "chat"
+        endpoint = (
+            "/v1/embeddings" if scenario == "embedding" else deployment_spec.endpoint
         )
-
-        assert (
-            model_ready
-        ), f"Model '{model}' did not become available within the timeout period"
-
-        # Send test request
-        url = f"{base_url}{endpoint}"
-        payload = {
-            "model": model,
-            "messages": [{"role": "user", "content": TEST_PROMPT}],
-            "max_tokens": DEFAULT_MAX_TOKENS,
-            "temperature": DEFAULT_TEMPERATURE,
-            "stream": False,
-        }
+        ready_payload = (
+            {"model": model, "input": "test"} if scenario == "embedding" else None
+        )
+        model_ready = await asyncio.to_thread(
+            wait_for_model_availability,
+            base_url,
+            endpoint,
+            model,
+            logger,
+            max_attempts=30,
+            payload=ready_payload,
+        )
+        assert model_ready, f"Model '{model}' did not become available"
         frontend_log_baseline = (
             len(normalize_log_lines(frontend_pod.logs(container="main")))
             if validate_agg_logging
             else 0
         )
-        response = send_request(
-            url, payload, timeout=float(DEFAULT_REQUEST_TIMEOUT), method="POST"
-        )
-
-        # Validate response
-        validate_chat_response(
-            response=response,
-            expected_model=model,
-            min_content_length=MIN_RESPONSE_CONTENT_LENGTH,
+        await asyncio.to_thread(
+            check_deployment_api,
+            base_url,
+            model,
+            scenario,
+            Path(resolve_test_output_path(request.node.name)) / "responses",
         )
 
         if validate_agg_logging:

--- a/tests/deploy/test_dgd.py
+++ b/tests/deploy/test_dgd.py
@@ -225,6 +225,7 @@ async def test_deployment(
             model,
             scenario,
             Path(resolve_test_output_path(request.node.name)) / "responses",
+            endpoint=endpoint,
         )
 
         if validate_agg_logging:

--- a/tests/deploy/test_n2_compatibility.py
+++ b/tests/deploy/test_n2_compatibility.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run shared deployment API checks against four mixed-version component pairs."""
+
+import asyncio
+import json
+import logging
+import os
+import tomllib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.deploy.api_checks import check_deployment_api
+from tests.deploy.dgd_utils import ManagedDeployment
+from tests.deploy.n2_utils import MODELS, compatibility_spec, version_matrix
+from tests.utils.client import wait_for_model_availability
+from tests.utils.test_output import resolve_test_output_path
+
+logger = logging.getLogger(__name__)
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def version_pairs(request):
+    frontend = request.config.getoption("--frontend-image")
+    worker = request.config.getoption("--image")
+    if not frontend or not worker:
+        raise pytest.UsageError("N-2 requires --frontend-image and --image")
+    if not request.config.getoption("--model-cache-pvc"):
+        raise pytest.UsageError("N-2 requires a prepared shared --model-cache-pvc")
+    line = os.environ.get("N2_RELEASE_LINE") or ".".join(
+        tomllib.loads((ROOT / "Cargo.toml").read_text())["workspace"]["package"][
+            "version"
+        ].split(".")[:2]
+    )
+    releases = json.loads((ROOT / "tests/deploy/n2/releases.json").read_text())
+    return version_matrix(releases, line, frontend, worker)
+
+
+@pytest.fixture
+async def mixed_deployment(request, version_pairs, pair_index, scenario, namespace):
+    pair = version_pairs[pair_index]
+    output = Path(resolve_test_output_path(request.node.name))
+    output.mkdir(parents=True, exist_ok=True)
+    spec = compatibility_spec(
+        ROOT,
+        pair,
+        scenario,
+        "n2-" + uuid.uuid4().hex[:10],
+        request.config.getoption("--model-cache-pvc"),
+        request.config.getoption("--model-cache-mount"),
+    )
+    spec.save(str(output / "deployment.yaml"))
+    (output / "versions.json").write_text(
+        json.dumps(
+            {
+                "pair": pair.name,
+                "frontend": pair.frontend,
+                "worker": pair.worker,
+                "scenario": scenario,
+            },
+            indent=2,
+        )
+    )
+    managed = ManagedDeployment(
+        str(output),
+        spec,
+        namespace,
+        skip_service_restart=True,
+        readiness_timeout=1200,
+        fail_fast_startup=True,
+    )
+    try:
+        async with managed as deployment:
+            yield deployment, output
+    finally:
+        if managed.cleanup_errors:
+            # Stop after pytest reports this item's original failure and teardown.
+            request.session.shouldstop = (
+                "N-2 cleanup failed; remaining pairs are not validated"
+            )
+
+
+@pytest.mark.k8s
+@pytest.mark.deploy
+@pytest.mark.sglang
+@pytest.mark.framework_agnostic
+@pytest.mark.core
+@pytest.mark.post_merge
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.timeout(1500)
+@pytest.mark.parametrize("scenario", ["embedding", "chat"])
+@pytest.mark.parametrize(
+    "pair_index",
+    range(4),
+    ids=["old-frontend-1", "old-worker-1", "old-frontend-2", "old-worker-2"],
+)
+async def test_n2_compatibility(mixed_deployment, scenario):
+    deployment, output = mixed_deployment
+    model = MODELS[scenario][0]
+    pods = await asyncio.to_thread(deployment.get_pods, ["Frontend"])
+    assert len(pods["Frontend"]) == 1
+    forward = await asyncio.to_thread(
+        deployment.port_forward, pods["Frontend"][0], 8000
+    )
+    assert forward is not None, "Frontend port forwarding failed"
+    base = f"http://127.0.0.1:{forward.local_port}"
+    endpoint = "/v1/embeddings" if scenario == "embedding" else "/v1/chat/completions"
+    payload = {"model": model, "input": "test"} if scenario == "embedding" else None
+    assert await asyncio.to_thread(
+        wait_for_model_availability,
+        base,
+        endpoint,
+        model,
+        logger,
+        payload=payload,
+    ), f"Model {model} did not become available"
+    await asyncio.to_thread(
+        check_deployment_api, base, model, scenario, output / "responses"
+    )

--- a/tests/deploy/test_n2_compatibility.py
+++ b/tests/deploy/test_n2_compatibility.py
@@ -120,5 +120,10 @@ async def test_n2_compatibility(mixed_deployment, scenario):
         payload=payload,
     ), f"Model {model} did not become available"
     await asyncio.to_thread(
-        check_deployment_api, base, model, scenario, output / "responses"
+        check_deployment_api,
+        base,
+        model,
+        scenario,
+        output / "responses",
+        endpoint=endpoint,
     )

--- a/tests/deploy/test_n2_compatibility_unit.py
+++ b/tests/deploy/test_n2_compatibility_unit.py
@@ -65,6 +65,9 @@ def test_example_patching_preserves_command_and_sets_component_versions(scenario
     assert components[1]["runtimeVersionOverride"] == "1.5.0"
     worker = components[1]["podTemplate"]["spec"]["containers"][0]
     assert worker["command"] == ["python3", "-m", "dynamo.sglang"]
+    if scenario == "embedding":
+        assert "--embedding-worker" in worker["args"]
+        assert "--use-sglang-tokenizer" in worker["args"]
     assert MODELS[scenario][1] in spec["decode"].model
     assert spec.spec()["spec"]["pvcs"] == [{"name": "shared", "create": False}]
     assert runtime_version("registry:5000/fe:1.5.0.dev20260911-ci") == "1.5.0"

--- a/tests/deploy/test_n2_compatibility_unit.py
+++ b/tests/deploy/test_n2_compatibility_unit.py
@@ -4,6 +4,8 @@
 import ast
 import json
 import logging
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -69,10 +71,99 @@ def test_example_patching_preserves_command_and_sets_component_versions(scenario
         assert "--embedding-worker" in worker["args"]
         assert "--use-sglang-tokenizer" in worker["args"]
     assert MODELS[scenario][1] in spec["decode"].model
-    assert spec.spec()["spec"]["pvcs"] == [{"name": "shared", "create": False}]
+    assert "pvcs" not in spec.spec()["spec"]
+    for component in components:
+        pod = component["podTemplate"]["spec"]
+        assert {
+            "name": "shared",
+            "persistentVolumeClaim": {"claimName": "shared"},
+        } in pod["volumes"]
+        main = next(c for c in pod["containers"] if c["name"] == "main")
+        assert {"name": "shared", "mountPath": "/models"} in main["volumeMounts"]
+        assert {"name": "HF_HOME", "value": "/models"} in main["env"]
     assert runtime_version("registry:5000/fe:1.5.0.dev20260911-ci") == "1.5.0"
     with pytest.raises(ValueError):
         compatibility_spec(ROOT, pair, scenario, "test", "", "/models")
+
+
+@pytest.mark.parametrize("schema", ["v1alpha1", "v1beta1"])
+def test_model_cache_mount_preserves_schema_and_is_idempotent(tmp_path, schema):
+    container = {"name": "main", "env": [{"name": "KEEP", "value": "yes"}]}
+    if schema == "v1beta1":
+        body = {
+            "components": [
+                {"name": "decode", "podTemplate": {"spec": {"containers": [container]}}}
+            ]
+        }
+    else:
+        body = {"services": {"decode": {"envs": [{"name": "KEEP", "value": "yes"}]}}}
+    path = tmp_path / "dgd.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "apiVersion": f"nvidia.com/{schema}",
+                "kind": "DynamoGraphDeployment",
+                "metadata": {"name": "test"},
+                "spec": body,
+            }
+        )
+    )
+    spec = DeploymentSpec(str(path))
+    spec.mount_model_cache_pvc("cache", "/cache")
+    first = json.dumps(spec.spec(), sort_keys=True)
+    spec.mount_model_cache_pvc("cache", "/cache")
+    assert json.dumps(spec.spec(), sort_keys=True) == first
+    result = spec.spec()["spec"]
+    if schema == "v1beta1":
+        assert "pvcs" not in result and "envs" not in result
+        component = result["components"][0]
+        assert "volumeMounts" not in component
+        pod = component["podTemplate"]["spec"]
+        assert pod["volumes"] == [
+            {"name": "cache", "persistentVolumeClaim": {"claimName": "cache"}}
+        ]
+        assert pod["containers"][0]["volumeMounts"] == [
+            {"name": "cache", "mountPath": "/cache"}
+        ]
+        assert pod["containers"][0]["env"] == [
+            {"name": "KEEP", "value": "yes"},
+            {"name": "HF_HOME", "value": "/cache"},
+        ]
+    else:
+        assert result["pvcs"] == [{"name": "cache", "create": False}]
+        assert result["envs"] == [{"name": "HF_HOME", "value": "/cache"}]
+        assert result["services"]["decode"]["volumeMounts"] == [
+            {"name": "cache", "mountPoint": "/cache"}
+        ]
+        assert result["services"]["decode"]["envs"] == [
+            {"name": "KEEP", "value": "yes"}
+        ]
+
+
+def test_snapshot_preflight_reads_files_and_rejects_missing_blob(tmp_path):
+    pair = version_matrix(
+        {
+            "1.4": {"frontend": "fe:1.4.2", "worker": "wk:1.4.2"},
+            "1.3": {"frontend": "fe:1.3.2", "worker": "wk:1.3.2"},
+        },
+        "1.5",
+        "fe:1.5.0",
+        "wk:1.5.0",
+    )[0]
+    spec = compatibility_spec(ROOT, pair, "chat", "test", "cache", "/models")
+    init = spec.spec()["spec"]["components"][1]["podTemplate"]["spec"][
+        "initContainers"
+    ][0]
+    assert init["volumeMounts"] == [
+        {"name": "cache", "mountPath": "/models", "readOnly": True}
+    ]
+    for name in ["config.json", "tokenizer.json", "model.safetensors"]:
+        (tmp_path / name).write_bytes(b"test")
+    command = [sys.executable, "-c", init["args"][0], str(tmp_path)]
+    assert subprocess.run(command, capture_output=True).returncode == 0
+    (tmp_path / "model.safetensors").unlink()
+    (tmp_path / "model.safetensors").symlink_to(tmp_path / "missing-blob")
+    assert subprocess.run(command, capture_output=True).returncode != 0
 
 
 def test_preparation_job_downloads_the_exact_snapshots_without_a_gpu():

--- a/tests/deploy/test_n2_compatibility_unit.py
+++ b/tests/deploy/test_n2_compatibility_unit.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from kubernetes_asyncio.client import exceptions
+
+from tests.deploy import test_n2_compatibility as suite
+from tests.deploy.dgd_utils import (
+    DeploymentSpec,
+    DeploymentStartupError,
+    ManagedDeployment,
+    PodStatusDetail,
+)
+from tests.deploy.n2_utils import (
+    MODELS,
+    compatibility_spec,
+    runtime_version,
+    version_matrix,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.framework_agnostic,
+]
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_matrix_uses_both_age_directions_without_candidate_controls():
+    releases = json.loads((ROOT / "tests/deploy/n2/releases.json").read_text())
+    pairs = version_matrix(releases, "1.5", "candidate-fe", "candidate-wk")
+    assert [(p.frontend, p.worker) for p in pairs] == [
+        (releases["1.4"]["frontend"], "candidate-wk"),
+        ("candidate-fe", releases["1.4"]["worker"]),
+        (releases["1.3"]["frontend"], "candidate-wk"),
+        ("candidate-fe", releases["1.3"]["worker"]),
+    ]
+    with pytest.raises(KeyError):
+        version_matrix(releases, "1.6", "fe", "wk")
+
+
+@pytest.mark.parametrize("scenario", ["chat", "embedding"])
+def test_example_patching_preserves_command_and_sets_component_versions(scenario):
+    releases = json.loads((ROOT / "tests/deploy/n2/releases.json").read_text())
+    pair = version_matrix(
+        releases,
+        "1.5",
+        "registry:5000/fe:1.5.0-ci-abc",
+        "registry:5000/wk:1.5.0-ci-abc",
+    )[0]
+    spec = compatibility_spec(ROOT, pair, scenario, "test", "shared", "/models")
+    components = spec.spec()["spec"]["components"]
+    assert components[0]["runtimeVersionOverride"] == "1.4.2"
+    assert components[1]["runtimeVersionOverride"] == "1.5.0"
+    worker = components[1]["podTemplate"]["spec"]["containers"][0]
+    assert worker["command"] == ["python3", "-m", "dynamo.sglang"]
+    assert MODELS[scenario][1] in spec["decode"].model
+    assert spec.spec()["spec"]["pvcs"] == [{"name": "shared", "create": False}]
+    assert runtime_version("registry:5000/fe:1.5.0.dev20260911-ci") == "1.5.0"
+    with pytest.raises(ValueError):
+        compatibility_spec(ROOT, pair, scenario, "test", "", "/models")
+
+
+def test_preparation_job_downloads_the_exact_snapshots_without_a_gpu():
+    job = yaml.safe_load((ROOT / "tests/deploy/n2/model-download.yaml").read_text())
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    tree = ast.parse(container["args"][0])
+    models = next(
+        ast.literal_eval(n.value)
+        for n in tree.body
+        if isinstance(n, ast.Assign) and n.targets[0].id == "models"
+    )
+    assert models == dict(MODELS.values())
+    assert "resources" not in container
+
+
+async def test_delete_waits_for_cr_and_owned_pods(monkeypatch, tmp_path):
+    deployment = ManagedDeployment(
+        str(tmp_path),
+        DeploymentSpec(str(ROOT / "examples/backends/sglang/deploy/agg.yaml")),
+        "test",
+    )
+    deployment._deployment_name = "test"
+    not_found = exceptions.ApiException(status=404)
+    deployment._custom_api = SimpleNamespace(
+        delete_namespaced_custom_object=AsyncMock(),
+        get_namespaced_custom_object=AsyncMock(side_effect=[{}, not_found, not_found]),
+    )
+    deployment._core_api = SimpleNamespace(
+        list_namespaced_pod=AsyncMock(
+            side_effect=[
+                SimpleNamespace(items=[1]),
+                SimpleNamespace(items=[1]),
+                SimpleNamespace(items=[]),
+            ]
+        )
+    )
+    monkeypatch.setattr("tests.deploy.dgd_utils.asyncio.sleep", AsyncMock())
+    await deployment._delete_deployment()
+    assert deployment._core_api.list_namespaced_pod.await_count == 3
+    assert (
+        deployment._custom_api.delete_namespaced_custom_object.call_args.kwargs[
+            "body"
+        ].propagation_policy
+        == "Foreground"
+    )
+
+
+async def test_cleanup_keeps_request_failure_and_records_cleanup_failure(tmp_path):
+    deployment = ManagedDeployment(str(tmp_path), SimpleNamespace(name="test"), "test")
+    deployment._logger = logging.getLogger(__name__)
+    failure = RuntimeError("delete failed")
+    deployment._cleanup = AsyncMock(side_effect=failure)
+    primary = ValueError("bad response")
+    await deployment.__aexit__(ValueError, primary, None)
+    assert deployment.cleanup_errors == [failure]
+    with pytest.raises(RuntimeError, match="delete failed"):
+        await deployment.__aexit__(None, None, None)
+
+
+@pytest.mark.parametrize("exit_code,fatal", [(0, False), (1, True)])
+async def test_restarted_init_container_only_fails_for_nonzero_exit(
+    monkeypatch, tmp_path, exit_code, fatal
+):
+    deployment = ManagedDeployment(
+        str(tmp_path),
+        SimpleNamespace(name="test", api_version="v1beta1"),
+        "test",
+        fail_fast_startup=True,
+    )
+    deployment._custom_api = SimpleNamespace(
+        get_namespaced_custom_object=AsyncMock(
+            return_value={
+                "status": {
+                    "state": "successful",
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(
+        deployment,
+        "_get_pod_status_details",
+        AsyncMock(
+            return_value=[
+                PodStatusDetail(
+                    "pod",
+                    "init",
+                    "Terminated",
+                    "Completed" if exit_code == 0 else "Error",
+                    exit_code=exit_code,
+                    restart_count=2,
+                )
+            ]
+        ),
+    )
+    if fatal:
+        with pytest.raises(DeploymentStartupError):
+            await deployment._wait_for_ready(timeout=1)
+    else:
+        assert await deployment._wait_for_ready(timeout=1)
+
+
+async def test_delete_timeout_is_reported(monkeypatch, tmp_path):
+    deployment = ManagedDeployment(
+        str(tmp_path), SimpleNamespace(name="test", api_version="v1beta1"), "test"
+    )
+    deployment._deployment_name = "test"
+    deployment._custom_api = SimpleNamespace(
+        delete_namespaced_custom_object=AsyncMock(),
+        get_namespaced_custom_object=AsyncMock(return_value={}),
+    )
+    deployment._core_api = SimpleNamespace(
+        list_namespaced_pod=AsyncMock(return_value=SimpleNamespace(items=[1]))
+    )
+    times = iter([0, 121])
+    monkeypatch.setattr(
+        "tests.deploy.dgd_utils.time", SimpleNamespace(monotonic=lambda: next(times))
+    )
+    with pytest.raises(TimeoutError, match="not deleted"):
+        await deployment._delete_deployment()
+
+
+async def test_cleanup_failure_stops_session_without_replacing_body_error(
+    monkeypatch, tmp_path
+):
+    failure = RuntimeError("cleanup failed")
+
+    class Deployment:
+        cleanup_errors = [failure]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    options = {"--model-cache-pvc": "shared", "--model-cache-mount": "/models"}
+    request = SimpleNamespace(
+        config=SimpleNamespace(getoption=options.__getitem__),
+        node=SimpleNamespace(name="test"),
+        session=SimpleNamespace(shouldstop=False),
+    )
+    pair = version_matrix(
+        {
+            "1.4": {"frontend": "fe:1.4.2", "worker": "wk:1.4.2"},
+            "1.3": {"frontend": "fe:1.3.1", "worker": "wk:1.3.1"},
+        },
+        "1.5",
+        "fe:1.5.0",
+        "wk:1.5.0",
+    )
+    monkeypatch.setattr(
+        suite, "ManagedDeployment", lambda *args, **kwargs: Deployment()
+    )
+    monkeypatch.setattr(suite, "resolve_test_output_path", lambda _: str(tmp_path))
+    fixture = suite.mixed_deployment.__wrapped__(request, pair, 0, "chat", "test")
+    await anext(fixture)
+    primary = ValueError("bad response")
+    with pytest.raises(ValueError, match="bad response"):
+        await fixture.athrow(primary)
+    assert (
+        request.session.shouldstop
+        == "N-2 cleanup failed; remaining pairs are not validated"
+    )

--- a/tests/utils/client.py
+++ b/tests/utils/client.py
@@ -162,6 +162,7 @@ def wait_for_model_availability(
     max_attempts: int = 15,
     attempt_timeouts: list[float] | None = None,
     headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
 ) -> bool:
     """
     Wait for model to be available by sending test requests.
@@ -174,6 +175,7 @@ def wait_for_model_availability(
         url: Base URL for the service (e.g., "http://localhost:8000")
         endpoint: API endpoint path (e.g., "/v1/chat/completions")
         model: Model name to test
+        payload: Optional endpoint-specific readiness request, such as embedding input.
         logger: Logger instance for output
         max_attempts: Maximum number of attempts to check availability (default: 15)
         attempt_timeouts: List of timeout values for each attempt (default: decreasing from 60s)
@@ -189,12 +191,16 @@ def wait_for_model_availability(
 
     for attempt in range(max_attempts):
         try:
-            test_payload = {
-                "model": model,
-                "messages": [{"role": "user", "content": "test"}],
-                "max_tokens": 1,
-                "stream": False,
-            }
+            test_payload = (
+                payload
+                if payload is not None
+                else {
+                    "model": model,
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1,
+                    "stream": False,
+                }
+            )
 
             timeout_val = attempt_timeouts[min(attempt, len(attempt_timeouts) - 1)]
             logger.debug(


### PR DESCRIPTION
## Summary

Related design and implementation plan: [DEP #14685](https://github.com/ai-dynamo/dynamo/issues/14685). This PR implements the N-2 component compatibility framework (phase 3), building on #14681 and transitively on #14680. Merge order: #14680 → #14681 → #14460.

Implement the SGLang N-2 component compatibility matrix on the shared deployment-test infrastructure. For the current 1.5 development line, test both frontend/worker age directions against 1.4.2 and 1.3.1. Each of the four mixed-version pairs runs chat and embedding, for eight deployments.

- Load the existing chat and embedding example YAML through `DeploymentSpec`. Patch component images and runtime versions, Kubernetes discovery, and fixed model snapshot paths. Run the same `check_deployment_api` used by ordinary deploy tests.
- Require successful ordinary SGLang deploy tests before PR/nightly compatibility runs. Manual dispatch runs the ordinary chat and embedding profiles first. Current/current controls are no longer implemented in the N-2 test module.
- Require the shared model-cache PVC. Prepare pinned snapshots with a GPU-free download Job; inference uses offline snapshot paths. Remove registry digest resolution, Pod exec, dynamic inference manifests, RWO/GPU-placement fallback, test-created ResourceQuota and the private Docker runner.
- Reuse `ManagedDeployment` for readiness, logs, Pod manifests/image IDs and cleanup. Keep fail-fast startup diagnostics and primary-error preservation. Make the shared deletion helper wait for both the DGD and its Pods; stop the pytest session after a cleanup failure without replacing the test's original exception.
- Store version-pair metadata, raw API responses and normal deployment/JUnit artifacts. Always tear down the dedicated compatibility vCluster. The version catalog, download manifest and pytest tests live under `tests/deploy/`.

Depends on #14681, which is stacked on #14680. Merge order: **#14680 → #14681 → #14460**. While those PRs are unmerged, GitHub's main-based diff includes their commits. Review this PR's framework changes in [the incremental diff](https://github.com/ai-dynamo/dynamo/compare/f9f8150f76d5e5b1fde71fc054f92e2191884a2d...3659ada6e54d3fb6f44b1f31c19ce0d8cff9e2ec).

The matrix covers static SGLang aggregated chat and embedding, not rolling upgrades or performance. Ordinary deploy prerequisites use the same model IDs and API checks but do not pin the matrix's snapshot revisions; they are functional prerequisites, not a strict experimental control.

## Validation

- 33 related CPU tests passed locally with the normal repository conftest: matrix selection, example patching/runtime versions, fixed download snapshots, shared API contracts, DGD/Pod deletion waiting and timeout, init-container success after restarts, original-error preservation, and session stop after cleanup failure.
- Collection produces exactly eight N-2 cases. Ordinary SGLang chat and embedding profiles collect separately for manual controls.
- Python formatting/import checks, workflow actionlint, action pin checks, CODEOWNERS coverage and diff whitespace checks passed. Actionlint excludes existing custom-runner labels and the unrelated pre-existing `if: false` job.
- GPU execution of this refactor is pending. Earlier runs of the superseded harness do not validate this implementation; no historical-matrix pass is claimed. CPU tests take under one second locally; GPU wall time still needs measurement. Cases run serially, bounded by a 240-minute workflow timeout.
- `RUN_DEPLOY_TESTS=false` skips PR compatibility validation. Missing shared-cache configuration fails before vCluster creation; unavailable images or protocol mismatches remain failures.
