### PR TITLE
fix(llm): align stop-sequence limits and return 400

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -33,8 +33,8 @@ pub mod validate;
 pub mod videos;
 
 use validate::{
-    BEST_OF_RANGE, FREQUENCY_PENALTY_RANGE, MIN_P_RANGE, N_RANGE, PRESENCE_PENALTY_RANGE,
-    TEMPERATURE_RANGE, validate_range, validate_top_p,
+    BEST_OF_RANGE, FREQUENCY_PENALTY_RANGE, MAX_STOP_SEQUENCES, MIN_P_RANGE, N_RANGE,
+    PRESENCE_PENALTY_RANGE, TEMPERATURE_RANGE, validate_range, validate_top_p,
 };
 
 /// Key under `extra_args` where media handlers nest a request's captured
@@ -220,14 +220,22 @@ impl<T: OpenAIStopConditionsProvider> StopConditionsProvider for T {
         let max_thinking_tokens = self.get_max_thinking_tokens();
 
         if let Some(stop) = &stop
-            && stop.len() > 4
+            && stop.len() > MAX_STOP_SEQUENCES
         {
-            anyhow::bail!("stop conditions must be less than 4")
+            return Err(common::invalid_argument_error(format!(
+                "Maximum of {} stop sequences allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                stop.len()
+            )));
         }
         if let Some(stop_token_ids) = &stop_token_ids
-            && stop_token_ids.len() > 4
+            && stop_token_ids.len() > MAX_STOP_SEQUENCES
         {
-            anyhow::bail!("stop token IDs must be less than 4")
+            return Err(common::invalid_argument_error(format!(
+                "Maximum of {} stop token IDs allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                stop_token_ids.len()
+            )));
         }
 
         // Use the trait method to get ignore_eos, which handles precedence

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -951,6 +951,73 @@ mod tests {
     }
 
     #[test]
+    fn test_stop_sequence_limit_enforced_consistently() {
+        use crate::protocols::openai::validate::MAX_STOP_SEQUENCES;
+
+        let max_stops: Vec<String> = (0..MAX_STOP_SEQUENCES).map(|i| i.to_string()).collect();
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stop": max_stops,
+        }))
+        .expect("Failed to deserialize request");
+        ValidateRequest::validate(&request).expect("max stops must validate");
+        request
+            .extract_stop_conditions()
+            .expect("max stops must extract");
+
+        let over_max_stops: Vec<String> = (0..=MAX_STOP_SEQUENCES).map(|i| i.to_string()).collect();
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stop": over_max_stops,
+        }))
+        .expect("Failed to deserialize request");
+        let err =
+            ValidateRequest::validate(&request).expect_err("over-max stops must fail validation");
+        let expected = format!(
+            "InvalidArgument: Maximum of {} stop sequences allowed, got {}",
+            MAX_STOP_SEQUENCES,
+            MAX_STOP_SEQUENCES + 1
+        );
+        assert_eq!(err.to_string(), expected);
+        let err = request
+            .extract_stop_conditions()
+            .expect_err("over-max stops must fail extraction");
+        assert_eq!(err.to_string(), expected);
+
+        let over_max_token_ids: Vec<u32> = (0..=MAX_STOP_SEQUENCES as u32).collect();
+        let expected_token_ids = format!(
+            "InvalidArgument: Maximum of {} stop token IDs allowed, got {}",
+            MAX_STOP_SEQUENCES,
+            MAX_STOP_SEQUENCES + 1
+        );
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stop": over_max_token_ids,
+        }))
+        .expect("Failed to deserialize request");
+        let err = ValidateRequest::validate(&request)
+            .expect_err("over-max stop token IDs must fail validation");
+        assert_eq!(err.to_string(), expected_token_ids);
+        let err = request
+            .extract_stop_conditions()
+            .expect_err("over-max stop token IDs must fail extraction");
+        assert_eq!(err.to_string(), expected_token_ids);
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stop_token_ids": over_max_token_ids,
+        }))
+        .expect("Failed to deserialize request");
+        let err = ValidateRequest::validate(&request)
+            .expect_err("over-max passthrough stop token IDs must fail validation");
+        assert_eq!(err.to_string(), expected_token_ids);
+    }
+
+    #[test]
     fn test_passthrough_token_constraints_validate() {
         let request_json = json!({
             "model": "test-model",

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -147,8 +147,15 @@ fn validate_no_unsupported_fields_with_ignore(
         anyhow::bail!("`cache_salt` must be a string");
     }
     if let Some(value) = unsupported_fields.get("stop_token_ids") {
-        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
+        let token_ids: Vec<crate::types::TokenIdType> = serde_json::from_value(value.clone())
             .map_err(|_| anyhow::anyhow!("`stop_token_ids` must be an array of token IDs"))?;
+        if token_ids.len() > MAX_STOP_SEQUENCES {
+            return Err(crate::protocols::common::invalid_argument_error(format!(
+                "Maximum of {} stop token IDs allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                token_ids.len()
+            )));
+        }
     }
     if let Some(value) = unsupported_fields.get("detokenize")
         && !value.is_boolean()
@@ -445,11 +452,11 @@ pub fn validate_stop(stop: &Option<dynamo_protocols::types::Stop>) -> Result<(),
                     anyhow::bail!("Stop sequences array cannot be empty");
                 }
                 if sequences.len() > MAX_STOP_SEQUENCES {
-                    anyhow::bail!(
+                    return Err(crate::protocols::common::invalid_argument_error(format!(
                         "Maximum of {} stop sequences allowed, got {}",
                         MAX_STOP_SEQUENCES,
                         sequences.len()
-                    );
+                    )));
                 }
                 for (i, sequence) in sequences.iter().enumerate() {
                     if sequence.is_empty() {
@@ -462,11 +469,11 @@ pub fn validate_stop(stop: &Option<dynamo_protocols::types::Stop>) -> Result<(),
                     anyhow::bail!("Stop token IDs array cannot be empty");
                 }
                 if token_ids.len() > MAX_STOP_SEQUENCES {
-                    anyhow::bail!(
+                    return Err(crate::protocols::common::invalid_argument_error(format!(
                         "Maximum of {} stop token IDs allowed, got {}",
                         MAX_STOP_SEQUENCES,
                         token_ids.len()
-                    );
+                    )));
                 }
             }
         }
@@ -1038,5 +1045,67 @@ mod tests {
         }))
         .unwrap();
         validate_response_format(&Some(fmt)).unwrap();
