### PR TITLE
fix(docs): Fix minor Gemma4 docs issues

### DIFF
--- a/docs/fern/pages/recipes/model-recipes/gemma-4-31b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/gemma-4-31b.mdx
@@ -222,9 +222,10 @@ git lfs pull --include='recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_nos
 
 kubectl run pvc-helper -n ${NAMESPACE} \
   --image=busybox:1.36 --restart=Never \
-  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}' \
-  --command -- sleep 3600
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sh","-c","while sleep 3600; do :; done"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}'
 
+kubectl wait --for=condition=Ready pod/pvc-helper \
+  -n "${NAMESPACE}" --timeout=120s
 TRACE_SOURCE="$(git rev-parse --show-toplevel)/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
 kubectl exec -n "${NAMESPACE}" pvc-helper -- mkdir -p /model-cache/traces
 kubectl cp "${TRACE_SOURCE}" \

--- a/docs/fern/pages/recipes/model-recipes/gemma-4-31b.mdx
+++ b/docs/fern/pages/recipes/model-recipes/gemma-4-31b.mdx
@@ -213,6 +213,24 @@ All targets use `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15p
 
 The Job passes the trace to AIPerf with `--custom-dataset-type mooncake_trace`. All targets use `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl`; its SHA-256 is `f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0`.
 
+### Stage the trace
+
+Before creating the benchmark Job, materialize the trace and copy it to the `shared-model-cache` PVC. The Job exits before AIPerf starts when `TRACE_FILE` is absent. Keep `pvc-helper` running to fetch the benchmark artifacts after the run.
+
+```bash
+git lfs pull --include='recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}' \
+  --command -- sleep 3600
+
+TRACE_SOURCE="$(git rev-parse --show-toplevel)/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+kubectl exec -n "${NAMESPACE}" pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp "${TRACE_SOURCE}" \
+  "${NAMESPACE}/pvc-helper:/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+```
+
 ### Run the benchmark
 
 Then run the Job:
@@ -225,7 +243,7 @@ kubectl wait --for=condition=Complete job/gemma4-31b-bench \
   -n ${NAMESPACE} --timeout=10800s
 ```
 
-For trace staging, concurrency sweeps, and fetching artifacts, see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gemma4-31b/perf/README.md).
+For concurrency sweeps and fetching artifacts, see the [benchmark README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gemma4-31b/perf/README.md).
 
 ## Expected Performance
 

--- a/recipes/gemma4-31b/perf/README.md
+++ b/recipes/gemma4-31b/perf/README.md
@@ -75,9 +75,10 @@ git lfs pull --include='recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_nos
 
 kubectl run pvc-helper -n ${NAMESPACE} \
   --image=busybox:1.36 --restart=Never \
-  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}' \
-  --command -- sleep 3600
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sh","-c","while sleep 3600; do :; done"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}'
 
+kubectl wait --for=condition=Ready pod/pvc-helper \
+  -n "${NAMESPACE}" --timeout=120s
 TRACE_SOURCE="$(git rev-parse --show-toplevel)/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
 kubectl exec -n "${NAMESPACE}" pvc-helper -- mkdir -p /model-cache/traces
 kubectl cp "${TRACE_SOURCE}" \

--- a/recipes/gemma4-31b/trtllm/agg-gb200-agentic/deploy.yaml
+++ b/recipes/gemma4-31b/trtllm/agg-gb200-agentic/deploy.yaml
@@ -144,7 +144,7 @@ spec:
                 - --tensor-parallel-size
                 - "1"
                 - --max-batch-size
-                - "32"
+                - "24"
                 - --max-num-tokens
                 - "12288"
                 - --max-seq-len

--- a/recipes/kustomize/components/dynamo-openapi/dynamo-openapi.json
+++ b/recipes/kustomize/components/dynamo-openapi/dynamo-openapi.json
@@ -393,6 +393,19 @@
                 }
               },
               "type": "object"
+            },
+            "roles": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "x-kubernetes-patch-merge-key": "name",
+              "x-kubernetes-patch-strategy": "merge"
             }
           },
           "type": "object"
@@ -800,6 +813,19 @@
                       }
                     },
                     "type": "object"
+                  },
+                  "roles": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "name",
+                    "x-kubernetes-patch-strategy": "merge"
                   }
                 },
                 "type": "object"
@@ -1269,6 +1295,19 @@
                 }
               },
               "type": "object"
+            },
+            "roles": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "x-kubernetes-patch-merge-key": "name",
+              "x-kubernetes-patch-strategy": "merge"
             }
           },
           "type": "object"
@@ -1627,6 +1666,19 @@
                       }
                     },
                     "type": "object"
+                  },
+                  "roles": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "name",
+                    "x-kubernetes-patch-strategy": "merge"
                   }
                 },
                 "type": "object"


### PR DESCRIPTION
## Overview:

Fix some documentation issues reported by QA.

## Details:

1. Add note about copying trace to PVC before starting benchmark job.
2. Fix inconsistent batch size in GB200 deployment YAML.

## Where should the reviewer start?

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for staging benchmark traces in shared model storage.
  - Updated the recipe README link description to cover concurrency sweeps and artifact retrieval.

- **Configuration**
  - Adjusted the TensorRT-LLM worker’s maximum batch size from 32 to 24 for the Gemma 4 31B agentic deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->