### PR TITLE
fix(vllm): preserve mixed media on decode handoff

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -848,17 +848,30 @@ class VllmMultimodalRequestProcessor:
                 ]
                 has_mm_data = False
 
-            # Preserve the fallback: video/audio media is loaded again
-            # on decode because the handoff currently carries image metadata only.
-            if multi_modal_data is None and has_mm_data:
+            # Video/audio media is loaded again on decode because the handoff
+            # currently carries image metadata only. For mixed requests, merge
+            # it with the reconstructed Qwen image placeholder.
+            if has_mm_data:
                 mm_map = request["multi_modal_data"]
-                if mm_map.get(VIDEO_URL_KEY) or mm_map.get(AUDIO_URL_KEY):
-                    multi_modal_data = await self.extract_multimodal_data(
-                        request,
+                local_mm_map = {
+                    key: mm_map[key]
+                    for key in (VIDEO_URL_KEY, AUDIO_URL_KEY)
+                    if mm_map.get(key)
+                }
+                if local_mm_map:
+                    local_request = dict(request)
+                    local_request["multi_modal_data"] = local_mm_map
+                    local_mm_data = await self.extract_multimodal_data(
+                        local_request,
                         request_id,
                         context,
                         mm_processor_kwargs,
                     )
+                    if local_mm_data:
+                        if multi_modal_data is None:
+                            multi_modal_data = local_mm_data
+                        else:
+                            multi_modal_data.update(local_mm_data)
         elif mode == DisaggregationMode.AGGREGATED:
             pre_rendered = await self.try_receive_mm_kwargs(request)
             if pre_rendered is None:

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -982,6 +982,49 @@ async def test_qwen_decode_reconstructs_placeholder_embeddings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_qwen_decode_merges_placeholder_image_with_reloaded_video(monkeypatch):
+    processor = _processor()
+    image = {"placeholder": object()}
+    video = object()
+    processor.video_loader.load_video_batch.return_value = [video]
+    monkeypatch.setattr(
+        mod,
+        "construct_qwen_decode_mm_data",
+        lambda grid, shape, request_id: {"image": image},
+    )
+    video_items = [{"Url": "https://example.com/video.mp4"}]
+
+    prepared = await _prepare_prompt(
+        processor,
+        {
+            "token_ids": [1, 2],
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/image.png"}],
+                "video_url": video_items,
+            },
+            "prefill_result": {
+                "disaggregated_params": {
+                    "embedding_params": {
+                        "image_grid_thw": [[1, 2, 2]],
+                        "embeddings_shape": [1, 16],
+                    }
+                }
+            },
+        },
+        "request-mixed-decode",
+        None,
+        DisaggregationMode.DECODE,
+    )
+
+    assert prepared.prompt["multi_modal_data"] == {
+        "image": image,
+        "video": video,
+    }
+    processor.image_loader.load_image_batch.assert_not_awaited()
+    processor.video_loader.load_video_batch.assert_awaited_once_with(video_items, {})
+
+
+@pytest.mark.asyncio
 async def test_non_qwen_decode_uses_expanded_prompt_tokens():
     processor = _processor(model="llava-hf/llava-1.5-7b-hf")
 

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -21,6 +21,7 @@ from tests.utils.multimodal import (
     make_image_payload_b64,
     make_image_payload_cached_tokens,
     make_image_payload_uuid_passthrough,
+    make_mixed_image_video_payload,
     make_qwen35_custom_encoder_multi_image_payload,
     make_qwen35_custom_encoder_payload,
     make_video_payload,
@@ -281,7 +282,14 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
             ),
             "epd_video": TopologyConfig(
-                marks=[pytest.mark.post_merge, pytest.mark.installs_extra_dependencies],
+                # Critical E/P/D regression gate: the decode handoff must retain
+                # both the reconstructed image placeholder and reloaded video.
+                # Keep this pre-merge despite its runtime because a unit test
+                # cannot prove the NIXL handoff and vLLM prompt agree.
+                marks=[
+                    pytest.mark.pre_merge,
+                    pytest.mark.installs_extra_dependencies,
+                ],
                 timeout_s=600,
                 delayed_start=60,
                 single_gpu=True,
@@ -296,7 +304,22 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         "opencv-python-headless"
                     ],
                 },
