### PR TITLE
docs: fix nvidia_peermem claim and retired GPU driver flag in AKS RDMA guide

### DIFF
--- a/docs/fern/pages/kubernetes/installation/managed-kubernetes/azure/spot-vms.mdx
+++ b/docs/fern/pages/kubernetes/installation/managed-kubernetes/azure/spot-vms.mdx
@@ -32,7 +32,7 @@ az aks nodepool add \
   --priority Spot \
   --eviction-policy Delete \
   --spot-max-price -1 \
-  --skip-gpu-driver-install
+  --gpu-driver None
 ```
 
 `--spot-max-price -1` means pay up to the on-demand price (recommended). `--eviction-policy Delete` removes evicted nodes from the pool; use `Deallocate` if you want to preserve node state across evictions.

--- a/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
+++ b/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
@@ -102,9 +102,13 @@ This targets nodes with Mellanox NICs (`feature.node.kubernetes.io/pci-15b3.pres
 Wait for the MOFED driver DaemonSet to finish installing on all nodes (this may take several minutes):
 
 ```bash
-kubectl get pods -n network-operator -l app=mofed-ubuntu22.04-ds -w
+kubectl get pods -n network-operator -l nvidia.com/ofed-driver -w
 # Wait until all pods show Running
 ```
+
+<Note>
+Select these pods by the `nvidia.com/ofed-driver` label rather than by name. The Network Operator names the DaemonSet `mofed-<os><version>-<kernel-hash>-ds`, so the name changes with the node OS version and kernel — and the pods' `app` label omits the `-ds` suffix that the DaemonSet name carries.
+</Note>
 
 </Step>
 <Step title="Deploy the IB Node Configuration DaemonSet" id="step-3-deploy-the-ib-node-configuration-daemonset">
@@ -197,7 +201,7 @@ kubectl get pods -n kube-system -l app=ib-node-config -w
 <Step title="Deploy the RDMA Shared Device Plugin" id="step-4-deploy-the-rdma-shared-device-plugin">
 The RDMA Shared Device Plugin exposes InfiniBand NICs as a Kubernetes extended resource so pods can request RDMA access.
 
-Create the ConfigMap with the device plugin configuration:
+Create `rdma-configmap.yaml` with the device plugin configuration:
 
 ```yaml
 apiVersion: v1
@@ -221,7 +225,7 @@ data:
     }
 ```
 
-Create the DaemonSet:
+Create `rdma-shared-dp-ds.yaml`:
 
 ```yaml
 apiVersion: apps/v1
@@ -317,7 +321,7 @@ kubectl get pods -n gpu-operator -w
 **1. Check that MOFED driver pods are running on all InfiniBand nodes:**
 
 ```bash
