### PR TITLE
test(sglang): guard against sending a session id SGLang never created

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -616,17 +616,8 @@ async def test_aggregated_fd_on_no_images_passes_none():
     assert captured["image_data"] is None
 
 
-# NVBug 6418893 — SGLang session radix wiring.
-#
-# Dynamo used to derive `session_params={"id": <session_id>}` from a request's
-# `agent_context.session_id` and pass it to `engine.async_generate`. SGLang
-# treats `session_params.id` as an explicit session lifecycle and rejects any id
-# that was not created through `open_session`, so every request carrying an
-# `agent_context.session_id` failed against an SGLang server. Commit `d245a5be3`
-# removed that wiring but added no test guarding its return. These tests assert
-# the corrected contract at the engine seam: no handler may synthesize
-# `session_params` from `agent_context`. See the "Session identity" note in
-# components/src/dynamo/sglang/AGENTS.md.
+# NVBug 6418893: SGLang rejects a `session_params.id` not created through
+# `open_session`, so no handler may synthesize one from `agent_context`.
 
 
 class _GenerateRecorder:

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -633,9 +633,14 @@ class _GenerateRecorder:
     """Stands in for ``sgl.Engine``, recording each ``async_generate`` call.
 
     ``calls`` holds one keyword-argument dict per call, so a test can assert both
-    what reached the engine and that the engine was reached exactly once. The
-    ``**kwargs`` signature matters: ``filter_supported_async_generate_kwargs``
-    inspects it and forwards every kwarg when it finds a var-keyword parameter.
+    what reached the engine and that the engine was reached exactly once.
+
+    The ``**kwargs`` signature is required. All three engine call sites splat
+    their keyword arguments straight into the call — ``sampling_params``,
+    ``stream``, ``bootstrap_*``, ``external_trace_header``, ``rid``,
+    ``data_parallel_rank``, ``lora_path``, and more — so a stub that named its
+    parameters would raise ``TypeError`` on the first one it had not listed, and
+    would need editing every time a handler adds a keyword argument.
     """
 
     def __init__(self) -> None:
@@ -648,36 +653,20 @@ class _GenerateRecorder:
         return _empty_stream()
 
 
-# The deleted helper read the flag through
-# `getattr(server_args, "enable_session_radix_cache", False)`, so an
-# attribute-free SimpleNamespace is exactly the fixture its default-False
-# behavior would have satisfied silently. Pinning all three states means no
-# future server_args flag can quietly reopen the path.
-_SESSION_RADIX_SERVER_ARGS = [
-    pytest.param({"enable_session_radix_cache": True}, id="radix_flag_true"),
-    pytest.param({"enable_session_radix_cache": False}, id="radix_flag_false"),
-    pytest.param({}, id="radix_flag_absent"),
-]
-
-_ADVERSARIAL_AGENT_CONTEXTS = [
-    pytest.param({}, id="no_agent_context_key"),
-    pytest.param({"agent_context": None}, id="null_agent_context"),
-    pytest.param({"agent_context": {}}, id="empty_agent_context"),
-    pytest.param({"agent_context": {"session_id": ""}}, id="empty_session_id"),
-    pytest.param({"agent_context": {"session_id": None}}, id="null_session_id"),
-    pytest.param({"agent_context": {"session_id": 123}}, id="int_session_id"),
-    pytest.param(
-        {"agent_context": {"session_id": {"id": "s-1"}}}, id="dict_session_id"
-    ),
-]
-
 _SESSION_AGENT_CONTEXT = {"agent_context": {"session_id": "s-1"}}
 
 
-def _set_server_args(handler: Any, extra_fields: Dict[str, Any]) -> None:
-    """Rebuild ``handler.config.server_args`` with the given extra attributes."""
+def _enable_session_radix_cache(handler: Any) -> None:
+    """Set ``enable_session_radix_cache=True`` on ``handler.config.server_args``.
+
+    The core-contract tests below run with the flag on because that is the most
+    demanding state: if any code ever reads the flag again, on is the state that
+    would re-enable the removed path. No production code reads it today.
+    """
     handler.config = SimpleNamespace(
-        server_args=SimpleNamespace(served_model_name="test-model", **extra_fields)
+        server_args=SimpleNamespace(
+            served_model_name="test-model", enable_session_radix_cache=True
+        )
     )
 
 
