### PR TITLE
fix(recipes): use Dynamo frontend image and parse Qwen3 reasoning

### DIFF
--- a/recipes/qwen3.6-35b-a3b/sglang/agg-b200-mtp/deploy.yaml
+++ b/recipes/qwen3.6-35b-a3b/sglang/agg-b200-mtp/deploy.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0
               imagePullPolicy: Always
               command: ["python3"]
               args:
@@ -61,6 +61,8 @@ spec:
                 - --kv-cache-dtype
                 - fp8_e4m3
                 - --reasoning-parser
+                - qwen3
+                - --dyn-reasoning-parser
                 - qwen3
                 - --tool-call-parser
                 - qwen3_coder

--- a/recipes/qwen3.6-35b-a3b/sglang/agg-gb200-mtp/deploy.yaml
+++ b/recipes/qwen3.6-35b-a3b/sglang/agg-gb200-mtp/deploy.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0
               imagePullPolicy: Always
               command: ["python3"]
               args:
@@ -61,6 +61,8 @@ spec:
                 - --kv-cache-dtype
                 - fp8_e4m3
                 - --reasoning-parser
+                - qwen3
+                - --dyn-reasoning-parser
                 - qwen3
                 - --tool-call-parser
                 - qwen3_coder

--- a/recipes/qwen3.6-35b-a3b/sglang/agg-h200-mtp/deploy.yaml
+++ b/recipes/qwen3.6-35b-a3b/sglang/agg-h200-mtp/deploy.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.4.0
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0
               imagePullPolicy: Always
               command: ["python3"]
               args:
@@ -54,6 +54,8 @@ spec:
                 - --attention-backend
                 - flashinfer
                 - --reasoning-parser
+                - qwen3
+                - --dyn-reasoning-parser
                 - qwen3
                 - --tool-call-parser
                 - qwen3_coder


### PR DESCRIPTION
- Using nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0 for frontend component.
- Passing qwen3 to --dyn-reasoning-parser, to prevent `<think>…</think>` reasoning leaking into message.content, and have it in message.reasoning_content.

## Overview:

Update the Qwen3.6 SGLang MTP recipes to use the dedicated Dynamo frontend image and correctly separate Qwen3 reasoning from assistant content.

## Details:

- Use nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.4.0 for the frontend component.
- Add --dyn-reasoning-parser qwen3 to the SGLang worker arguments.
- Apply the same changes to the B200, GB200, and H200 MTP recipes.

## Where should the reviewer start?

Review the frontend image and SGLang parser arguments in:
- recipes/qwen3.6-35b-a3b/sglang/agg-b200-mtp/deploy.yaml
- recipes/qwen3.6-35b-a3b/sglang/agg-gb200-mtp/deploy.yaml
- recipes/qwen3.6-35b-a3b/sglang/agg-h200-mtp/deploy.yaml

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [X] Confirmed — no related issue