-kubectl get pods -n network-operator -l app=mofed-ubuntu22.04-ds
+kubectl get pods -n network-operator -l nvidia.com/ofed-driver
 ```
 
 **2. Check that IB node config pods completed initialization:**

--- a/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
+++ b/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
@@ -19,7 +19,7 @@ The Network Operator and NicClusterPolicy steps in this guide are based on the [
 - At least **2 GPU nodes** to enable cross-node RDMA communication
 - **ND-series VMs** with Mellanox ConnectX InfiniBand NICs (e.g., `Standard_ND96asr_v4`, `Standard_ND96isr_H100_v5`)
 - **Ubuntu OS** on the node pool (required for NVIDIA driver compatibility)
-- GPU driver installation **skipped** on the node pool (`--skip-gpu-driver-install`) — see [GPU Node Pool Setup](../managed-kubernetes/azure/aks-setup.mdx#step-2-add-a-gpu-node-pool)
+- GPU driver installation **skipped** on the node pool (`--gpu-driver none`) — see [GPU Node Pool Setup](../managed-kubernetes/azure/aks-setup.mdx#step-2-add-a-gpu-node-pool). This guide installs the GPU Operator (Step 5), and AKS-managed drivers cannot coexist with it.
 
 **Register the AKS InfiniBand feature** to ensure nodes land on the same physical InfiniBand network:
 
@@ -40,6 +40,12 @@ The RDMA setup involves five components installed in this order:
 3. **IB Node Configuration** — Loads InfiniBand kernel modules and sets memlock limits
 4. **RDMA Shared Device Plugin** — Exposes InfiniBand NICs to pods as a Kubernetes resource
 5. **GPU Operator** — Installed with RDMA-specific settings (NFD disabled, GPUDirect RDMA enabled, host MOFED)
+
+<Note>
+Steps 1 and 2 install the OFED/DOCA driver, which the AKS node image does not ship — the Network Operator is what makes the Mellanox NICs usable for RDMA. Step 5 is only needed because this guide manages GPU drivers with the GPU Operator.
+
+Azure documents a second, simpler option: keep the **AKS-managed GPU driver** (create the node pool without `--gpu-driver none`) and load `nvidia_peermem` with Azure's [`nvidia-peermem-reloader`](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet, which drops Step 5 entirely. The two driver sources are mutually exclusive and cannot coexist on the same node pool. See [GPU Drivers](https://github.com/Azure/aks-rdma-infiniband/blob/main/website/docs/configurations/02-gpu-drivers.md) in the Azure RDMA repo for the trade-offs. The steps below cover the GPU Operator path.
+</Note>
 
 <Steps toc={true}>
 <Step title="Install the NVIDIA Network Operator" id="step-1-install-the-nvidia-network-operator">
@@ -385,22 +391,16 @@ If you see `ENOMEM` errors from `ibv_reg_mr` and `ib-node-config` is running, ve
   ```
 - If limits are not unlimited, the ib-node-config DaemonSet needs to be re-applied and services restarted
 
-**GPUDirect RDMA not working — `nvidia_peermem` module missing:**
+**GPUDirect RDMA not working — `nvidia_peermem` module not loaded:**
 
-ND-series nodes (including ND H100 v5) do **not** ship `nvidia_peermem` in the host OS. This module is required for InfiniBand adapters to directly read/write GPU memory — without it, RDMA transfers fall back to staging through host memory.
+`nvidia_peermem` lets InfiniBand adapters read and write GPU memory directly — without it, RDMA transfers fall back to staging through host memory.
 
-Verify whether the module is loaded:
+The module ships **inside the NVIDIA GPU driver package** (since driver R470) rather than in the node OS image, and nothing loads it automatically — it must be loaded explicitly. See [GPUDirect RDMA and GPUDirect Storage](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-rdma.html) for how kernel-mode support is provided. Where the module lives therefore depends on which driver source the node pool uses:
 