@@ -736,18 +725,20 @@ async def _capture_aggregated_kwargs(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
-async def test_aggregated_decode_omits_session_params_for_agent_context(
-    server_args_fields,
-):
+async def test_aggregated_decode_omits_session_params_for_agent_context():
     """Aggregated decode must not turn ``agent_context.session_id`` into
     ``session_params`` (NVBug 6418893).
 
-    The absent-key assertion is deliberate, not a stale leftover: reverting
-    commit ``d245a5be3`` restores ``_session_kwargs`` and makes this fail.
+    The absent-key assertion is deliberate, not a stale leftover. It goes red if
+    the wiring commit ``d245a5be3`` removed is reintroduced into production code:
+    a new ``session_params`` splat at this call site puts the key into the
+    recorded kwargs. (A literal ``git revert`` of ``d245a5be3`` would not turn it
+    red, because that commit also deleted a ``handler._session_kwargs = lambda
+    req: {}`` stub from ``_new_decode_handler`` in this file, and reverting
+    restores the stub.)
     """
     handler = _new_decode_handler(enable_frontend_decoding=False)
-    _set_server_args(handler, server_args_fields)
+    _enable_session_radix_cache(handler)
     recorder = _GenerateRecorder()
     handler.engine = recorder
 
@@ -767,19 +758,18 @@ async def test_aggregated_decode_omits_session_params_for_agent_context(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
-async def test_disaggregated_decode_omits_session_params_for_agent_context(
-    server_args_fields,
-):
+async def test_disaggregated_decode_omits_session_params_for_agent_context():
     """Disaggregated decode must not attach ``session_params`` either
     (NVBug 6418893).
 
     Commit ``d245a5be3`` removed a separate ``_session_kwargs`` call site on this
-    branch of ``DecodeWorkerHandler.generate``, so it needs its own test.
+    branch of ``DecodeWorkerHandler.generate``, so it needs its own test: a
+    reintroduction that only re-wires the aggregated branch would leave this one
+    green, and the reverse.
     """
     handler = _new_decode_handler(enable_frontend_decoding=False)
     handler.serving_mode = DisaggregationMode.DECODE
-    _set_server_args(handler, server_args_fields)
+    _enable_session_radix_cache(handler)
     recorder = _GenerateRecorder()
     handler.engine = recorder
 
@@ -805,15 +795,16 @@ async def test_disaggregated_decode_omits_session_params_for_agent_context(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
-async def test_prefill_omits_session_params_for_agent_context(server_args_fields):
+async def test_prefill_omits_session_params_for_agent_context():
     """Prefill must not attach ``session_params`` either (NVBug 6418893).
 
     The third ``_session_kwargs`` call site removed by commit ``d245a5be3`` was
-    in ``PrefillWorkerHandler.generate``.
+    in ``PrefillWorkerHandler.generate``. ``_new_prefill_handler`` builds its own
+    handler, so this test is unaffected by the decode-side stub that a literal
+    revert of that commit would restore.
     """
     handler = _new_prefill_handler()
-    _set_server_args(handler, server_args_fields)
+    _enable_session_radix_cache(handler)
     recorder = _GenerateRecorder()
     handler.engine = recorder
 
@@ -829,25 +820,6 @@ async def test_prefill_omits_session_params_for_agent_context(server_args_fields
 
     assert len(recorder.calls) == 1
     captured = recorder.calls[0]
-    assert captured["input_ids"] == [1, 2, 3]
-    assert "session_params" not in captured
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("request_overrides", _ADVERSARIAL_AGENT_CONTEXTS)
-async def test_aggregated_decode_tolerates_adversarial_agent_context(
-    request_overrides,
-):
-    """Missing, empty, and wrong-typed session ids reach the engine unchanged.
-
-    The no-raise half carries as much weight as the absent key. The removed
-    ``_session_id`` helper guarded on ``isinstance(session_id, str)``; a
-    reintroduction that drops the guard surfaces as an exception rather than a
-    wrong keyword argument, and only running these inputs catches that variant.
-    An exception anywhere in ``generate`` fails the test.
-    """
-    captured = await _capture_aggregated_kwargs(request_overrides)
-
     assert captured["input_ids"] == [1, 2, 3]
     assert "session_params" not in captured
 

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -624,14 +624,9 @@ class _GenerateRecorder:
     """Stands in for ``sgl.Engine``, recording each ``async_generate`` call.
 
     ``calls`` holds one keyword-argument dict per call, so a test can assert both
-    what reached the engine and that the engine was reached exactly once.
-
-    The ``**kwargs`` signature is required. All three engine call sites splat
-    their keyword arguments straight into the call — ``sampling_params``,
-    ``stream``, ``bootstrap_*``, ``external_trace_header``, ``rid``,
-    ``data_parallel_rank``, ``lora_path``, and more — so a stub that named its
-    parameters would raise ``TypeError`` on the first one it had not listed, and
-    would need editing every time a handler adds a keyword argument.
+    what reached the engine and that the engine was reached exactly once. The
+    ``**kwargs`` signature accepts whatever keyword arguments a call site passes,
+    so the recorder stays compatible as those call sites evolve.
     """
 
     def __init__(self) -> None:
@@ -644,7 +639,14 @@ class _GenerateRecorder:
         return _empty_stream()
 
 
-_SESSION_AGENT_CONTEXT = {"agent_context": {"session_id": "s-1"}}
+@pytest.fixture
+def session_agent_context() -> Dict[str, Any]:
+    """Request fields carrying a session id, rebuilt for each test.
+
+    The nested ``agent_context`` mapping reaches the handler by reference, so
+    each test needs its own copy.
+    """
+    return {"agent_context": {"session_id": "s-1"}}
 
 
 def _enable_session_radix_cache(handler: Any) -> None:
@@ -662,11 +664,7 @@ def _enable_session_radix_cache(handler: Any) -> None:
 
 
 def _new_prefill_handler() -> PrefillWorkerHandler:
-    """Build a PrefillWorkerHandler without invoking sgl.Engine.
-
-    Same bypass-``__init__`` pattern as ``_new_decode_handler`` above and as
-    test_sglang_decode_handler.py.
-    """
+    """Build a PrefillWorkerHandler without invoking sgl.Engine."""
     handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
     handler.use_sglang_tokenizer = False
     handler.enable_trace = False
@@ -716,17 +714,11 @@ async def _capture_aggregated_kwargs(
 
 
 @pytest.mark.asyncio
-async def test_aggregated_decode_omits_session_params_for_agent_context():
+async def test_aggregated_decode_omits_session_params_for_agent_context(
+    session_agent_context: Dict[str, Any],
+):
     """Aggregated decode must not turn ``agent_context.session_id`` into
     ``session_params`` (NVBug 6418893).
-
-    The absent-key assertion is deliberate, not a stale leftover. It goes red if
-    the wiring commit ``d245a5be3`` removed is reintroduced into production code:
-    a new ``session_params`` splat at this call site puts the key into the
-    recorded kwargs. (A literal ``git revert`` of ``d245a5be3`` would not turn it
-    red, because that commit also deleted a ``handler._session_kwargs = lambda
-    req: {}`` stub from ``_new_decode_handler`` in this file, and reverting
-    restores the stub.)
     """
     handler = _new_decode_handler(enable_frontend_decoding=False)
     _enable_session_radix_cache(handler)
@@ -736,7 +728,7 @@ async def test_aggregated_decode_omits_session_params_for_agent_context():
     request = {
         "token_ids": [1, 2, 3],
         "multi_modal_data": {},
-        **_SESSION_AGENT_CONTEXT,
+        **session_agent_context,
     }
 
     async for _ in handler.generate(request, _Context()):
@@ -749,14 +741,14 @@ async def test_aggregated_decode_omits_session_params_for_agent_context():
 
 
 @pytest.mark.asyncio
-async def test_disaggregated_decode_omits_session_params_for_agent_context():
+async def test_disaggregated_decode_omits_session_params_for_agent_context(
+    session_agent_context: Dict[str, Any],
+):
     """Disaggregated decode must not attach ``session_params`` either
     (NVBug 6418893).
 
-    Commit ``d245a5be3`` removed a separate ``_session_kwargs`` call site on this
-    branch of ``DecodeWorkerHandler.generate``, so it needs its own test: a
-    reintroduction that only re-wires the aggregated branch would leave this one
-    green, and the reverse.
+    ``DecodeWorkerHandler.generate`` reaches the engine through a separate
+    disaggregated branch, so that call site needs its own coverage.
     """
     handler = _new_decode_handler(enable_frontend_decoding=False)
     handler.serving_mode = DisaggregationMode.DECODE
@@ -772,7 +764,7 @@ async def test_disaggregated_decode_omits_session_params_for_agent_context():
             "bootstrap_port": 1234,
             "bootstrap_room": 7,
         },
-        **_SESSION_AGENT_CONTEXT,
+        **session_agent_context,
     }
 
     async for _ in handler.generate(request, _Context()):
@@ -786,13 +778,13 @@ async def test_disaggregated_decode_omits_session_params_for_agent_context():
 
 
 @pytest.mark.asyncio
-async def test_prefill_omits_session_params_for_agent_context():
+async def test_prefill_omits_session_params_for_agent_context(
+    session_agent_context: Dict[str, Any],
+):
     """Prefill must not attach ``session_params`` either (NVBug 6418893).
 
-    The third ``_session_kwargs`` call site removed by commit ``d245a5be3`` was
-    in ``PrefillWorkerHandler.generate``. ``_new_prefill_handler`` builds its own
-    handler, so this test is unaffected by the decode-side stub that a literal
-    revert of that commit would restore.
+    ``PrefillWorkerHandler.generate`` has its own engine call site, so it needs
+    coverage independent of the decode handler.
     """
     handler = _new_prefill_handler()
     _enable_session_radix_cache(handler)
@@ -803,7 +795,7 @@ async def test_prefill_omits_session_params_for_agent_context():
         "token_ids": [1, 2, 3],
         "sampling_options": {},
         "stop_conditions": {},
-        **_SESSION_AGENT_CONTEXT,
+        **session_agent_context,
     }
 
     async for _ in handler.generate(request, _Context()):
@@ -816,17 +808,13 @@ async def test_prefill_omits_session_params_for_agent_context():
 
 
 @pytest.mark.asyncio
-async def test_agent_context_contributes_no_engine_kwargs():
-    """Control: an ``agent_context`` changes nothing about the engine payload.
-
-    Asserting only that ``session_params`` is absent would still pass if a
-    handler grew some other ``agent_context``-derived keyword argument.
-    Comparing the whole key set against an otherwise identical request pins that
-    ``agent_context`` contributes nothing. This control stays green under
-    refactors of the kwargs assembly and goes red only when ``agent_context``
-    starts contributing a key.
+async def test_agent_context_contributes_no_engine_kwargs(
+    session_agent_context: Dict[str, Any],
+):
+    """Control: an ``agent_context`` contributes no engine keyword argument at
+    all, not merely no ``session_params``.
     """
-    with_context = await _capture_aggregated_kwargs(_SESSION_AGENT_CONTEXT)
+    with_context = await _capture_aggregated_kwargs(session_agent_context)
     without_context = await _capture_aggregated_kwargs({})
 
     assert set(with_context) == set(without_context)

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -646,12 +646,13 @@ def session_agent_context() -> Dict[str, Any]:
 
 
 def _enable_session_radix_cache(handler: Any) -> None:
-    """Set ``enable_session_radix_cache=True`` on ``handler.config.server_args``.
+    """Enable the former session-radix path on the test handler.
 
     The core-contract tests below run with the flag on because that is the most
     demanding state: if any code ever reads the flag again, on is the state that
     would re-enable the removed path. No production code reads it today.
     """
+    handler.enable_session_radix_cache = True
     handler.config = SimpleNamespace(
         server_args=SimpleNamespace(
             served_model_name="test-model", enable_session_radix_cache=True

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -690,29 +690,6 @@ def _new_prefill_handler() -> PrefillWorkerHandler:
     return handler
 
 
-async def _capture_aggregated_kwargs(
-    request_overrides: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Run one aggregated decode request; return the recorded engine kwargs.
-
-    Asserts the engine was called exactly once. Without that check, an
-    "``x`` is absent" assertion would also pass when the handler never reached
-    the engine at all.
-    """
-    handler = _new_decode_handler(enable_frontend_decoding=False)
-    recorder = _GenerateRecorder()
-    handler.engine = recorder
-
-    request: Dict[str, Any] = {"token_ids": [1, 2, 3], "multi_modal_data": {}}
-    request.update(request_overrides)
-
-    async for _ in handler.generate(request, _Context()):
-        pass
-
-    assert len(recorder.calls) == 1
-    return recorder.calls[0]
-
-
 @pytest.mark.asyncio
 async def test_aggregated_decode_omits_session_params_for_agent_context(
     session_agent_context: Dict[str, Any],
@@ -805,17 +782,3 @@ async def test_prefill_omits_session_params_for_agent_context(
     captured = recorder.calls[0]
     assert captured["input_ids"] == [1, 2, 3]
     assert "session_params" not in captured
-
-
-@pytest.mark.asyncio
-async def test_agent_context_contributes_no_engine_kwargs(
-    session_agent_context: Dict[str, Any],
-):
-    """Control: an ``agent_context`` contributes no engine keyword argument at
-    all, not merely no ``session_params``.
-    """
-    with_context = await _capture_aggregated_kwargs(session_agent_context)
-    without_context = await _capture_aggregated_kwargs({})
-
-    assert set(with_context) == set(without_context)
-    assert "session_params" not in with_context

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -616,10 +616,6 @@ async def test_aggregated_fd_on_no_images_passes_none():
     assert captured["image_data"] is None
 
 
-# NVBug 6418893: SGLang rejects a `session_params.id` not created through
-# `open_session`, so no handler may synthesize one from `agent_context`.
-
-
 class _GenerateRecorder:
     """Stands in for ``sgl.Engine``, recording each ``async_generate`` call.
 
@@ -695,7 +691,7 @@ async def test_aggregated_decode_omits_session_params_for_agent_context(
     session_agent_context: Dict[str, Any],
 ):
     """Aggregated decode must not turn ``agent_context.session_id`` into
-    ``session_params`` (NVBug 6418893).
+    ``session_params``.
     """
     handler = _new_decode_handler(enable_frontend_decoding=False)
     _enable_session_radix_cache(handler)
@@ -721,8 +717,7 @@ async def test_aggregated_decode_omits_session_params_for_agent_context(
 async def test_disaggregated_decode_omits_session_params_for_agent_context(
     session_agent_context: Dict[str, Any],
 ):
-    """Disaggregated decode must not attach ``session_params`` either
-    (NVBug 6418893).
+    """Disaggregated decode must not attach ``session_params`` either.
 
     ``DecodeWorkerHandler.generate`` reaches the engine through a separate
     disaggregated branch, so that call site needs its own coverage.
@@ -758,7 +753,7 @@ async def test_disaggregated_decode_omits_session_params_for_agent_context(
 async def test_prefill_omits_session_params_for_agent_context(
     session_agent_context: Dict[str, Any],
 ):
-    """Prefill must not attach ``session_params`` either (NVBug 6418893).
+    """Prefill must not attach ``session_params`` either.
 
     ``PrefillWorkerHandler.generate`` has its own engine call site, so it needs
     coverage independent of the decode handler.

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -26,6 +26,7 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     FrontendDecodedVideo,
 )
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
 from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
     Modality,
     MultimodalEncodeWorkerHandler,
@@ -613,3 +614,257 @@ async def test_aggregated_fd_on_no_images_passes_none():
         pass
 
     assert captured["image_data"] is None
+
+
+# NVBug 6418893 — SGLang session radix wiring.
+#
+# Dynamo used to derive `session_params={"id": <session_id>}` from a request's
+# `agent_context.session_id` and pass it to `engine.async_generate`. SGLang
+# treats `session_params.id` as an explicit session lifecycle and rejects any id
+# that was not created through `open_session`, so every request carrying an
+# `agent_context.session_id` failed against an SGLang server. Commit `d245a5be3`
+# removed that wiring but added no test guarding its return. These tests assert
+# the corrected contract at the engine seam: no handler may synthesize
+# `session_params` from `agent_context`. See the "Session identity" note in
+# components/src/dynamo/sglang/AGENTS.md.
+
+
+class _GenerateRecorder:
+    """Stands in for ``sgl.Engine``, recording each ``async_generate`` call.
+
+    ``calls`` holds one keyword-argument dict per call, so a test can assert both
+    what reached the engine and that the engine was reached exactly once. The
+    ``**kwargs`` signature matters: ``filter_supported_async_generate_kwargs``
+    inspects it and forwards every kwarg when it finds a var-keyword parameter.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[Dict[str, Any]] = []
+
+    async def async_generate(
+        self, **kwargs: Any
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        self.calls.append(kwargs)
+        return _empty_stream()
+
+
+# The deleted helper read the flag through
+# `getattr(server_args, "enable_session_radix_cache", False)`, so an
+# attribute-free SimpleNamespace is exactly the fixture its default-False
+# behavior would have satisfied silently. Pinning all three states means no
+# future server_args flag can quietly reopen the path.
+_SESSION_RADIX_SERVER_ARGS = [
+    pytest.param({"enable_session_radix_cache": True}, id="radix_flag_true"),
+    pytest.param({"enable_session_radix_cache": False}, id="radix_flag_false"),
+    pytest.param({}, id="radix_flag_absent"),
+]
+
+_ADVERSARIAL_AGENT_CONTEXTS = [
+    pytest.param({}, id="no_agent_context_key"),
+    pytest.param({"agent_context": None}, id="null_agent_context"),
+    pytest.param({"agent_context": {}}, id="empty_agent_context"),
+    pytest.param({"agent_context": {"session_id": ""}}, id="empty_session_id"),
+    pytest.param({"agent_context": {"session_id": None}}, id="null_session_id"),
+    pytest.param({"agent_context": {"session_id": 123}}, id="int_session_id"),
+    pytest.param(
+        {"agent_context": {"session_id": {"id": "s-1"}}}, id="dict_session_id"
+    ),
+]
+
+_SESSION_AGENT_CONTEXT = {"agent_context": {"session_id": "s-1"}}
+
+
+def _set_server_args(handler: Any, extra_fields: Dict[str, Any]) -> None:
+    """Rebuild ``handler.config.server_args`` with the given extra attributes."""
+    handler.config = SimpleNamespace(
+        server_args=SimpleNamespace(served_model_name="test-model", **extra_fields)
+    )
+
+
+def _new_prefill_handler() -> PrefillWorkerHandler:
+    """Build a PrefillWorkerHandler without invoking sgl.Engine.
+
+    Same bypass-``__init__`` pattern as ``_new_decode_handler`` above and as
+    test_sglang_decode_handler.py.
+    """
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.use_sglang_tokenizer = False
+    handler.enable_trace = False
+    handler.serving_mode = DisaggregationMode.PREFILL
+    handler.config = SimpleNamespace(
+        server_args=SimpleNamespace(served_model_name="test-model")
+    )
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler._generate_bootstrap_room = lambda: 7
+    handler._consume_tasks = set()
+
+    @asynccontextmanager
+    async def no_cancellation_monitor(*args, **kwargs):
+        yield None
+
+    handler._cancellation_monitor = no_cancellation_monitor
+
+    handler._get_input_param = lambda req: {"input_ids": req.get("token_ids", [])}
+    handler._resolve_lora = lambda req: None
+    handler._priority_kwargs = lambda priority: {}
+
+    return handler
+
+
+async def _capture_aggregated_kwargs(
+    request_overrides: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Run one aggregated decode request; return the recorded engine kwargs.
+
+    Asserts the engine was called exactly once. Without that check, an
+    "``x`` is absent" assertion would also pass when the handler never reached
+    the engine at all.
+    """
+    handler = _new_decode_handler(enable_frontend_decoding=False)
+    recorder = _GenerateRecorder()
+    handler.engine = recorder
+
+    request: Dict[str, Any] = {"token_ids": [1, 2, 3], "multi_modal_data": {}}
+    request.update(request_overrides)
+
+    async for _ in handler.generate(request, _Context()):
+        pass
+
+    assert len(recorder.calls) == 1
+    return recorder.calls[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
+async def test_aggregated_decode_omits_session_params_for_agent_context(
+    server_args_fields,
+):
+    """Aggregated decode must not turn ``agent_context.session_id`` into
+    ``session_params`` (NVBug 6418893).
+
+    The absent-key assertion is deliberate, not a stale leftover: reverting
+    commit ``d245a5be3`` restores ``_session_kwargs`` and makes this fail.
+    """
+    handler = _new_decode_handler(enable_frontend_decoding=False)
+    _set_server_args(handler, server_args_fields)
+    recorder = _GenerateRecorder()
+    handler.engine = recorder
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {},
+        **_SESSION_AGENT_CONTEXT,
+    }
+
+    async for _ in handler.generate(request, _Context()):
+        pass
+
+    assert len(recorder.calls) == 1
+    captured = recorder.calls[0]
+    assert captured["input_ids"] == [1, 2, 3]
+    assert "session_params" not in captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
+async def test_disaggregated_decode_omits_session_params_for_agent_context(
+    server_args_fields,
+):
+    """Disaggregated decode must not attach ``session_params`` either
+    (NVBug 6418893).
+
+    Commit ``d245a5be3`` removed a separate ``_session_kwargs`` call site on this
+    branch of ``DecodeWorkerHandler.generate``, so it needs its own test.
+    """
+    handler = _new_decode_handler(enable_frontend_decoding=False)
+    handler.serving_mode = DisaggregationMode.DECODE
+    _set_server_args(handler, server_args_fields)
+    recorder = _GenerateRecorder()
+    handler.engine = recorder
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {},
+        "bootstrap_info": {
+            "bootstrap_host": "127.0.0.1",
+            "bootstrap_port": 1234,
+            "bootstrap_room": 7,
+        },
+        **_SESSION_AGENT_CONTEXT,
+    }
+
+    async for _ in handler.generate(request, _Context()):
+        pass
+
+    assert len(recorder.calls) == 1
+    captured = recorder.calls[0]
+    assert captured["input_ids"] == [1, 2, 3]
+    assert captured["bootstrap_room"] == 7
+    assert "session_params" not in captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_args_fields", _SESSION_RADIX_SERVER_ARGS)
+async def test_prefill_omits_session_params_for_agent_context(server_args_fields):
+    """Prefill must not attach ``session_params`` either (NVBug 6418893).
+
+    The third ``_session_kwargs`` call site removed by commit ``d245a5be3`` was
+    in ``PrefillWorkerHandler.generate``.
+    """
+    handler = _new_prefill_handler()
+    _set_server_args(handler, server_args_fields)
+    recorder = _GenerateRecorder()
+    handler.engine = recorder
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {},
+        **_SESSION_AGENT_CONTEXT,
+    }
+
+    async for _ in handler.generate(request, _Context()):
+        pass
+
+    assert len(recorder.calls) == 1
+    captured = recorder.calls[0]
+    assert captured["input_ids"] == [1, 2, 3]
+    assert "session_params" not in captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("request_overrides", _ADVERSARIAL_AGENT_CONTEXTS)
+async def test_aggregated_decode_tolerates_adversarial_agent_context(
+    request_overrides,
+):
+    """Missing, empty, and wrong-typed session ids reach the engine unchanged.
+
+    The no-raise half carries as much weight as the absent key. The removed
+    ``_session_id`` helper guarded on ``isinstance(session_id, str)``; a
+    reintroduction that drops the guard surfaces as an exception rather than a
+    wrong keyword argument, and only running these inputs catches that variant.
+    An exception anywhere in ``generate`` fails the test.
+    """
+    captured = await _capture_aggregated_kwargs(request_overrides)
+
+    assert captured["input_ids"] == [1, 2, 3]
+    assert "session_params" not in captured
+
+
+@pytest.mark.asyncio
+async def test_agent_context_contributes_no_engine_kwargs():
+    """Control: an ``agent_context`` changes nothing about the engine payload.
+
+    Asserting only that ``session_params`` is absent would still pass if a
+    handler grew some other ``agent_context``-derived keyword argument.
+    Comparing the whole key set against an otherwise identical request pins that
+    ``agent_context`` contributes nothing. This control stays green under
+    refactors of the kwargs assembly and goes red only when ``agent_context``
+    starts contributing a key.
+    """
+    with_context = await _capture_aggregated_kwargs(_SESSION_AGENT_CONTEXT)
+    without_context = await _capture_aggregated_kwargs({})
+
+    assert set(with_context) == set(without_context)
+    assert "session_params" not in with_context


### PR DESCRIPTION
## Overview:

Dynamo used to attach `session_params={"id": <session_id>}` to an SGLang request whenever
that request carried an `agent_context.session_id`. SGLang accepts only a session id created
through its `open_session` lifecycle, so it rejected every such request. Commit `d245a5be3`
removed that wiring but added no test, so nothing stops it coming back. This change adds the
guard. No production file is touched.

## Details:

All new code is in `components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py`:
169 added lines: one import, a stub engine, two helpers, a fixture, and
three tests.

A `_GenerateRecorder` stub replaces `sgl.Engine` and records the keyword arguments of each
`async_generate` call, so the tests observe what reaches the engine rather than the shape of
any helper. Three tests cover the three call sites `d245a5be3` edited — aggregated decode,
disaggregated decode, and prefill — and each asserts that `session_params` is absent. Because
an absent-key assertion would also pass if the engine were never reached, each test also
asserts `len(recorder.calls) == 1` and checks a payload key it expects to be there. The tests run
with `enable_session_radix_cache=True`, need no GPU or model, and add no pytest marker.

## Where should the reviewer start?

`components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py`, from the
`NVBug 6418893` comment, then the three test docstrings. The assertions are deliberately inverted
relative to the original bug report, which described the removed wiring as the wanted
behavior. `components/src/dynamo/sglang/AGENTS.md` ("Session identity") documents
synthesizing `session_params.id` from `agent_context` as prohibited.

## Related Issues

Closes [OPS-8470](https://linear.app/nvidia/issue/OPS-8470/unit-test-sglang-regression-coverage-for-nvbug-6418893-session-radix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for prefill, aggregated decode, and disaggregated decode request handling.
  - Verified that optional session context does not unintentionally alter engine parameters.
  - Added test fixtures and recording utilities to validate request processing consistently.
  - Expanded coverage for scenarios with and without optional request context.
  - Confirmed consistent behavior across supported decoding and prefill workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->