### PR TITLE
refactor(tests): reuse shared readiness check in GMS

### DIFF
--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -18,6 +18,7 @@ from tests.gpu_memory_service.common.gms import GMSServer
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DefaultPort
 from tests.utils.engine_process import EngineProcess
 from tests.utils.gpu_args import build_gpu_mem_args
+from tests.utils.http_checks import check_health_ready
 from tests.utils.managed_process import DynamoFrontendProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_ports, deallocate_ports
@@ -157,7 +158,7 @@ class GMSEngineProcess(EngineProcess, ABC):
                 **self.env_updates(),
             },
             health_check_urls=[
-                (f"http://localhost:{system_port}/health", self._is_ready),
+                (f"http://localhost:{system_port}/health", check_health_ready),
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api),
                 (f"http://localhost:{frontend_port}/health", check_health_generate),
             ],
@@ -187,12 +188,6 @@ class GMSEngineProcess(EngineProcess, ABC):
 
     def resume_payload(self) -> dict:
         return {}
-
-    def _is_ready(self, response) -> bool:
-        try:
-            return response.json().get("status") == "ready"
-        except ValueError:
-            return False
 
     def _request_engine(
         self,


### PR DESCRIPTION
## Summary

Reuse `tests.utils.http_checks.check_health_ready` for the GMS engine health endpoint and remove the duplicate `_is_ready` method. The shared predicate requires HTTP 200 and a JSON object with `status: ready`, and rejects malformed responses.

Depends on #14499. This PR contains only the GMS runtime change; its base is `rupei/cleanup-python-test-infra`.

## Validation

- Existing HTTP helper tests: 9 passed (`.venv/bin/python -m pytest --noconftest -o addopts='' -o filterwarnings='' tests/utils/test_http_checks.py -q`; isolated from GPU test fixtures and optional pytest plugin configuration).
- Python compile check for the changed file passed.
- All applicable pre-commit checks passed.
- Parent and child diffs pass `git diff --check`.
- GPU integration tests were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine readiness checks by using the shared health-check behavior for system-port validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->