-```bash
-# Check on a GPU node via a privileged pod or node shell
-lsmod | grep nvidia_peermem
-# If empty, the module is not loaded
+- **GPU Operator (this guide, `--gpu-driver none`)** — the host has no NVIDIA driver at all, so `nvidia_peermem` is absent from the host's `/lib/modules` by design. The module is built and loaded inside the `nvidia-driver-daemonset` instead.
+- **AKS-managed GPU driver** — the driver install places `nvidia_peermem` in the host's `/lib/modules` (as `updates/dkms/nvidia-peermem.ko`), but does not load it. Loading it also requires an `ib_core` that exposes the peer-memory API, which the DOCA/OFED stack provides; on a node with only the inbox `ib_core`, `modprobe nvidia_peermem` fails with `Invalid argument` even though the module file is present.
 
-modinfo nvidia_peermem
-# If "Module not found", it is also not present in the host's /lib/modules
-```
-
-With the GPU Operator managing drivers (`driver.rdma.enabled=true`), `nvidia_peermem` is built and loaded by the `nvidia-driver-daemonset` — it lives in the driver pod's `/lib/modules`, not the host's native kernel modules. Verify the driver daemonset is loading it:
+Verify the module inside the driver daemonset:
 
 ```bash
 kubectl exec -n gpu-operator $(kubectl get pod -n gpu-operator -l app=nvidia-driver-daemonset -o jsonpath='{.items[0].metadata.name}') -- lsmod | grep nvidia_peermem
@@ -412,8 +412,10 @@ If this returns empty, ensure `driver.rdma.enabled=true` and `driver.rdma.useHos
 kubectl rollout restart daemonset/nvidia-driver-daemonset -n gpu-operator
 ```
 
+Running `lsmod` or `modinfo nvidia_peermem` on the host is not a meaningful check on this path — the module belongs to the driver container, so an empty result there is expected and does not indicate a problem.
+
 <Note>
-The [nvidia-peermem-reloader](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet from the Azure RDMA repo is designed for clusters using **AKS-managed GPU drivers** (without the GPU Operator). It simply runs `modprobe nvidia-peermem` — which will fail on ND H100 v5 nodes because the host OS doesn't include the module. When using the GPU Operator (recommended), the operator handles `nvidia_peermem` automatically via `driver.rdma.enabled=true`.
+The [nvidia-peermem-reloader](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet from the Azure RDMA repo is the fix for the **AKS-managed GPU driver** case, where the module is present on the host but unloaded. It mounts the host's `/lib/modules` and runs `modprobe nvidia-peermem`. Do not use it alongside the GPU Operator: with `--gpu-driver none` there is no host driver for it to load a module from. When using the GPU Operator, `driver.rdma.enabled=true` handles `nvidia_peermem` instead.
 </Note>
 
 ## See Also

--- a/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
+++ b/docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx
@@ -19,7 +19,7 @@ The Network Operator and NicClusterPolicy steps in this guide are based on the [
 - At least **2 GPU nodes** to enable cross-node RDMA communication
 - **ND-series VMs** with Mellanox ConnectX InfiniBand NICs (e.g., `Standard_ND96asr_v4`, `Standard_ND96isr_H100_v5`)
 - **Ubuntu OS** on the node pool (required for NVIDIA driver compatibility)
-- GPU driver installation **skipped** on the node pool (`--gpu-driver none`) — see [GPU Node Pool Setup](../managed-kubernetes/azure/aks-setup.mdx#step-2-add-a-gpu-node-pool). This guide installs the GPU Operator (Step 5), and AKS-managed drivers cannot coexist with it.
+- GPU driver installation **skipped** on the node pool (`--gpu-driver none`) — see [GPU Node Pool Setup](../managed-kubernetes/azure/aks-setup.mdx#step-2-add-a-gpu-node-pool). This guide has the GPU Operator build and manage the driver (Step 5) so that it is compiled with RDMA support. A node takes its driver from either the host or the Operator's driver daemonset, not both.
 
 **Register the AKS InfiniBand feature** to ensure nodes land on the same physical InfiniBand network:
 
@@ -44,7 +44,7 @@ The RDMA setup involves five components installed in this order:
 <Note>
 Steps 1 and 2 install the OFED/DOCA driver, which the AKS node image does not ship — the Network Operator is what makes the Mellanox NICs usable for RDMA. Step 5 is only needed because this guide manages GPU drivers with the GPU Operator.
 
-Azure documents a second, simpler option: keep the **AKS-managed GPU driver** (create the node pool without `--gpu-driver none`) and load `nvidia_peermem` with Azure's [`nvidia-peermem-reloader`](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet, which drops Step 5 entirely. The two driver sources are mutually exclusive and cannot coexist on the same node pool. See [GPU Drivers](https://github.com/Azure/aks-rdma-infiniband/blob/main/website/docs/configurations/02-gpu-drivers.md) in the Azure RDMA repo for the trade-offs. The steps below cover the GPU Operator path.
+Azure documents a second, simpler option: keep the **AKS-managed GPU driver** (create the node pool without `--gpu-driver none`) and load `nvidia_peermem` with Azure's [`nvidia-peermem-reloader`](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet, which drops Step 5 entirely. A node takes its driver from one source or the other, so if you still want the Operator's other components on that path, install it with [`driver.enabled=false`](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) so it does not manage the driver. See [GPU Drivers](https://github.com/Azure/aks-rdma-infiniband/blob/main/website/docs/configurations/02-gpu-drivers.md) in the Azure RDMA repo for the trade-offs. The steps below cover the GPU Operator path.
 </Note>
 
 <Steps toc={true}>
@@ -415,7 +415,7 @@ kubectl rollout restart daemonset/nvidia-driver-daemonset -n gpu-operator
 Running `lsmod` or `modinfo nvidia_peermem` on the host is not a meaningful check on this path — the module belongs to the driver container, so an empty result there is expected and does not indicate a problem.
 
 <Note>
-The [nvidia-peermem-reloader](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet from the Azure RDMA repo is the fix for the **AKS-managed GPU driver** case, where the module is present on the host but unloaded. It mounts the host's `/lib/modules` and runs `modprobe nvidia-peermem`. Do not use it alongside the GPU Operator: with `--gpu-driver none` there is no host driver for it to load a module from. When using the GPU Operator, `driver.rdma.enabled=true` handles `nvidia_peermem` instead.
+The [nvidia-peermem-reloader](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) DaemonSet from the Azure RDMA repo is the fix for the **AKS-managed GPU driver** case, where the module is present on the host but unloaded. It mounts the host's `/lib/modules` and runs `modprobe nvidia-peermem`. It has nothing to load on a `--gpu-driver none` node pool, since there is no host driver there — on this guide's path, `driver.rdma.enabled=true` handles `nvidia_peermem` inside the driver daemonset instead.
 </Note>
 
 ## See Also


### PR DESCRIPTION
## Overview

Three fixes to the [InfiniBand on Azure](https://docs.nvidia.com/dynamo/kubernetes/installation/rdma-setup/infiniband-on-azure) guide, all verified against primary sources or a live AKS cluster:

1. The guide says ND-series nodes don't ship `nvidia_peermem` in the host OS. They do.
2. A `kubectl` wait command whose label selector cannot match any pod.
3. A CLI flag retired in August 2025.

Reported by an engineer on Microsoft's AKS Node SIG reviewing this guide for Azure accuracy.

## Summary

- **`nvidia_peermem` is present, not missing.** Corrects the troubleshooting section to say the module is *not loaded* rather than *missing*, and explains where it lives on each driver path.
- **Fixes a selector that never matches.** `-l app=mofed-ubuntu22.04-ds` cannot match any pod; replaced with the stable `nvidia.com/ofed-driver` label in both places it appears.
- **Replaces the retired `--skip-gpu-driver-install`** with `--gpu-driver none` here and in `spot-vms.mdx`.
- Names the two Step 4 manifests that `kubectl apply -f` refers to but the prose never introduces.
- Adds a note describing Azure's supported AKS-managed-driver alternative, which does not need Step 5.

## Details

### 1. `nvidia_peermem` ships with the driver

It has been part of the driver package since R470, and NVIDIA's driver README states no service loads it automatically. The driver's `dkms.conf` confirms it is built on install:

```
AUTOINSTALL="yes"
BUILT_MODULE_NAME[4]="nvidia-peermem"
```

Verified on a live AKS GPU node using the AKS-managed driver (`580.159.04`):

```
$ modinfo nvidia_peermem
filename: /lib/modules/6.8.0-1065-azure/updates/dkms/nvidia-peermem.ko
version:  580.159.04

