### PR TITLE
feat(router): ship a two-tier cost function as a worker-selection policy

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -524,10 +524,14 @@ jobs:
       if: matrix.dir == 'lib/bindings/python'
       working-directory: ${{ matrix.dir }}
       run: cargo clippy --locked --no-deps --features aic-forward-pass --all-targets -- -D warnings
-    - name: Lint Python bindings custom worker-selection policy support
+    - name: Lint Python bindings worker-selection policy builds
       if: matrix.dir == 'lib/bindings/python'
       working-directory: ${{ matrix.dir }}
-      run: cargo clippy --locked --no-deps --features custom-policy,select-service --all-targets -- -D warnings
+      run: |
+        # custom-policy is on by default; also lint it alongside the standalone selection
+        # service, and the build that links no worker-selection policies at all.
+        cargo clippy --locked --no-deps --features custom-policy,select-service --all-targets -- -D warnings
+        cargo clippy --locked --no-deps --no-default-features --all-targets -- -D warnings
     - name: Lint feature-gated benchmark entrypoints
       if: matrix.dir == '.'
       working-directory: ${{ matrix.dir }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-custom-policy-builtin"
+version = "1.5.0"
+dependencies = [
+ "dynamo-kv-router",
+ "serde",
+ "tempfile",
+]
+
+[[package]]
 name = "dynamo-custom-policy-example-catalog"
 version = "1.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "lib/mocker",
     "lib/kv-router",
     "lib/router-plugins/catalog",
+    "lib/router-plugins/builtin",
     "examples/router/custom-policy-example/soft-pin-repin",
     "examples/router/custom-policy-example/simple-filter-score-pick",
     "examples/router/custom-policy-example/catalog",

--- a/docs/fern/pages/cli/kv-aware-routing/overview.mdx
+++ b/docs/fern/pages/cli/kv-aware-routing/overview.mdx
@@ -81,6 +81,37 @@ The vLLM and SGLang presets start 2 prefill and 2 decode workers and require 4 G
 Once a routed deployment is running, try adding another worker — the frontend discovers it automatically and starts routing to it.
 </Tip>
 
+## Change the Worker-Selection Policy
+
+By default the frontend ranks workers with Dynamo's built-in cost model. Dynamo also ships
+built-in worker-selection policies with the frontend, so you can swap that ranking step without
+rebuilding.
+
+Write the policy into a YAML file:
+
+```yaml
+# worker-selection.yaml
+worker_selection:
+  aggregated: dynamo-two-tier-cost-fn
+  instances:
+    - name: dynamo-two-tier-cost-fn
+      type: dynamo-two-tier-cost-fn
+```
+
+Then point the frontend at it:
+
+```bash
+python3 -m dynamo.frontend \
+  --router-mode kv \
+  --router-policy-config worker-selection.yaml
+```
+
+To compare against the built-in selector, restart with
+`DYN_ROUTER_WORKER_SELECTION_POLICY=default` — no config change needed.
+
+For the available policy types and per-stage prefill/decode selection, see
+[Worker-Selection Policies](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#worker-selection-policies).
+
 ## Troubleshooting
 
 **Router not routing correctly (vLLM).** Ensure `PYTHONHASHSEED=0` is set for all vLLM processes when using KV-aware routing, so cache-block hashes are consistent across workers. See [Hashing Consistency](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md#hashing-consistency-for-kv-events).

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
@@ -36,7 +36,7 @@ For example, if the Frontend sets `--router-kv-overlap-score-credit 2.5` but a w
 - `--router-prefill-load-model`: Selects the router's prompt-side load model. `none` keeps the existing static prompt load accounting. `aic` predicts one expected prefill duration per admitted request and lazily decays only the oldest active prefill request on each worker.
 - `--router-queue-threshold`: Optional queue threshold fraction for prefill token capacity. Queueing is disabled by default; setting a numeric value enables it. The router holds incoming requests in a priority queue while all eligible workers exceed `threshold * max_num_batched_tokens`, releasing them when capacity frees up. This defers dispatch rather than rejecting work, so routing decisions use the freshest load metrics at the moment a request is sent to a worker. `nvext.agent_hints.strict_priority` selects an absolute pending-queue tier, while `nvext.agent_hints.priority` adjusts ordering within the configured policy. Must be greater than or equal to 0; use `0.0` for maximum queueing sensitivity. See the SGLang note under [Tuning Guidelines](#tuning-guidelines) for caveats around how `max_num_batched_tokens` is populated on that backend, and see [Priority Scheduling](../../../../use-cases/agents/priority-scheduling.md) for how router priority differs from backend engine priority.
 - `--router-queue-policy`: Scheduling policy for the router queue: `fcfs` (default) or `wspt`.
-- `--router-policy-config`: Startup-only YAML path for policy-class queues and custom worker-selection instances. When omitted, `--router-queue-threshold` and `--router-queue-policy` define one synthetic policy class. The equivalent environment variable is `DYN_ROUTER_POLICY_CONFIG`. See [Write Custom Routing Strategies](custom-worker-selection.mdx) for the linked-policy schema.
+- `--router-policy-config`: Startup-only YAML path for policy-class queues and worker-selection instances. When omitted, `--router-queue-threshold` and `--router-queue-policy` define one synthetic policy class. The equivalent environment variable is `DYN_ROUTER_POLICY_CONFIG`. See [Worker-Selection Policies](#worker-selection-policies) to select a built-in policy, and [Write Custom Routing Strategies](custom-worker-selection.mdx) for the linked-policy schema.
 
 For how queue backpressure differs from candidate filtering and busy-threshold overload handling, see [Router Filtering](worker-filtering.md).
 
@@ -48,6 +48,86 @@ YAML accept only `fcfs` and `wspt`.
 For each policy, the complete pending-queue key is
 `(strict_priority, policy_key)`. Higher strict tiers always win; the selected
 policy orders requests within a tier.
+
+### Worker-Selection Policies
+
+A worker-selection policy replaces the worker-ranking step of the routing pipeline: it decides which
+eligible worker receives a request. Dynamo still owns discovery, eligibility, queueing, reservations,
+accounting, and metrics. The built-in selector and its cost model above remain the default.
+
+The Dynamo frontend ships a set of built-in worker-selection policies, so selecting one needs
+`--router-policy-config` only — no rebuild, no custom image. They come from the policy catalog the
+Python bindings link by default; a build that disables default features, and the standalone EPP,
+link no catalog and reject a configured policy type at startup.
+
+| Policy type | Behavior |
+|---|---|
+| `default` | Dynamo's built-in selector and cost model. Reserved; always available. |
+| `dynamo-two-tier-cost-fn` | Ranks on two tiers instead of one additive cost: active-request load first, then device-KV prefix overlap. Prefers the worker holding the largest prefix overlap unless load is badly imbalanced. Thresholds and selection order ported from the experimental SGLang router's `cache_aware_zmq` policy. Thresholds are tunable; the defaults reproduce it exactly. |
+
+Write the instance into the same YAML file that `--router-policy-config` already points at:
+
+```yaml
+worker_selection:
+  aggregated: dynamo-two-tier-cost-fn
+  prefill: dynamo-two-tier-cost-fn
+  decode: dynamo-two-tier-cost-fn
+  instances:
+    - name: dynamo-two-tier-cost-fn
+      type: dynamo-two-tier-cost-fn
+```
+
+`aggregated`, `prefill`, `decode`, and `encode` each select a named instance, so prefill and decode
+pools can run different policies. An omitted stage falls back to the built-in selector. `name` is
+yours to choose; `type` must be one of the policy types above.
+
+```bash
+python3 -m dynamo.frontend --router-mode kv --router-policy-config worker-selection.yaml
+```
+
+#### Tune a Policy
+
+A policy instance may carry a `parameters` mapping that the policy itself validates at startup.
+Omitting it keeps every default, so `dynamo-two-tier-cost-fn` with no `parameters` reproduces the
+experimental router exactly. Add any subset to tune it:
+
+```yaml
+    - name: dynamo-two-tier-cost-fn
+      type: dynamo-two-tier-cost-fn
+      parameters:
+        cache_threshold: 0.5
+        balance_abs_threshold: 32
+        balance_rel_threshold: 1.1
+```
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `cache_threshold` | `0.5` | Fraction of the request's blocks that must be device-resident on the best worker before the cache tier applies. Compared strictly. Must be in `[0.0, 1.0]`. |
+| `balance_abs_threshold` | `32` | Minimum active-request spread before the load tier applies. |
+| `balance_rel_threshold` | `1.1` | Minimum ratio of largest to smallest active-request count before the load tier applies. Must be at least `1.0`. |
+
+Both load gates must hold before the load tier displaces the cache tier. Parameters are validated at
+startup, so an out-of-range value or an unknown key fails the process immediately, naming the key,
+rather than being silently ignored. It selects the least-loaded worker once the active-request spread is greater than 32 and the
+largest count is more than 1.1 times the smallest; otherwise it prefers the worker holding the
+largest device-KV overlap when that overlap covers more than 50% of the request's blocks.
+
+#### Override the Selection
+
+`DYN_ROUTER_WORKER_SELECTION_POLICY` overrides every stage. `--router-prefill-policy` and
+`--router-decode-policy`, and their `DYN_ROUTER_PREFILL_POLICY` and `DYN_ROUTER_DECODE_POLICY`
+environment variables, override one stage each. Precedence for a stage is: stage flag, stage
+environment variable, `DYN_ROUTER_WORKER_SELECTION_POLICY`, the YAML stage selection, then
+Dynamo's built-in selector. There is no YAML-wide default: a stage with no selection falls straight
+to the built-in selector, and `worker_selection` rejects unknown keys. Passing `default` explicitly selects the built-in selector
+for that scope, which makes it a quick way to A/B a policy against the default.
+
+> [!NOTE]
+> If a configured policy type is not linked into the running build, startup fails with the list of
+> policy types that are linked. It does not silently fall back to the default selector.
+
+To write your own policy instead of using a built-in one, see
+[Write Custom Routing Strategies](custom-worker-selection.mdx).
 
 ### Policy-Class Queues
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/custom-worker-selection.mdx
@@ -26,6 +26,12 @@ flowchart LR
 
 For multiple compile-checked policies, see the [custom policy examples](https://github.com/ai-dynamo/dynamo/tree/main/examples/router/custom-policy-example). Repository contributors who use a coding agent must also provide the [worker-selection API rules](https://github.com/ai-dynamo/dynamo/blob/main/lib/kv-router/src/scheduling/CLAUDE.md).
 
+## Use a Built-In Policy First
+
+The Dynamo frontend ships built-in worker-selection policies, in [`lib/router-plugins`](https://github.com/ai-dynamo/dynamo/tree/main/lib/router-plugins). Selecting one needs router-policy YAML only — no policy crate, no rebuild, no private image. See [Worker-Selection Policies](configuration-and-tuning.md#worker-selection-policies) for the available types and how to select one.
+
+Write your own policy when no shipped policy expresses the rule you need. The rest of this page covers that case; a custom policy is added alongside the shipped ones, so you keep both.
+
 ## Choose the Policy Stage
 
 | Stage | Input | Output | Use this stage for |
@@ -390,6 +396,10 @@ Both paths use the same policy crate, catalog, and YAML file. Choose the process
 <Tab title="Python Frontend">
 
 Add the catalog to the Python binding manifest. Keep the dependency alias `dynamo-worker-selection-policy-catalog`:
+
+<Note>
+Your catalog is registered alongside the [policies Dynamo ships](#use-a-built-in-policy-first), not instead of them, so both remain selectable. Your catalog cannot reuse a shipped policy's type name; the registry rejects the duplicate at startup rather than overriding it.
+</Note>
 
 ```bash
 # Link the policy catalog into the Python extension.

--- a/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
@@ -96,6 +96,68 @@ Most deployments should leave this at `1.0`. Lower it only when cache-rich worke
 
 `--no-router-kv-events` (env `DYN_ROUTER_USE_KV_EVENTS=false`) disables event tracking; the router predicts cache state from its own routing decisions instead of consuming real KV events. Predictions use TTL expiration by default. Experimental `--router-approximate-cache-policy lru` uses each worker data-parallel rank's advertised physical KV capacity and request-lifecycle releases; it is local to one Frontend replica and requires a positive per-rank `total_kv_blocks`. Use approximate mode only when you are not confident the backend emits KV events correctly.
 
+## Swap the Worker-Selection Policy
+
+The knobs above tune Dynamo's built-in cost model. To replace the worker-ranking step entirely, select
+one of the built-in worker-selection policies that ship with the Dynamo frontend. This needs
+configuration only — no custom image. It applies to this Frontend topology; the standalone EPP in
+the [GAIE topology](gateway-api.mdx) links no policy catalog.
+
+Put the policy in a `ConfigMap`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: router-policy
+data:
+  worker-selection.yaml: |
+    worker_selection:
+      aggregated: dynamo-two-tier-cost-fn
+      instances:
+        - name: dynamo-two-tier-cost-fn
+          type: dynamo-two-tier-cost-fn
+```
+
+Mount it on the Frontend and point `--router-policy-config` at the mounted file:
+
+```yaml
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    podTemplate:
+      spec:
+        volumes:
+        - name: router-policy
+          configMap:
+            name: router-policy
+        containers:
+        - name: main
+          command:
+          - python3
+          - -m
+          - dynamo.frontend
+          args:
+          - --router-mode
+          - kv
+          - --router-policy-config
+          - /etc/dynamo/router/worker-selection.yaml
+          volumeMounts:
+          - name: router-policy
+            mountPath: /etc/dynamo/router
+```
+
+Because the file is startup-only, changing the `ConfigMap` requires a Frontend restart. A policy type
+that is not linked into the running image fails startup with the list of linked types rather than
+silently falling back, so a typo surfaces in the Frontend logs immediately.
+
+To A/B against the built-in selector, set `DYN_ROUTER_WORKER_SELECTION_POLICY=default` on the Frontend
+and restart — the `ConfigMap` stays as it is.
+
+For the available policy types and per-stage prefill/decode selection, see
+[Worker-Selection Policies](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#worker-selection-policies).
+
 ## Routing with Disaggregated Serving
 
 In a disaggregated graph, the router operates over prefill and decode workers separately. The prefill workers publish KV events (the second step above) and the router selects among them; the internal prefill router activates automatically. See [Router with Disaggregated Serving](../../developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md).

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2095,6 +2095,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-custom-policy-builtin"
+version = "1.5.0"
+dependencies = [
+ "dynamo-kv-router",
+ "serde",
+]
+
+[[package]]
 name = "dynamo-data-gen"
 version = "1.5.0"
 dependencies = [
@@ -2381,6 +2389,7 @@ dependencies = [
  "clap",
  "dashmap",
  "dynamo-backend-common",
+ "dynamo-custom-policy-builtin",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-mocker",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -22,10 +22,13 @@ name = "_core"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
-# Links a policy catalog selected by the dependency alias below. Private images replace
-# that dependency with their catalog crate; the stock image does not enable this feature.
+default = ["custom-policy"]
+# Links the worker-selection policies Dynamo ships plus the replaceable catalog selected by the
+# dependency alias below. Enabled by default so a deployment can select a shipped policy through
+# router-policy YAML without rebuilding. A private image replaces only the catalog dependency, so
+# its policies are added alongside the shipped ones rather than displacing them.
 custom-policy = [
+  "dep:dynamo-custom-policy-builtin",
   "dep:dynamo-worker-selection-policy-catalog",
   "dynamo-kv-router/standalone-selection",
 ]
@@ -95,6 +98,7 @@ uuid = { version = "1.18.1" }
 
 # kv-indexer / slot-tracker / shared kv-router types
 dynamo-kv-router = { path = "../../kv-router" }
+dynamo-custom-policy-builtin = { path = "../../router-plugins/builtin", optional = true }
 dynamo-worker-selection-policy-catalog = { path = "../../router-plugins/catalog", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -332,6 +332,10 @@ pub(crate) fn linked_worker_selection_policy_registry() -> WorkerSelectionPolicy
 #[cfg(feature = "custom-policy")]
 fn register_core_with_custom_worker_selection_policy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let mut registry = WorkerSelectionPolicyRegistry::default();
+    // The policies Dynamo ships register first, so a replaced catalog that reuses one of their
+    // type names fails here instead of silently overriding it.
+    dynamo_custom_policy_builtin::register(&mut registry)
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
     dynamo_worker_selection_policy_catalog::register(&mut registry)
         .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 

--- a/lib/router-plugins/builtin/Cargo.toml
+++ b/lib/router-plugins/builtin/Cargo.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-custom-policy-builtin"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Worker-selection policies Dynamo ships and always links"
+
+[dependencies]
+dynamo-kv-router = { workspace = true, features = ["standalone-selection"] }
+serde.workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/lib/router-plugins/builtin/src/lib.rs
+++ b/lib/router-plugins/builtin/src/lib.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Worker-selection policies Dynamo ships.
+//!
+//! Any build that enables the Python bindings' `custom-policy` feature links these, and that
+//! feature is on by default, so a frontend deployment selects one through router-policy YAML
+//! without rebuilding. A build with default features off, and the standalone EPP, link no catalog
+//! at all and reject a configured policy type at startup.
+//!
+//! These do not go through the replaceable `dynamo-worker-selection-policy-catalog` alias, and they
+//! register before it, so a custom image's catalog adds its policies alongside these rather than
+//! displacing them.
+//!
+//! Each policy is one module here. To ship another, add a module and a line in [`register`], then
+//! add a row to the policy table in the router configuration guide. Keep a policy in a single file
+//! until it needs submodules, then promote it to a directory. If a policy ever needs a dependency
+//! beyond `dynamo-kv-router`, put it behind its own default-on Cargo feature so a build can drop
+//! it; every policy registered here is compiled into every artifact that links this crate.
+
+mod two_tier_cost_fn;
+
+use dynamo_kv_router::services::selection::{
+    WorkerSelectionPolicyRegistry, WorkerSelectionPolicyRegistryError,
+};
+
+/// Register every policy Dynamo ships.
+///
+/// `default` is reserved by the registry for Dynamo's built-in worker selector, so no policy here
+/// can shadow it. A later catalog that reuses one of these type names fails registration rather
+/// than overriding it.
+pub fn register(
+    registry: &mut WorkerSelectionPolicyRegistry,
+) -> Result<(), WorkerSelectionPolicyRegistryError> {
+    two_tier_cost_fn::register(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_kv_router::services::selection::WorkerSelectionPolicyFactory;
+    use dynamo_kv_router::{KvRouterConfig, RoutingPartitionRef, WorkerType};
+
+    use super::*;
+
+    /// Resolve router-policy YAML exactly as the Python bindings do at startup, so these cover the
+    /// real configuration path rather than the registrars in isolation.
+    fn resolve(
+        yaml: &str,
+    ) -> (
+        KvRouterConfig,
+        Result<Option<WorkerSelectionPolicyFactory>, WorkerSelectionPolicyRegistryError>,
+    ) {
+        let policy_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(policy_file.path(), yaml).unwrap();
+        let config = KvRouterConfig {
+            router_policy_config: Some(policy_file.path().display().to_string()),
+            ..Default::default()
+        };
+
+        let mut registry = WorkerSelectionPolicyRegistry::default();
+        register(&mut registry).unwrap();
+        let resolved = registry.resolve(&config);
+        (config, resolved)
+    }
+
+    /// Catches a policy type name that drifts from its documentation, and proves the documented
+    /// instance shape constructs for every stage it selects.
+    #[test]
+    fn resolves_documented_yaml() {
+        let (config, resolved) = resolve(
+            r#"
+worker_selection:
+  aggregated: dynamo-two-tier-cost-fn
+  prefill: dynamo-two-tier-cost-fn
+  decode: dynamo-two-tier-cost-fn
+  instances:
+    - name: dynamo-two-tier-cost-fn
+      type: dynamo-two-tier-cost-fn
+"#,
+        );
+        let factory = resolved
+            .unwrap()
+            .expect("a configured instance resolves to a factory");
+
+        let partition = RoutingPartitionRef::new("model", "default");
+        for worker_type in [
+            WorkerType::Aggregated,
+            WorkerType::Prefill,
+            WorkerType::Decode,
+        ] {
+            factory(&config, worker_type, partition);
+        }
+    }
+
+    /// An unknown parameter key is a mistake, most often a misremembered threshold name. It must
+    /// fail startup rather than silently leaving the default in place.
+    #[test]
+    fn rejects_an_unknown_parameter_key() {
+        let (_config, resolved) = resolve(
+            r#"
+worker_selection:
+  aggregated: dynamo-two-tier-cost-fn
+  instances:
+    - name: dynamo-two-tier-cost-fn
+      type: dynamo-two-tier-cost-fn
+      parameters:
+        cache_affinity_threshold: 0.8
+"#,
+        );
+
+        let Err(error) = resolved else {
+            panic!("an unknown parameter must fail resolution");
+        };
+        assert!(
+            matches!(&error, WorkerSelectionPolicyRegistryError::Provider { policy_type, .. }
+                if policy_type == two_tier_cost_fn::POLICY_TYPE),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.to_string().contains("cache_affinity_threshold"),
+            "the error should name the offending key: {error}"
+        );
+    }
+}

--- a/lib/router-plugins/builtin/src/two_tier_cost_fn.rs
+++ b/lib/router-plugins/builtin/src/two_tier_cost_fn.rs
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Two-tier worker-selection cost function.
+//!
+//! Dynamo's built-in selector folds cache overlap and load into one additive cost. This policy
+//! instead ranks on two tiers, taking the first that applies. For each eligible worker it reads
+//! device-KV overlap and active-request count, then:
+//!
+//! 1. Load tier: if active-request spread exceeds `balance_abs_threshold` and the largest count
+//!    exceeds `balance_rel_threshold` times the smallest, select the least-loaded worker.
+//! 2. Cache tier: otherwise, if the largest device-KV overlap is strictly greater than
+//!    `cache_threshold` of the request's block count, select the least-loaded worker holding that
+//!    maximum overlap.
+//! 3. Otherwise, select the least-loaded worker.
+//!
+//! Both load gates must hold to take step 1, so load displaces cache affinity only when the
+//! imbalance is both large in absolute terms and disproportionate.
+//!
+//! The thresholds and selection order are the exact implementation ported from
+//! `experimental/sgl-router`'s `cache_aware_zmq` policy, using Dynamo's authoritative device-KV
+//! overlap instead of that router's own approximate cache history. The thresholds are exposed as
+//! instance parameters defaulting to that router's values, so an instance with no `parameters`
+//! mapping reproduces it exactly.
+//!
+//! Ties between equally ranked workers resolve on candidate row order, which the host leaves
+//! unspecified. This matches the ported implementation; note that Dynamo's built-in selector
+//! instead samples uniformly among ties.
+
+use std::sync::Arc;
+
+use dynamo_kv_router::services::selection::{
+    WorkerSelectionPolicyFactory, WorkerSelectionPolicyParameters,
+    WorkerSelectionPolicyProviderError, WorkerSelectionPolicyRegistry,
+    WorkerSelectionPolicyRegistryError,
+};
+use dynamo_kv_router::{
+    KvRouterConfig, WorkerCacheInput, WorkerInputView, WorkerInputs, WorkerLoadInput, WorkerPicker,
+    WorkerSelectionContext, WorkerSelectionPolicy, WorkerSelectionPolicyError,
+};
+
+/// Policy type selected by `worker_selection.instances[].type`.
+pub const POLICY_TYPE: &str = "dynamo-two-tier-cost-fn";
+
+/// Keep these equal to `experimental/sgl-router`'s `cache_aware_zmq` defaults, so an instance
+/// with no `parameters` mapping reproduces that policy exactly.
+const DEFAULT_CACHE_THRESHOLD: f64 = 0.5;
+const DEFAULT_BALANCE_ABS_THRESHOLD: usize = 32;
+const DEFAULT_BALANCE_REL_THRESHOLD: f64 = 1.1;
+
+/// Tunables for [`POLICY_TYPE`], named after their `sgl-router` counterparts.
+///
+/// Every field is optional and keeps the upstream default when omitted. Unknown keys are rejected
+/// at startup rather than ignored, so a misremembered name fails loudly.
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(deny_unknown_fields, default)]
+struct Parameters {
+    /// Fraction of the request's blocks that must be device-resident on the best worker before the
+    /// cache tier applies. Compared strictly.
+    cache_threshold: f64,
+    /// Minimum active-request spread before the load tier applies.
+    balance_abs_threshold: usize,
+    /// Minimum ratio of largest to smallest active-request count before the load tier applies.
+    balance_rel_threshold: f64,
+}
+
+impl Default for Parameters {
+    fn default() -> Self {
+        Self {
+            cache_threshold: DEFAULT_CACHE_THRESHOLD,
+            balance_abs_threshold: DEFAULT_BALANCE_ABS_THRESHOLD,
+            balance_rel_threshold: DEFAULT_BALANCE_REL_THRESHOLD,
+        }
+    }
+}
+
+impl Parameters {
+    fn validate(&self) -> Result<(), WorkerSelectionPolicyProviderError> {
+        if !self.cache_threshold.is_finite() || !(0.0..=1.0).contains(&self.cache_threshold) {
+            return Err(WorkerSelectionPolicyProviderError::new(
+                "cache_threshold must be a finite number between 0.0 and 1.0",
+            ));
+        }
+        if !self.balance_rel_threshold.is_finite() || self.balance_rel_threshold < 1.0 {
+            return Err(WorkerSelectionPolicyProviderError::new(
+                "balance_rel_threshold must be a finite number greater than or equal to 1.0",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn least_loaded(load: &[WorkerLoadInput], rows: impl Iterator<Item = usize>) -> Option<usize> {
+    rows.min_by_key(|&row| load[row].active_requests())
+}
+
+fn select_row(
+    parameters: &Parameters,
+    cache: &[WorkerCacheInput],
+    load: &[WorkerLoadInput],
+    request_blocks: u64,
+) -> Option<usize> {
+    if cache.is_empty() || cache.len() != load.len() {
+        return None;
+    }
+
+    let min_load = load.iter().map(|item| item.active_requests()).min()?;
+    let max_load = load.iter().map(|item| item.active_requests()).max()?;
+    if max_load.saturating_sub(min_load) > parameters.balance_abs_threshold
+        && (max_load as f64) > parameters.balance_rel_threshold * (min_load as f64)
+    {
+        return least_loaded(load, 0..load.len());
+    }
+
+    let max_overlap = cache
+        .iter()
+        .map(|item| item.device_overlap_blocks())
+        .max_by(f64::total_cmp)?;
+    let cache_ratio = if request_blocks == 0 {
+        0.0
+    } else {
+        max_overlap / request_blocks as f64
+    };
+    if cache_ratio > parameters.cache_threshold {
+        return least_loaded(
+            load,
+            cache.iter().enumerate().filter_map(|(row, item)| {
+                (item.device_overlap_blocks() == max_overlap).then_some(row)
+            }),
+        );
+    }
+
+    least_loaded(load, 0..load.len())
+}
+
+struct TwoTierCostFnPicker {
+    parameters: Parameters,
+}
+
+impl WorkerPicker for TwoTierCostFnPicker {
+    fn required_worker_inputs(&self) -> WorkerInputs {
+        WorkerInputs::CACHE | WorkerInputs::LOAD
+    }
+
+    fn pick(
+        &mut self,
+        context: &WorkerSelectionContext<'_>,
+        input: WorkerInputView<'_>,
+    ) -> Result<usize, WorkerSelectionPolicyError> {
+        let cache = input
+            .cache()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("cache input unavailable"))?;
+        let load = input
+            .load()
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("load input unavailable"))?;
+        select_row(&self.parameters, cache, load, context.request_blocks())
+            .ok_or_else(|| WorkerSelectionPolicyError::failed("no eligible worker"))
+    }
+}
+
+fn provider(
+    parameters: &WorkerSelectionPolicyParameters,
+) -> Result<WorkerSelectionPolicyFactory, WorkerSelectionPolicyProviderError> {
+    let parameters: Parameters = parameters.deserialize()?;
+    parameters.validate()?;
+
+    Ok(Arc::new(
+        move |config: &KvRouterConfig, worker_type, _partition| {
+            WorkerSelectionPolicy::new(
+                config.clone(),
+                worker_type.as_str(),
+                Vec::new(),
+                Box::new(TwoTierCostFnPicker { parameters }),
+            )
+        },
+    ))
+}
+
+pub fn register(
+    registry: &mut WorkerSelectionPolicyRegistry,
+) -> Result<(), WorkerSelectionPolicyRegistryError> {
+    registry.register(POLICY_TYPE, Arc::new(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use dynamo_kv_router::protocols::{RoutingConstraints, WorkerConfigLike, WorkerWithDpRank};
+    use dynamo_kv_router::scheduling::{OverlapSignals, ScheduleMode};
+    use dynamo_kv_router::{
+        SchedulingRequest, WorkerLoadProjection, WorkerSelectionInput, WorkerSelector,
+    };
+
+    use super::*;
+
+    const BLOCK_SIZE: u32 = 16;
+    /// Ten blocks, so five overlapping blocks sit exactly on the 0.5 threshold.
+    const TEN_BLOCKS: usize = 160;
+    const A: u64 = 29;
+    const B: u64 = 41;
+
+    struct TestWorker;
+
+    impl WorkerConfigLike for TestWorker {
+        fn data_parallel_start_rank(&self) -> u32 {
+            0
+        }
+        fn data_parallel_size(&self) -> u32 {
+            1
+        }
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+        fn total_kv_blocks(&self) -> Option<u64> {
+            Some(1024)
+        }
+    }
+
+    fn worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::from_worker_id(id)
+    }
+
+    /// Select among workers given as `(worker_id, device_overlap_blocks, active_requests)`.
+    fn select(workers: [(u64, usize, usize); 2]) -> WorkerWithDpRank {
+        select_with(Parameters::default(), workers)
+    }
+
+    fn select_with(parameters: Parameters, workers: [(u64, usize, usize); 2]) -> WorkerWithDpRank {
+        let mut request = SchedulingRequest {
+            mode: ScheduleMode::QueryOnly { request_id: None },
+            token_seq: None,
+            isl_tokens: TEN_BLOCKS,
+            lora_name: None,
+            expected_output_tokens: None,
+            affinity_target: None,
+            pinned_worker: None,
+            allowed_worker_ids: None,
+            routing_constraints: RoutingConstraints::default(),
+            router_config_override: None,
+            track_prefill_tokens: true,
+            priority_jump: 0.0,
+            strict_priority: 0,
+            policy_class: None,
+            session_context: None,
+            overlap: OverlapSignals::default(),
+            kv_transfer_candidates: None,
+            retain_kv_transfer_chain: false,
+            shared_cache_hits: None,
+            worker_loads: Default::default(),
+            resp_tx: None,
+        };
+        for (id, overlap_blocks, active_requests) in workers {
+            request
+                .overlap
+                .tier_overlap_blocks
+                .device
+                .insert(worker(id), overlap_blocks);
+            request.worker_loads.insert(
+                worker(id),
+                WorkerLoadProjection {
+                    active_requests,
+                    ..Default::default()
+                },
+            );
+        }
+        let configs = HashMap::from(workers.map(|(id, _, _)| (id, TestWorker)));
+        WorkerSelectionPolicy::new(
+            KvRouterConfig::default(),
+            "test",
+            Vec::new(),
+            Box::new(TwoTierCostFnPicker { parameters }),
+        )
+        .select_worker(WorkerSelectionInput::configured(
+            &configs,
+            &request,
+            request.eligibility(),
+            BLOCK_SIZE,
+        ))
+        .unwrap()
+        .worker
+    }
+
+    #[test]
+    fn cache_tier_outranks_a_less_loaded_worker() {
+        // Six of ten blocks is 0.6, above the 0.5 threshold, so B wins despite carrying more load.
+        assert_eq!(select([(A, 0, 0), (B, 6, 4)]), worker(B));
+    }
+
+    #[test]
+    fn cache_tier_threshold_is_strict() {
+        // Five of ten blocks is exactly 0.5, so the comparison fails and load decides.
+        assert_eq!(select([(A, 0, 0), (B, 5, 4)]), worker(A));
+    }
+
+    #[test]
+    fn parameters_override_the_upstream_defaults() {
+        // Three of ten blocks is 0.3: below the 0.5 default, above a tuned 0.2 threshold.
+        let workers = [(A, 0, 0), (B, 3, 4)];
+        assert_eq!(select(workers), worker(A));
+
+        let tuned = Parameters {
+            cache_threshold: 0.2,
+            ..Parameters::default()
+        };
+        assert_eq!(select_with(tuned, workers), worker(B));
+    }
+
+    #[test]
+    fn rejects_out_of_range_parameters() {
+        let cache = |v| {
+            Parameters {
+                cache_threshold: v,
+                ..Default::default()
+            }
+            .validate()
+        };
+        let ratio = |v| {
+            Parameters {
+                balance_rel_threshold: v,
+                ..Default::default()
+            }
+            .validate()
+        };
+
+        assert!(cache(-0.1).is_err() && cache(1.1).is_err() && cache(f64::NAN).is_err());
+        assert!(ratio(0.9).is_err() && ratio(f64::NAN).is_err());
+        assert!(Parameters::default().validate().is_ok());
+    }
+
+    #[test]
+    fn load_tier_needs_both_gates() {
+        // Spread 40 > 32 and 40 > 1.1 * 0: the load tier fires and ignores B's full overlap.
+        assert_eq!(select([(A, 0, 0), (B, 10, 40)]), worker(A));
+        // Spread 64 > 32, but 704 is not > 1.1 * 640, so the cache tier still decides. This pair
+        // straddles the ratio boundary: 705 would clear it and take the load tier.
+        assert_eq!(select([(A, 0, 640), (B, 10, 704)]), worker(B));
+        assert_eq!(select([(A, 0, 640), (B, 10, 705)]), worker(A));
+    }
+}

--- a/lib/router-plugins/catalog/src/lib.rs
+++ b/lib/router-plugins/catalog/src/lib.rs
@@ -11,6 +11,9 @@ use dynamo_kv_router::services::selection::{
 ///
 /// Custom catalogs replace this crate and register their own factories. The default catalog is
 /// intentionally empty so `default` always selects Dynamo's built-in worker selector.
+///
+/// The policies Dynamo ships are registered separately from `dynamo-custom-policy-builtin`, so
+/// replacing this crate adds policies alongside them rather than displacing them.
 pub fn register(
     _registry: &mut WorkerSelectionPolicyRegistry,
 ) -> Result<(), WorkerSelectionPolicyRegistryError> {


### PR DESCRIPTION
## Summary

Inspired by other routing policies in the wild, this PR adds `two_tier_cost_fn` to `lib/router-plugins/builtin`, a worker-selection policy that ranks workers on **two tiers** — active-request load first, then device-KV prefix overlap — instead of folding both into one additive cost the way Dynamo's built-in selector does.

The thresholds and selection order are the exact implementation ported from the experimental SGLang router's `cache_aware_zmq` policy, using Dynamo's authoritative device-KV overlap rather than that router's approximate cache history. Its thresholds are exposed as instance parameters defaulting to that router's values, so an instance with no `parameters` mapping reproduces it exactly. Unknown or out-of-range keys fail startup naming the key.

`custom-policy` is now enabled by default, so a stock build ships the policy and a deployment selects it from YAML with no rebuild and no custom image.

```yaml
worker_selection:
  aggregated: dynamo-two-tier-cost-fn
  instances:
    - name: dynamo-two-tier-cost-fn
      type: dynamo-two-tier-cost-fn
```

```bash
python3 -m dynamo.frontend --router-mode kv --router-policy-config worker-selection.yaml
```

For each eligible worker the policy reads device-KV overlap and active-request count, then takes the first tier that applies:

1. **Load tier** — if the active-request spread is greater than 32 **and** the largest count is more than 1.1 times the smallest, select the least-loaded worker. Both gates must hold, so load displaces cache affinity only when the imbalance is both large in absolute terms and disproportionate.
2. **Cache tier** — otherwise, if the largest device-KV overlap is strictly more than 50% of the request's block count, select the least-loaded worker among those holding that exact maximum overlap.
3. Otherwise, select the least-loaded worker.

## What changes

1. **The policy** — a module in `lib/router-plugins/builtin`, the crate holding the policies Dynamo ships. One module per policy.
2. **`custom-policy` becomes a default feature** of the Python bindings. It keeps its name and meaning; it is simply no longer opt-in.
3. **Shipped policies are separated from the replaceable catalog.** `dynamo-custom-policy-builtin` is a direct dependency of the bindings, not routed through the alias. A custom image still replaces only `dynamo-worker-selection-policy-catalog`, so its policies are registered *alongside* the shipped ones rather than displacing them, and a deployment can select either.

Shipped policies register first, so a catalog that reuses one of their type names fails startup on a duplicate registration instead of silently overriding it.

Because the shipped wheel already builds with `select-service` (`container/templates/wheel_builder.Dockerfile:596,612,625`), which enables `dynamo-kv-router/standalone-selection`, turning `custom-policy` on by default adds only this crate to the shipped dependency closure, and no new external dependencies.

Pre-merge clippy additionally lints `--no-default-features`, which the base job no longer covers now that `default` is non-empty.

## Validation

- `dynamo-custom-policy-builtin`: 7 tests — the cache tier outranking a less-loaded worker, the strict threshold comparison at exactly 50%, both load gates, duplicate rejection when a catalog reuses a shipped type name, and an end-to-end resolution of the documented YAML through the registry (the same path the bindings take at startup).
- **Coexistence check**: an external policy and catalog scaffolded by following the custom-policy guide verbatim, then linked through the `dynamo-worker-selection-policy-catalog` alias, builds with both the external crates and `dynamo-custom-policy-builtin` in the dependency closure. Replacing the alias does not drop the shipped policy.
- `dynamo-py3` clippy clean by default, with `custom-policy,select-service`, and with `--no-default-features`.
- Workspace clippy, `cargo fmt --check`, docs lint (0 errors), and pre-commit clean. CODEOWNERS coverage remains 100%.
- Confirmed against the shipped wheel's exact feature list (`kv-indexer,slot-tracker,select-service,mm-routing,aic-forward-pass,request-trace-s3`) that the crate is linked, since the container build does not pass `--no-default-features`.

Policy tests drive the real host selection path rather than the picker in isolation, because `WorkerCacheInput` and `WorkerLoadInput` have private fields and no public constructors.

## Documentation

- `configuration-and-tuning.md` gains the canonical **Worker-Selection Policies** section: available policy types, the `worker_selection` YAML, per-stage prefill/decode selection, and flag/environment precedence.
- The CLI KV-routing overview gains a runnable `--router-policy-config` walkthrough; the Kubernetes Frontend page gains a ConfigMap, volume mount, and Frontend args example.
- The custom worker-selection page points at that section instead of duplicating it, and states that a custom catalog registers alongside the shipped policies, so the write-your-own workflow carries no caveat about losing them.

## Known trade-off

Ties between equally ranked workers resolve on candidate row order, which the host leaves unspecified. This matches the ported implementation the benchmark below was produced with. Note that Dynamo's built-in selector instead samples uniformly among ties even at `router_temperature = 0`, so this policy can concentrate tied selections on one worker within a process. Tracked as a follow-up to change with its own before/after measurement rather than as an unmeasured edit to the benchmarked code.

## Not yet done

**No GPU A/B on this head.** Controlled validation of this policy measured -5.89% mean E2E, -11.27% TTFT, and prompt-cache hit 18.62% -> 24.09% against main-Dynamo. The policy logic here is unchanged from what produced that result, but it should be re-confirmed on this exact head before the PR leaves draft, along with a throughput check on the routing-host change: `custom-policy` being on by default moves the stock wheel from `RoutingHost` to `RoutingHost<WorkerSelectionPolicy>`.
