### PR TITLE
fix(operator): tolerate transient worker liveness failures (cherry-pick #13512)

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1404,7 +1404,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											TimeoutSeconds:   4,
 											PeriodSeconds:    5,
 											SuccessThreshold: 0,
-											FailureThreshold: 1,
+											FailureThreshold: 3,
 										},
 										ReadinessProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{

--- a/deploy/operator/internal/dynamo/component_worker.go
+++ b/deploy/operator/internal/dynamo/component_worker.go
@@ -28,6 +28,10 @@ func NewWorkerDefaults() *WorkerDefaults {
 func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
 	container := w.getCommonContainer(context)
 	canaryHealthChecksEnabled := runtimefeatures.CanaryHealthChecks.Enabled(context.RuntimeVersion)
+	livenessFailureThreshold := int32(1)
+	if runtimefeatures.IncreasedWorkerFailureThreshold.Enabled(context.RuntimeVersion) {
+		livenessFailureThreshold = 3
+	}
 
 	// Add system port
 	container.Ports = []corev1.ContainerPort{
@@ -43,6 +47,7 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 		},
 	}
 
+	// Restart legacy workers after one failed liveness check and newer workers after three.
 	container.LivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -52,7 +57,7 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 		},
 		PeriodSeconds:    5,
 		TimeoutSeconds:   4, // TimeoutSeconds should be < PeriodSeconds
-		FailureThreshold: 1, // A single failed liveness check restarts the Pod.
+		FailureThreshold: livenessFailureThreshold,
 	}
 
 	// ReadinessProbe in Dynamo worker context doesn't determine that the worker is ready to receive traffic

--- a/deploy/operator/internal/dynamo/component_worker_test.go
+++ b/deploy/operator/internal/dynamo/component_worker_test.go
@@ -41,13 +41,13 @@ func TestWorkerDefaultsCanaryHealthCheckVersionGate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log("render the worker defaults for the resolved runtime version")
 			container, err := NewWorkerDefaults().GetBaseContainer(ComponentContext{
 				RuntimeVersion: tt.runtimeVersion,
 			})
 			require.NoError(t, err)
-			require.NotNil(t, container.LivenessProbe)
-			require.EqualValues(t, 1, container.LivenessProbe.FailureThreshold)
 
+			t.Log("verify the canary health-check environment default")
 			for _, env := range container.Env {
 				if env.Name == "DYN_HEALTH_CHECK_ENABLED" {
 					require.Equal(t, tt.wantEnabled, env.Value)
@@ -55,6 +55,48 @@ func TestWorkerDefaultsCanaryHealthCheckVersionGate(t *testing.T) {
 				}
 			}
 			t.Fatal("DYN_HEALTH_CHECK_ENABLED was not rendered")
+		})
+	}
+}
+
+func TestWorkerDefaultsLivenessFailureThresholdVersionGate(t *testing.T) {
+	tests := []struct {
+		name             string
+		runtimeVersion   *runtimeversion.Version
+		wantFailureCount int32
+	}{
+		{
+			name:             "unknown legacy runtime",
+			wantFailureCount: 1,
+		},
+		{
+			name:             "older runtime",
+			runtimeVersion:   &runtimeversion.Version{Major: 1, Minor: 4, Patch: 9},
+			wantFailureCount: 1,
+		},
+		{
+			name:             "minimum supported runtime",
+			runtimeVersion:   &runtimeversion.Version{Major: 1, Minor: 5, Patch: 0},
+			wantFailureCount: 3,
+		},
+		{
+			name:             "newer runtime",
+			runtimeVersion:   &runtimeversion.Version{Major: 2, Minor: 0, Patch: 0},
+			wantFailureCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("render the worker defaults for the resolved runtime version")
+			container, err := NewWorkerDefaults().GetBaseContainer(ComponentContext{
+				RuntimeVersion: tt.runtimeVersion,
+			})
+			require.NoError(t, err)
+
+			t.Log("verify the version-gated liveness failure threshold")
+			require.NotNil(t, container.LivenessProbe)
+			require.Equal(t, tt.wantFailureCount, container.LivenessProbe.FailureThreshold)
 		})
 	}
 }

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6515,7 +6515,7 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 							},
 							PeriodSeconds:    5,
 							TimeoutSeconds:   4,
