### PR TITLE
fix(ci): copy EPP sidecar crate into sidecar and wheel_builder build contexts

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -344,6 +344,8 @@ sidecar:
   # acceptable CI fan-out is agreed. Keep the remaining scope narrow for now.
   - 'lib/sidecar/**'
   - '.github/workflows/shared-build-sidecar.yml'
+  - 'Cargo.toml'
+  - 'Cargo.lock'
   # Compliance policy and baseline changes can fail the sidecar image build.
   - 'container/compliance/**'
   - '!**/*.md'

--- a/.github/scripts/test-filters.js
+++ b/.github/scripts/test-filters.js
@@ -156,6 +156,16 @@ const testCases = [
     expect: { sidecar: true },
     desc: 'compliance policy changes validate the sidecar image gate'
   },
+  {
+    file: 'Cargo.toml',
+    expect: { sidecar: true, rust: true },
+    desc: 'root workspace manifest is a sidecar image build input'
+  },
+  {
+    file: 'Cargo.lock',
+    expect: { sidecar: true, rust: true },
+    desc: 'root lockfile is a sidecar image build input'
+  },
 
   // Doc files should be excluded from core (negation patterns)
   {

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -630,6 +630,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
 # wheel metadata and optional source archival both validate every member.
 COPY examples/router/custom-policy-example/ /opt/dynamo/examples/router/custom-policy-example/
 COPY deploy/inference-gateway/ext-proc/ /opt/dynamo/deploy/inference-gateway/ext-proc/
+COPY deploy/inference-gateway/sidecar/ /opt/dynamo/deploy/inference-gateway/sidecar/
 
 {% if target == "planner" or (target == "runtime" and framework in ("vllm", "sglang", "trtllm")) %}
 COPY container/deps/requirements.aisimulate.txt /opt/dynamo/container/deps/requirements.aisimulate.txt

--- a/lib/sidecar/Dockerfile
+++ b/lib/sidecar/Dockerfile
@@ -73,6 +73,7 @@ COPY .cargo/ .cargo/
 COPY lib/ lib/
 COPY examples/router/custom-policy-example/ examples/router/custom-policy-example/
 COPY deploy/inference-gateway/ext-proc/ deploy/inference-gateway/ext-proc/
+COPY deploy/inference-gateway/sidecar/ deploy/inference-gateway/sidecar/
 
 # ---- vLLM builder -----------------------------------------------------------
 FROM builder-base AS vllm-builder


### PR DESCRIPTION
## Overview:

Post-merge `dynamo-sidecar / Build multi-arch cpu` is failing on `main` ([run 34260106540](https://github.com/ai-dynamo/dynamo/actions/runs/34260106540)). Cargo cannot load the root workspace inside the image because a workspace member is missing from the Docker build context.

## Details:

- #13669 (`19377cdf9e`) added `deploy/inference-gateway/sidecar` to the root Cargo workspace and updated the ext-proc Dockerfile, but not the other two Dockerfiles that stage the workspace.
- `lib/sidecar/Dockerfile`: add the missing `COPY`. This is the red job.
- `container/templates/wheel_builder.Dockerfile`: same missing `COPY`. Latent today because the only step there that loads the full workspace (`cargo vendor`) is behind `ENABLE_SOURCE_ARCHIVAL`, which every current caller sets to false. Fixed now so re-enabling source archival does not trip on it.
- `.github/filters.yaml`: #13669 passed PR CI because the `sidecar` filter only matched `lib/sidecar/**`, so the image build was skipped. Add root `Cargo.toml` and `Cargo.lock` so workspace changes run the sidecar image build pre-merge. The EPP crate directory itself is intentionally not added: it is a different sidecar, its own image build is already gated by the `frontend` filter, and source edits inside it cannot break the `dynamo-sidecar` image. Over the last 60 days on `main` this roughly doubles pre-merge sidecar builds (77 commits touched `Cargo.lock` vs 72 matching the current filter).
- `.github/scripts/test-filters.js`: test cases for the new patterns.

Validation: staged exactly the paths each Dockerfile copies and ran `cargo metadata --no-deps --offline` against them. Before this change it fails with the same `failed to load manifest for workspace member .../deploy/inference-gateway/sidecar` error as CI; after, the workspace loads. `npm test` in `.github/scripts` passes the new cases (the 3 pre-existing `docs` failures are unrelated and also fail on `main`).

## Where should the reviewer start?

`.github/filters.yaml` for the fan-out trade-off. The two Dockerfile changes are one line each.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)