### PR TITLE
fix(kv-router): heartbeat worker metrics so silence is not ambiguous

### DIFF
--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -2139,7 +2139,9 @@ mod worker_metrics_tests {
     use anyhow::Result;
     use dynamo_kv_router::protocols::ActiveLoad;
 
-    use super::super::worker_metrics::{WorkerMetricsPublisher, WorkerMetricsSink};
+    use super::super::worker_metrics::{
+        HEARTBEAT_INTERVAL, WorkerMetricsPublisher, WorkerMetricsSink,
+    };
 
     struct ChannelSink(tokio::sync::mpsc::UnboundedSender<ActiveLoad>);
 
@@ -2186,6 +2188,28 @@ mod worker_metrics_tests {
                 .is_err(),
             "same-rank updates should be coalesced"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unchanged_ranks_republish_on_the_heartbeat() {
+        let publisher = WorkerMetricsPublisher::new().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        publisher.start_metrics_publishing_with(ChannelSink(tx), 42);
+
+        publisher.publish(Some(0), None, Some(100)).unwrap();
+        let first = rx.recv().await.expect("metrics publishing task stopped");
+        assert_eq!(first.kv_used_blocks, Some(100));
+
+        // Nothing changes from here. The rank has to keep saying so, or a consumer that starts
+        // now cannot tell it from a rank that never reported.
+        tokio::time::sleep(HEARTBEAT_INTERVAL + Duration::from_millis(1)).await;
+        let beat = tokio::time::timeout(HEARTBEAT_INTERVAL, rx.recv())
+            .await
+            .expect("an unchanged rank went silent instead of repeating itself")
+            .expect("metrics publishing task stopped");
+        assert_eq!(beat.worker_id, 42);
+        assert_eq!(beat.dp_rank, 0);
+        assert_eq!(beat.kv_used_blocks, Some(100));
     }
 }
 

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -15,6 +15,20 @@ use crate::kv_router::KV_METRICS_SUBJECT;
 
 const PUBLISH_DEBOUNCE: Duration = Duration::from_millis(1);
 
+/// How often each rank republishes its newest metrics while nothing changes.
+///
+/// Publication is edge-triggered, so without this a rank whose load stops changing goes silent
+/// and its last value is the only evidence it ever existed. A consumer that starts later, resets,
+/// or loses its connection has no way to tell that rank from one that never reported: both are
+/// absent. `KvWorkerMonitor` reads that as an instance with no load state, and the DC Relay's
+/// `PoolLoadSnapshot` reports degraded coverage until the rank happens to move again, which on an
+/// idle pool can be indefinitely.
+///
+/// Short enough that a consumer recovers within one scrape or reconnect, long enough that a large
+/// DP group's steady-state chatter stays negligible next to the per-change traffic that dominates
+/// under load.
+pub(super) const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
 #[derive(Debug, Clone, Default, PartialEq)]
 struct WorkerMetrics {
     dp_rank: DpRank,
@@ -60,6 +74,21 @@ impl WorkerMetricsDebouncer {
                     deadline: now + self.debounce,
                 },
             );
+        }
+    }
+
+    /// Re-queue the newest metrics for every rank with nothing already pending.
+    ///
+    /// A rank with a pending update is left alone: that update is newer and is about to go out
+    /// regardless, so replacing it would only move its deadline.
+    fn refresh(&mut self, now: tokio::time::Instant) {
+        for (&dp_rank, metrics) in &self.last_metrics {
+            self.pending
+                .entry(dp_rank)
+                .or_insert_with(|| PendingMetrics {
+                    metrics: metrics.clone(),
+                    deadline: now,
+                });
         }
     }
 
@@ -159,6 +188,10 @@ impl WorkerMetricsPublisher {
             let mut debouncer = WorkerMetricsDebouncer::new(PUBLISH_DEBOUNCE);
             let publish_timer = tokio::time::sleep(tokio::time::Duration::ZERO);
             tokio::pin!(publish_timer);
+            let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+            // A slow sink should delay the next heartbeat, never bank ticks and then emit a burst
+            // of them once it drains.
+            heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
             loop {
                 tokio::select! {
@@ -172,6 +205,12 @@ impl WorkerMetricsPublisher {
 
                         let now = tokio::time::Instant::now();
                         debouncer.observe(&rx.borrow_and_update(), now);
+                        if let Some(deadline) = debouncer.next_deadline() {
+                            publish_timer.as_mut().reset(deadline);
+                        }
+                    }
+                    _ = heartbeat.tick() => {
+                        debouncer.refresh(tokio::time::Instant::now());
                         if let Some(deadline) = debouncer.next_deadline() {
                             publish_timer.as_mut().reset(deadline);
                         }


### PR DESCRIPTION
## Overview:

`WorkerMetricsPublisher` is edge-triggered: a rank publishes when its metrics change, and is otherwise silent. Its last value is then the only evidence the rank exists, so any consumer that was not listening at that moment cannot tell it from a rank that has never reported. Both look identical — absent.

This adds a 10s heartbeat: each rank republishes its newest metrics while nothing is changing.

## Details:

Consumers do act on the "reported" / "never reported" distinction:

- `KvWorkerMonitor` treats an instance with no load state as unknown when computing overloaded instances.
- The DC Relay's `PoolLoadSnapshot::has_degraded_coverage` is true while `kv_observed_ranks < kv_expected_ranks`.

Either can begin observing after a rank has gone quiet — a consumer that starts later, one that reconnects, or `PoolLoadState::clear_observations` on a capacity refresh. From that point the idle rank stays unobserved until its load happens to move again, which on an idle pool may be indefinitely. A DC Relay pool in that state reports degraded coverage permanently, and a router charges it the full unmeasured penalty despite the pool being healthy and reachable.

The change is confined to `WorkerMetricsDebouncer`, which already keeps the newest `WorkerMetrics` per `DpRank` for its dedup check — the heartbeat just re-queues those entries:

- `refresh()` inserts a pending entry for every rank that does not already have one. A rank with a pending update is skipped, because that update is newer and is about to be published anyway, so a busy fleet pays nothing for the heartbeat.
- The interval uses `MissedTickBehavior::Delay`, so a slow sink delays the next beat rather than banking ticks and emitting a burst once it drains.

At 10s a consumer recovers within roughly one scrape or reconnect, while a large DP group's steady-state chatter stays small next to the per-change traffic that dominates under load. I picked the interval to be safely under typical scrape periods; happy to change it, or to make it configurable, if you would rather.

## Where should the reviewer start?

`lib/llm/src/kv_router/publisher/worker_metrics.rs` — `HEARTBEAT_INTERVAL`, `WorkerMetricsDebouncer::refresh`, and the new `heartbeat.tick()` arm in `start_metrics_publishing_with`.

`lib/llm/src/kv_router/publisher/tests.rs` — `unchanged_ranks_republish_on_the_heartbeat` uses `start_paused` so it exercises the real 10s interval without waiting. It fails (with "an unchanged rank went silent instead of repeating itself") when the `heartbeat.tick()` arm is removed.

## Related Issues

- Relates to #11225

<!-- Found while running the DC Relay across two data centers: an idle pool that had already
     reported stayed at degraded coverage indefinitely, because the relay had cleared its
     observations and no rank had any reason to speak again. -->