-							FailureThreshold: 1,
+							FailureThreshold: 3,
 						},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
@@ -6652,6 +6652,43 @@ func TestGenerateBasePodSpec_WorkerPreservesHealthCheckOverride(t *testing.T) {
 			t.Fatal("expected DYN_HEALTH_CHECK_ENABLED in main container")
 		})
 	}
+}
+
+func TestGenerateBasePodSpec_WorkerPreservesLivenessProbeOverride(t *testing.T) {
+	t.Log("configure a new runtime with a user-specified liveness failure threshold")
+	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType:   commonconsts.ComponentTypeWorker,
+		DynamoNamespace: ptr.To("default-test-deployment"),
+		ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+			MainContainer: &corev1.Container{
+				Image: "test-image:1.5.0",
+				LivenessProbe: &corev1.Probe{
+					FailureThreshold: 5,
+				},
+			},
+		},
+	})
+
+	t.Log("render the worker pod specification")
+	podSpec, err := GenerateBasePodSpec(
+		component,
+		BackendFrameworkSGLang,
+		&mockSecretsRetriever{},
+		"test-deployment",
+		"default",
+		RoleMain,
+		1,
+		&configv1alpha1.OperatorConfiguration{},
+		commonconsts.MultinodeDeploymentTypeGrove,
+		"test-service",
+		nil,
+		staticContainerGPUCount(0),
+	)
+	require.NoError(t, err)
+
+	t.Log("verify the user-specified threshold takes precedence over the gated default")
+	require.NotNil(t, podSpec.Containers[0].LivenessProbe)
+	require.EqualValues(t, 5, podSpec.Containers[0].LivenessProbe.FailureThreshold)
 }
 
 func TestGenerateBasePodSpec_GPUMemoryServiceExtraClientContainers(t *testing.T) {

--- a/deploy/operator/internal/dynamo/hash_test.go
+++ b/deploy/operator/internal/dynamo/hash_test.go
@@ -310,12 +310,20 @@ func TestComputeBetaDGDWorkersSpecHash_UsesResolvedRuntimeVersion(t *testing.T) 
 }
 
 func TestRuntimeFeatureGatesDoNotPrecedeVersionHashing(t *testing.T) {
-	t.Log("ensure runtime-gated rendering cannot change a legacy unhashed worker generation")
-	assert.GreaterOrEqual(
-		t,
-		runtimefeatures.CanaryHealthChecks.MinRuntimeVersion.Compare(minimumHashedRuntimeVersion),
-		0,
-	)
+	tests := []struct {
+		name string
+		gate runtimefeatures.Gate
+	}{
+		{name: "canary health checks", gate: runtimefeatures.CanaryHealthChecks},
+		{name: "increased worker failure threshold", gate: runtimefeatures.IncreasedWorkerFailureThreshold},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("ensure runtime-gated rendering cannot change a legacy unhashed worker generation")
+			assert.GreaterOrEqual(t, tt.gate.MinRuntimeVersion.Compare(minimumHashedRuntimeVersion), 0)
+		})
+	}
 }
 
 func TestComputeBetaDGDWorkersSpecHash_TracksPreservedAlphaResourceMetadata(t *testing.T) {

--- a/deploy/operator/internal/features/runtime/gate_test.go
+++ b/deploy/operator/internal/features/runtime/gate_test.go
@@ -65,3 +65,13 @@ func TestCanaryHealthChecksThreshold(t *testing.T) {
 		t.Fatalf("MinRuntimeVersion = %s, want 1.5.0", got)
 	}
 }
+
+func TestIncreasedWorkerFailureThreshold(t *testing.T) {
+	t.Log("inspect the central worker liveness feature gate")
+	got := IncreasedWorkerFailureThreshold.MinRuntimeVersion.String()
+
+	t.Log("verify the increased failure threshold is introduced by runtime 1.5.0")
+	if got != "1.5.0" {
+		t.Fatalf("MinRuntimeVersion = %s, want 1.5.0", got)
+	}
+}