-                tests=[MmCase(payload=make_video_payload(MULTIMODAL_VIDEO_EXPECTED))],
+                tests=[
+                    MmCase(
+                        suffix="mixed_frontend_decoding",
+                        payload=make_mixed_image_video_payload(
+                            MULTIMODAL_VIDEO_EXPECTED,
+                            frontend_decoding=True,
+                        ),
+                        followup_payloads=[
+                            make_video_payload(
+                                MULTIMODAL_VIDEO_EXPECTED,
+                                frontend_decoding=True,
+                            )
+                        ],
+                        extra_script_args=["--frontend-decoding"],
+                    )
+                ],
             ),
             "p_d": TopologyConfig(
                 marks=[pytest.mark.post_merge],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -282,12 +282,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
             ),
             "epd_video": TopologyConfig(
-                # Critical E/P/D regression gate: the decode handoff must retain
-                # both the reconstructed image placeholder and reloaded video.
-                # Keep this pre-merge despite its runtime because a unit test
-                # cannot prove the NIXL handoff and vLLM prompt agree.
+                # E/P/D regression gate: the decode handoff must retain both
+                # the reconstructed image placeholder and reloaded video.
                 marks=[
-                    pytest.mark.pre_merge,
+                    pytest.mark.post_merge,
                     pytest.mark.installs_extra_dependencies,
                 ],
                 timeout_s=600,

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -390,6 +390,36 @@ def make_video_payload(
     )
 
 
+def make_mixed_image_video_payload(
+    expected_response: list[str], *, frontend_decoding: bool = False
+) -> ChatPayload:
+    """Mixed image/video payload that requires usable video context."""
+    video_url = MULTIMODAL_VIDEO_URL if frontend_decoding else LOCAL_VIDEO_TEST_URI
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": (
+                    "Ignore the image. What shape appears in the video? "
+                    "Respond with only the shape."
+                ),
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": MULTIMODAL_IMG_URL},
+            },
+            {
+                "type": "video_url",
+                "video_url": {"url": video_url},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=16,
+    )
+
+
 def _make_http_video_payload(url: str, expected_response: list[str]) -> ChatPayload:
     return chat_payload(
         [

--- a/tests/utils/test_multimodal.py
+++ b/tests/utils/test_multimodal.py
@@ -5,9 +5,14 @@ import base64
 
 import pytest
 
-from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
+from tests.serve.conftest import (
+    MULTIMODAL_IMG_URL,
+    MULTIMODAL_VIDEO_URL,
+    get_multimodal_test_image_bytes,
+)
 from tests.utils.multimodal import (
     UuidPassthroughChatPayload,
+    make_mixed_image_video_payload,
     make_qwen35_custom_encoder_multi_image_payload,
 )
 
@@ -82,3 +87,18 @@ def test_qwen35_multi_image_payload_is_order_sensitive() -> None:
         + base64.b64encode(get_multimodal_test_image_bytes(color)).decode()
         for color in ("green", "red")
     ]
+
+
+def test_mixed_image_video_payload_requires_video_context() -> None:
+    payload = make_mixed_image_video_payload(["triangle"], frontend_decoding=True)
+    content = payload.body["messages"][0]["content"]
+
+    assert content[1] == {
+        "type": "image_url",
+        "image_url": {"url": MULTIMODAL_IMG_URL},
+    }
+    assert content[2] == {
+        "type": "video_url",
+        "video_url": {"url": MULTIMODAL_VIDEO_URL},
+    }
+    assert payload.expected_response == ["triangle"]


### PR DESCRIPTION
## Summary

Fix mixed-media requests, such as image + video in the same request, for vLLM fully disaggregated Encode/Prefill/Decode serving.

## Problem

The Qwen decode handoff reconstructs an image placeholder from prefill metadata. This makes decode-side multimodal data non-empty, so the previous fallback—which loaded video/audio only when no multimodal data existed—was skipped. Mixed image + video requests therefore reached decode with the image placeholder but without the video data used during prefill, causing an inconsistent prompt/mRoPE state and malformed or empty output.

Pure-image and pure-video requests do not hit this combination and were unaffected.

## Fix

- preserve the image placeholder reconstructed from the prefill handoff
- reload only video/audio from the original request on decode
- merge the reloaded media with the existing image placeholder
- avoid reloading or recomputing image embeddings
- add focused unit coverage and a post-merge mixed image+video E/P/D regression test

This also covers mixed image + audio through the same video/audio reload path. It is separate from the NIXL KV lease-expiry issue; the lease override used in supplemental testing is not part of this PR.

## Validation

- `python3 -m pytest -q test_vllm_request_processor.py`: 73 passed
- `python3 -m pytest -xvv tests/utils/test_multimodal.py`: 4 passed
- post-merge collection selects `mm_epd_video_qwen3-vl-2b_mixed_frontend_decoding`
- pre-commit hooks on all changed files
- mixed image+video E/P/D A/B on GB300: patched requests returned coherent output with 3/3 successful KV transfers; prompt processing increased from 2,878 to the expected 3,372 tokens, restoring the missing video expansion
- one-GPU E/P/D with a controlled 80-second decode pause and test-only 100-second KV lease: returned `triangle` with 3,375 prompt tokens, one successful transfer, and no lease expiry
