### PR TITLE
docs(epp): stop pinning vLLM on-ramp version

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -17,8 +17,8 @@ For the user-facing walkthrough, start with
 
 This on-ramp is available for aggregated serving only at this time.
 
-The aggregated on-ramp uses the floating upstream `vllm/vllm-openai:latest` image. For reproducible
-deployments, replace it with a pinned or internally mirrored image your platform standardizes on.
+Replace `<VLLM_IMAGE>` in `agg.yaml` with the vLLM image your platform uses, including its release
+tag or digest. Use a digest for reproducible deployments.
 KV-aware selection is provided by the runtime-free
 [selection service](../../../../../docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md),
 which the EPP runs **in-process**: the EPP and the selection service are compiled into one binary,

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -17,8 +17,8 @@ For the user-facing walkthrough, start with
 
 This on-ramp is available for aggregated serving only at this time.
 
-The aggregated on-ramp uses the upstream `vllm/vllm-openai:v0.28.0` image. Replace it with the vLLM
-image your platform standardizes on if you need another pinned or internally mirrored image.
+The aggregated on-ramp uses the floating upstream `vllm/vllm-openai:latest` image. For reproducible
+deployments, replace it with a pinned or internally mirrored image your platform standardizes on.
 KV-aware selection is provided by the runtime-free
 [selection service](../../../../../docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md),
 which the EPP runs **in-process**: the EPP and the selection service are compiled into one binary,

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: vllm/vllm-openai:v0.28.0
+          image: vllm/vllm-openai:latest
           args:
             - --model
             - Qwen/Qwen3-0.6B

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -42,8 +42,8 @@
 #     This secret is required only for gated models; the public model used below
 #     does not require it.
 #
-# Replace `dynamo/dynamo-epp:dev` before applying this manifest unless that
-# image is already available to the cluster.
+# Replace `<VLLM_IMAGE>` and `dynamo/dynamo-epp:dev` with images available to
+# the cluster before applying this manifest.
 #
 # Apply with: kubectl apply -n <ns> -f agg.yaml
 # Test:
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: vllm/vllm-openai:latest
+          image: <VLLM_IMAGE>
           args:
             - --model
             - Qwen/Qwen3-0.6B

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -245,7 +245,7 @@ Compare a typical existing vLLM container with the changes required by the on-ra
 ```yaml
 containers:
   - name: vllm
-    image: vllm/vllm-openai:v0.28.0
+    image: vllm/vllm-openai:latest
     args:
       - --model
       - Qwen/Qwen3-0.6B
@@ -261,7 +261,7 @@ containers:
 ```yaml
 containers:
   - name: vllm
-    image: vllm/vllm-openai:v0.28.0
+    image: vllm/vllm-openai:latest
     args:
       - --model
       - Qwen/Qwen3-0.6B

--- a/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/vanilla-vllm-onramp.mdx
@@ -182,10 +182,13 @@ creates the workload layer in `$NAMESPACE`:
 - Two standalone EPP replicas and their gRPC and replica-synchronization Service.
 - An `InferencePool` and an `HTTPRoute` that attaches to the cross-namespace Gateway.
 
-Apply the manifest from the repository root using the image you pushed:
+Set `VLLM_IMAGE` to the vLLM image your platform uses, including its release tag or digest. Use a
+digest for reproducible deployments. Apply the manifest from the repository root using that image
+and the EPP image you pushed:
 
 ```bash
-sed "s#dynamo/dynamo-epp:dev#$EPP_IMAGE#" \
+sed -e "s#dynamo/dynamo-epp:dev#${EPP_IMAGE:?Set EPP_IMAGE to the image you pushed}#" \
+  -e "s#<VLLM_IMAGE>#${VLLM_IMAGE:?Set VLLM_IMAGE to your chosen vLLM image}#" \
   deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml |
   kubectl apply -n "$NAMESPACE" -f -
 ```
@@ -238,14 +241,16 @@ kubectl patch deployment/vllm-qwen -n "$NAMESPACE" --type merge \
 Do not use `kubectl label deployment` for this step. That command changes
 `Deployment.metadata.labels`, which does not label the worker pods.
 
-Compare a typical existing vLLM container with the changes required by the on-ramp.
+Compare a typical existing vLLM container with the changes required by the on-ramp. In both
+snippets, replace `<VLLM_IMAGE>` with your existing vLLM image reference, including its release tag
+or digest.
 
 **Before — existing vLLM container:**
 
 ```yaml
 containers:
   - name: vllm
-    image: vllm/vllm-openai:latest
+    image: <VLLM_IMAGE>
     args:
       - --model
       - Qwen/Qwen3-0.6B
@@ -261,7 +266,7 @@ containers:
 ```yaml
 containers:
   - name: vllm
-    image: vllm/vllm-openai:latest
+    image: <VLLM_IMAGE>
     args:
       - --model
       - Qwen/Qwen3-0.6B


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary

Make vLLM image selection explicit in the inference-gateway on-ramp, so the example does not need a new release pin with every vLLM bump.

- Use `<VLLM_IMAGE>` in the manifest and both before/after examples.
- Document choosing a release tag or digest.
- Require and substitute `VLLM_IMAGE` and `EPP_IMAGE` in the deployment command.

## Validation

- Release-tag and digest substitutions each rendered nine parseable YAML resources. Missing image variables fail clearly and emit no manifest.
- Pre-commit, docs lint, and Fern configuration checks passed. Fern's link check reports one unrelated broken link already present on main.
- No Kubernetes deployment was run.

Linear: [DYN-4206](https://linear.app/nvidia/issue/DYN-4206/stop-pinning-an-explicit-vllm-version-in-the-inference-gateway-on-ramp)
<!-- pr-description:end -->