--- a/deploy/operator/internal/features/runtime/gates.go
+++ b/deploy/operator/internal/features/runtime/gates.go
@@ -17,6 +17,15 @@ var (
 		MinRuntimeVersion: runtimeversion.Version{Major: 1, Minor: 5, Patch: 0},
 	}
 
+	// IncreasedWorkerFailureThreshold gates the worker liveness default.
+	// Runtime 1.5.0 is the first version whose resolved runtime version is
+	// included in the worker hash, so enabling the feature cannot silently
+	// change an existing worker generation.
+	IncreasedWorkerFailureThreshold = Gate{
+		Name:              "IncreasedWorkerFailureThreshold",
+		MinRuntimeVersion: runtimeversion.Version{Major: 1, Minor: 5, Patch: 0},
+	}
+
 	// NativeRustEPP gates the native Rust EPP requirement: runtime versions at
 	// or above this threshold must not carry the legacy Go EPP's eppConfig,
 	// and versions below it still require it. Introduced for Dynamo runtime

--- a/docs/fern/pages/kubernetes/operations/observability.mdx
+++ b/docs/fern/pages/kubernetes/operations/observability.mdx
@@ -358,12 +358,13 @@ defaults to `9090`:
 
 | Probe | Path | Period | Timeout | Failure threshold |
 | --- | --- | --- | --- | --- |
-| Liveness | `/live` | 5 seconds | 30 seconds | 1 |
+| Liveness | `/live` | 5 seconds | 4 seconds | 1 for unknown or pre-1.5.0 runtimes; 3 for runtime 1.5.0 and later |
 | Readiness | `/health` | 10 seconds | 30 seconds | 60 |
 | Startup | `/live` | 10 seconds | 5 seconds | 720 |
 
-The worker startup probe allows approximately two hours for model download and engine warm-up.
-User-specified probes take precedence over these defaults. See the
+The worker startup probe allows approximately two hours for model download and engine warm-up. The
+operator keeps the single-failure liveness behavior for custom images whose runtime version cannot
+be resolved. User-specified probes take precedence over these defaults. See the
 [API Reference](../../reference/kubernetes-api/full-api-reference.mdx) for defaults that vary by component type.
 
 </Step>


### PR DESCRIPTION
## Summary

- Cherry-pick #13512 onto `release/1.5.0`.
- Require three consecutive failed worker liveness probes for Dynamo runtime `1.5.0` and later.
- Preserve the single-failure default for unknown and earlier runtimes, as well as explicit pod-template overrides.
- Document the version-dependent worker liveness default and preserve the worker-hash rollout invariant.

## Original PR

- Main PR: #13512
- Main merge commit: `c447a3f49b30f3987457760306053515c9b5de7e`
- Backport commit: `229d3f064d72d1a4eff7431776c843a01e8917df`

## Release adaptation

Clean cherry-pick with no conflicts or release-specific code changes.

## Validation

- `go test ./internal/features/runtime ./internal/dynamo -count=1` — passed
- `go test ./internal/controller -run ^TestDynamoComponentDeploymentReconcileRejectsStoredCheckpointIncompatibilityBeforeSideEffects$ -count=1` — passed
- `gofmt -d` on all changed Go files — clean
- `uvx pre-commit run --from-ref origin/release/1.5.0 --to-ref HEAD` — passed
- `git diff --check origin/release/1.5.0..HEAD` — passed
- `go test ./internal/features/runtime ./internal/dynamo ./internal/controller -count=1` — controller envtest cases could not start because the local required binary `deploy/operator/bin/k8s/1.30.0-linux-amd64/etcd` is absent; runtime and Dynamo packages passed.
- Branch contains exactly one DCO-signed cherry-pick commit with source provenance.

## Related Issues

- [x] Confirmed — no related GitHub issue beyond the source PR