$ lsmod | grep peermem
                      # present on disk, not loaded

$ dkms status
nvidia/580.159.04, 6.8.0-1065-azure, x86_64: installed
```

Readers of this guide see nothing on the host because the guide provisions the node pool with **no host GPU driver** — a consequence of its own prerequisite, not a property of ND-series hardware. On the GPU Operator path the module belongs to `nvidia-driver-daemonset`, which is where the check belongs. The removed host-side `lsmod`/`modinfo` snippet was guaranteed to look like a failure on the very configuration the guide sets up.

Azure's docs agree the module is present but unloaded: the AKS-managed driver install "does not load the Nvidia peer memory kernel module automatically" ([source](https://github.com/Azure/aks-rdma-infiniband/blob/main/website/docs/configurations/02-gpu-drivers.md)). Their [`nvidia-peermem-reloader`](https://github.com/Azure/aks-rdma-infiniband/tree/main/configs/nvidia-peermem-reloader) mounts the host's `/lib/modules` and `modprobe`s it on a 30s liveness probe — impossible if the module weren't on the host.

One nuance the updated text now calls out: loading it also needs an `ib_core` exposing the peer-memory API, which DOCA/OFED provides. On inbox `ib_core`, `modprobe nvidia_peermem` fails with `Invalid argument` despite the file being present.

### 2. The MOFED selector matches nothing

The guide asks readers to wait on:

```bash
kubectl get pods -n network-operator -l app=mofed-ubuntu22.04-ds -w
```

In network-operator `v26.1.0` — the version this guide pins — the OFED DaemonSet template is:

```yaml
labels:
  app: mofed-{{ .RuntimeSpec.OSName }}{{ .RuntimeSpec.OSVer }}-{{ .RuntimeSpec.KernelHash }}
  nvidia.com/ofed-driver: ""
