### PR TITLE
ci: verify Node 24 on the staging runner

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -86,6 +86,8 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      with:
+        python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
       timeout-minutes: 3
 

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -80,7 +80,7 @@ jobs:
           echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: stg-deploy-tester-v1
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

- move the existing pre-commit job from `ubuntu-latest` to the `aws-ci-stg` runner `stg-deploy-tester-v1`
- set Python 3.13 explicitly because the self-hosted runner does not include the Python preinstalled on GitHub-hosted images
- exercise existing Node 20-declared actions under the runner-level Node 24 opt-in from ai-dynamo/velonix#661
- leave all production runner configuration unchanged

Tracks OPS-8394.

## Validation

- `pre-commit run --files .github/workflows/pre-merge.yml`
- [staging pre-commit job](https://github.com/ai-dynamo/dynamo/actions/runs/34269088293/job/102205803593) passed on runner `stg-deploy-tester-v1-9mlhw-runner-dvw24` with runner version 2.336.0
- GitHub annotated that the Node 20-declared `actions/setup-python@v5.6.0` and `actions/cache@v4` actions were forced to run on Node 24
- verified the live `aws-ci-stg` runner pod inherited `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- no production Kubernetes resources or Velonix production overlays were modified