### PR TITLE
build(deps): [cherry-pick 1.5.0] bump Snapshot to v0.1.0

### DIFF
--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -46,6 +46,6 @@ dependencies:
     repository: oci://ghcr.io/ai-dynamo/grove
     condition: global.grove.install
   - name: snapshot
-    version: 0.1.0-rc.1
+    version: 0.1.0
     repository: oci://ghcr.io/ai-dynamo/snapshot
     condition: global.snapshot.install

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -150,7 +150,7 @@ Kubernetes: `>=1.30.0-0`
 | https://charts.bitnami.com/bitnami | etcd | 12.0.18 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.12-rc1 |
-| oci://ghcr.io/ai-dynamo/snapshot | snapshot | 0.1.0-rc.1 |
+| oci://ghcr.io/ai-dynamo/snapshot | snapshot | 0.1.0 |
 | oci://ghcr.io/kai-scheduler/kai-scheduler | kai-scheduler | v0.13.4 |
 
 ## Values

--- a/deploy/operator/go.mod
+++ b/deploy/operator/go.mod
@@ -6,7 +6,7 @@ require (
 	emperror.dev/errors v0.8.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/ai-dynamo/grove/operator/api v0.1.0-alpha.12-rc1
-	github.com/ai-dynamo/snapshot/api v0.1.0-rc.1
+	github.com/ai-dynamo/snapshot/api v0.1.0
 	github.com/bsm/gomega v1.27.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3

--- a/deploy/operator/go.sum
+++ b/deploy/operator/go.sum
@@ -18,8 +18,8 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/ai-dynamo/grove/operator/api v0.1.0-alpha.12-rc1 h1:rhi1HzLU68RO573k0bQHkTc+o293Ij2sVYmNPoc1d2s=
 github.com/ai-dynamo/grove/operator/api v0.1.0-alpha.12-rc1/go.mod h1:aebLeDCrknulT10/uDj2G1i9K2MEIfVAa25bzrvWxsQ=
-github.com/ai-dynamo/snapshot/api v0.1.0-rc.1 h1:cBZrt90xsKbTPC0rJuu1Yos8Sar0lqpPhX+J3HjItdc=
-github.com/ai-dynamo/snapshot/api v0.1.0-rc.1/go.mod h1:LPkn788YGMGlWN1hm1M3Jm82WVY6tUWpRfmE+8seA04=
+github.com/ai-dynamo/snapshot/api v0.1.0 h1:S8HG6K+YhloUc/usu03wiJ8fTo3Mhju/oWQVFDYVw/o=
+github.com/ai-dynamo/snapshot/api v0.1.0/go.mod h1:LPkn788YGMGlWN1hm1M3Jm82WVY6tUWpRfmE+8seA04=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
## Summary

- bump the standalone Snapshot Go API dependency from v0.1.0-rc.1 to v0.1.0 on release/1.5.0
- bump the platform chart Snapshot dependency from 0.1.0-rc.1 to 0.1.0
- regenerate the release branch platform chart README

## Validation

- `KUBEBUILDER_ASSETS=<envtest-assets> go test ./api/... ./internal/...`
- `helm dependency update .`
- `make lint`
- verified `oci://ghcr.io/ai-dynamo/snapshot/snapshot:0.1.0` resolves successfully