name: mofed-{{ ... }}-ds
```

The pods' `app` label carries a **kernel hash** and has **no `-ds` suffix** — `-ds` is only on the DaemonSet name. The hardcoded `ubuntu22.04` is additionally wrong on AKS node pools running Ubuntu 24.04. The command returns an empty list, so the reader waits indefinitely on a step that already succeeded.

Both occurrences now use `nvidia.com/ofed-driver`, which the operator sets on the DaemonSet and its pods regardless of OS or kernel.

### 3. Retired flag

`--skip-gpu-driver-install` was retired after 2025-08-14 in favour of `--gpu-driver` ([Azure/AKS#4925](https://github.com/Azure/AKS/issues/4925)); confirmed absent from Azure CLI 2.90.0. The sibling [AKS setup](https://docs.nvidia.com/dynamo/kubernetes/installation/managed-kubernetes/azure/aks-setup) page already uses the current flag.

## Where should the reviewer start?

`docs/fern/pages/kubernetes/installation/rdma-setup/infiniband-on-azure.mdx` — the `nvidia_peermem` troubleshooting section and the Step 2 selector are the substantive changes.

`spot-vms.mdx` is a one-line fix of the same retired flag; happy to split it out.

## Validation

- `python3 docs/fern/scripts/docs_lint.py` → `Docs lint passed: 0 errors`, zero findings in the changed files.
- `npx fern-api@latest check` → no errors in the changed files; the 26 reported errors are pre-existing, in gitignored `pages/reference/api/{python,rust}` artifacts generated at publish time.
- Internal anchor `#step-5-install-the-gpu-operator-rdma-enabled` resolves.

Checked and confirmed **correct as-is** while reviewing the rest of the page, so left untouched: the kustomize URL resolves via `kubectl kustomize`; `ghcr.io/mellanox/k8s-rdma-shared-dev-plugin:v1.5.3` exists; `driver.rdma.enabled`, `driver.rdma.useHostMofed` and `nfd.enabled` are real chart values; `network-operator v26.1.0` is published; the `AKSInfinibandSupport` feature flag is valid; both ND SKU names resolve; and `mofed-container` is the correct container name.

## Related Issues

None.

## Notes / possible follow-ups (not in this PR)

- The RDMA shared device plugin step predates [DRANET](https://dranet.sigs.k8s.io/docs/user/azure-aks/); DRA went GA in Kubernetes 1.34 and may be worth documenting as an alternative.
- The "`IPC_LOCK` is not required" claim may deserve a second look — Azure's own pod examples do set it. The guide's reasoning is self-consistent given the `ib-node-config` DaemonSet, so I left it alone deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure AKS Spot GPU node pool instructions to use the current GPU driver option.
  * Clarified Azure InfiniBand setup paths for GPU Operator and AKS-managed GPU drivers.
  * Added guidance for `nvidia_peermem` behavior, MOFED pod verification, device plugin manifests, and related troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->