### PR TITLE
fix(vllm): extend multimodal EPD KV lease

### DIFF
--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -19,6 +19,10 @@ FRONTEND_DECODING=false
 # share GPUs. Keep the lease above the observed 75-77 second handoff window,
 # while allowing deployments to choose a shorter cleanup interval.
 DYN_VLLM_KV_LEASE_DURATION=${DYN_VLLM_KV_LEASE_DURATION:-100}
+if ! [[ "$DYN_VLLM_KV_LEASE_DURATION" =~ ^([6-9]|[1-9][0-9]+)$ ]]; then
+    echo "DYN_VLLM_KV_LEASE_DURATION must be an integer >= 6" >&2
+    exit 2
+fi
 KV_TRANSFER_CONFIG="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"kv_lease_duration\":${DYN_VLLM_KV_LEASE_DURATION}}}"
 
 # --single-gpu: Packs all 3 workers (encode, prefill, decode) onto a single GPU.

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -15,6 +15,12 @@ export DYN_REQUEST_PLANE=tcp
 MODEL_NAME="llava-hf/llava-1.5-7b-hf"
 FRONTEND_DECODING=false
 
+# Media processing can delay the P->D KV pull, especially when E/P/D workers
+# share GPUs. Keep the lease above the observed 75-77 second handoff window,
+# while allowing deployments to choose a shorter cleanup interval.
+DYN_VLLM_KV_LEASE_DURATION=${DYN_VLLM_KV_LEASE_DURATION:-100}
+KV_TRANSFER_CONFIG="{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"kv_lease_duration\":${DYN_VLLM_KV_LEASE_DURATION}}}"
+
 # --single-gpu: Packs all 3 workers (encode, prefill, decode) onto a single GPU.
 # This is intended for functional testing with small models (e.g. 2B) where CI
 # only has 1 GPU available. It reduces performance by:
@@ -224,19 +230,19 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 VLLM_USE_V2_MODEL_RUNNER=${VLLM_USE_V2_MODEL_RUNNER:-0} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_ENCODE \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
+python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config "$KV_TRANSFER_CONFIG" --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (${PREFILL_GPU_MEM_ARGS})..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_PREFILL \
-CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $PREFILL_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_PREFILL}\"}" &
+CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $PREFILL_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config "$KV_TRANSFER_CONFIG" --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_PREFILL}\"}" &
 
 # Start decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (${DECODE_GPU_MEM_ARGS})..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_DECODE \
-CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm  --disaggregation-mode decode --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $DECODE_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_DECODE}\"}" &
+CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm  --disaggregation-mode decode --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $DECODE_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config "$KV_TRANSFER_CONFIG" --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_DECODE}\"}" &
 
 echo "=================================================="
 echo "All components started. Waiting for initialization..."


### PR DESCRIPTION
## Summary

- raise the multimodal E/P/D NIXL KV lease from vLLM's 30-second default to 100 seconds
- apply one shared transfer configuration to Encode, Prefill, and Decode
- expose `DYN_VLLM_KV_LEASE_DURATION` so deployments can tune the retention window

This mitigates delayed P-to-D handoffs, especially when E/P/D workers share GPU resources. Successful transfers still release their blocks immediately; abandoned transfers may retain blocks longer. This is a deployment mitigation, not a replacement for upstream fail-closed lease-expiry handling.

## Validation

- `bash -n examples/backends/vllm/launch/disagg_multimodal_epd.sh`
- pre-commit hooks on the changed launcher
- exact candidate launcher on one RTX 5880 Ada with Dynamo 1.5.0-rc.3 / vLLM 0.28.0
- stopped the decode EngineCore for 80 seconds; the NIXL pull began approximately 78 seconds after prefill completed
- mixed image+video request returned a coherent yellow-triangle answer with 3,375 prompt tokens
- one successful 92.312 MB KV transfer, 100% external-prefix-cache hit rate, and no lease-expiry or `RequestNotFound` logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable KV-transfer lease duration for multimodal vLLM deployments.
  - Defaults the lease duration to 100 seconds.
  - Applies the shared KV-transfer configuration consistently across encode, prefill, and decode workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->