+    }
+
+    #[test]
+    fn validate_stop_accepts_up_to_max_sequences() {
+        let max_strings = Some(dynamo_protocols::types::Stop::StringArray(
+            (0..MAX_STOP_SEQUENCES).map(|i| i.to_string()).collect(),
+        ));
+        validate_stop(&max_strings).unwrap();
+
+        let max_token_ids = Some(dynamo_protocols::types::Stop::TokenIdArray(
+            (0..MAX_STOP_SEQUENCES as u32).collect(),
+        ));
+        validate_stop(&max_token_ids).unwrap();
+    }
+
+    #[test]
+    fn validate_stop_rejects_over_max_sequences() {
+        let over_max_strings = Some(dynamo_protocols::types::Stop::StringArray(
+            (0..=MAX_STOP_SEQUENCES).map(|i| i.to_string()).collect(),
+        ));
+        let err = validate_stop(&over_max_strings).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "InvalidArgument: Maximum of {} stop sequences allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                MAX_STOP_SEQUENCES + 1
+            )
+        );
+
+        let over_max_token_ids = Some(dynamo_protocols::types::Stop::TokenIdArray(
+            (0..=MAX_STOP_SEQUENCES as u32).collect(),
+        ));
+        let err = validate_stop(&over_max_token_ids).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "InvalidArgument: Maximum of {} stop token IDs allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                MAX_STOP_SEQUENCES + 1
+            )
+        );
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_rejects_over_max_stop_token_ids() {
+        let over_max: Vec<u32> = (0..=MAX_STOP_SEQUENCES as u32).collect();
+        let unsupported_fields = HashMap::from([("stop_token_ids".to_string(), json!(over_max))]);
+
+        let err = validate_no_unsupported_fields(&unsupported_fields).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "InvalidArgument: Maximum of {} stop token IDs allowed, got {}",
+                MAX_STOP_SEQUENCES,
+                MAX_STOP_SEQUENCES + 1
+            )
+        );
+
+        let at_max: Vec<u32> = (0..MAX_STOP_SEQUENCES as u32).collect();
+        let ok_fields = HashMap::from([("stop_token_ids".to_string(), json!(at_max))]);
+        validate_no_unsupported_fields(&ok_fields).unwrap();
     }
 }


### PR DESCRIPTION
## Overview:

Fixes the opaque HTTP 500 returned when a chat/completion request contains more than 4 `stop` (or `stop_token_ids`) entries. The request now fails fast at the HTTP boundary with a clear 400 validation error, and the two previously inconsistent stop-sequence limits in the codebase are aligned to a single constant.


## Details:

The bug had two layers:

- **Inconsistent limits**: pre-validation allowed up to 32 stop sequences (`MAX_STOP_SEQUENCES = 32` in `validate.rs`), while request extraction bailed at more than 4 (hard-coded in `openai.rs::extract_stop_conditions`). 
- **500 instead of 400**: the extraction failure was a plain `anyhow::bail!`, which the HTTP error mapper could not classify, so it fell through to the generic "Failed to generate completions" 500.

Changes:

- `lib/llm/src/protocols/openai/validate.rs`
  - `MAX_STOP_SEQUENCES` tightened from 32 to 4, matching the OpenAI API contract.
  - Validation error messages corrected to the accurate "Maximum of N stop sequences allowed, got M" (the old "less than 4" wording was wrong — exactly 4 are accepted).
- `lib/llm/src/protocols/openai.rs`
  - `extract_stop_conditions` now uses the shared `MAX_STOP_SEQUENCES` constant instead of a hard-coded 4, with corrected messages.

The 500→400 fix is structural, validation now rejects over-limit requests at the entry point, so they never reach the engine path that produced the opaque 500.

## Where should the reviewer start?

1. `lib/llm/src/protocols/openai/validate.rs` — the constant, the two `validate_stop` messages, and the new `stop_token_ids` count check in `validate_no_unsupported_fields`.
2. `lib/llm/src/protocols/openai.rs` — `extract_stop_conditions` backstop now shares the same constant.
3. Tests: `validate.rs` and `chat_completions.rs`

## Validation

- `cargo test -p dynamo-llm --lib protocols::openai`
- `cargo clippy -p dynamo-llm --lib`
- `cargo fmt -p dynamo-llm`
- E2E(Frontend + vLLM worker):

```bash
curl -s http://<frontend>:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen3-VL-2B-Instruct","messages":[{"role":"user","content":"Say hi"}],"max_tokens":5,"stop":["a","b","c","d","e"]}'

# response
{"message":"Validation: Maximum of 4 stop sequences allowed, got 5","type":"Bad Request","code":400}
```

```bash
curl -s http://<frontend>:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{"model":"Qwen3-VL-2B-Instruct","messages":[{"role":"user","content":"Say hi"}],"max_tokens":5,"stop_token_ids":[1,2,3,4,5]}'

#response
{"message":"Validation: Maximum of 4 stop token IDs allowed, got 5","type":"Bad Request","code":400}
```

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #14463 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stop-sequence validation now consistently enforces a maximum of four entries across supported request formats.
  * Validation errors now identify the applicable limit and the number of entries provided.
* **Tests**
  * Added coverage for valid four-entry configurations and rejected five-entry configurations, including token ID passthrough cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->