### PR TITLE
feat(router): let workers declare when prefill stays cancellable

### DIFF
--- a/components/src/dynamo/sglang/engine_generate.py
+++ b/components/src/dynamo/sglang/engine_generate.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from typing import Any
 
 from pydantic import TypeAdapter
@@ -91,7 +91,7 @@ def build_native_generate_request(
 
 async def native_generate_stream(
     engine: Any, request: GenerateReqInput
-) -> AsyncIterator[dict[str, Any]]:
+) -> AsyncGenerator[dict[str, Any], None]:
     """Dispatch exactly as SGLang native ``/generate`` handler does."""
     async for response in engine.tokenizer_manager.generate_request(request, None):
         yield {"token_ids": [], "engine_data": {"sglang_response": response}}

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -401,6 +401,13 @@ async def get_runtime_config(
     runtime_config = ModelRuntimeConfig()
     runtime_config.kv_state_endpoint = dynamo_args.kv_state_endpoint
     runtime_config.context_length = server_args.context_length
+    # Safe only because both legs are now cancellable: SGLang's decode leg
+    # parks on the bootstrap room as soon as prefill hands back bootstrap info,
+    # and aborting the prefill while that receiver waits wedges the pair. Both
+    # handlers submit under an ID known before their first output, so a client
+    # disconnect tears down prefill and decode together. The abort is
+    # best-effort -- work already admitted to the scheduler still drains.
+    runtime_config.prefill_cancel_until = "anytime"
     # Multimodal encode workers have no tokenizer manager and delegate
     # generation overflow handling to their downstream backend.
     if engine is not None:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1237,6 +1237,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         request_id_future: asyncio.Future,
         context: Context,
         sglang_request_id: str,
+        sample_count: int = 1,
     ) -> bool:
         """Arm the monitor for *sglang_request_id*, or report the client left.
 
@@ -1262,7 +1263,15 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                 f"{sglang_request_id} for Context: {context.id()}"
             )
             return False
-        request_id_future.set_result(sglang_request_id)
+        # Parallel sampling replaces the submitted ID with one per sample
+        # (GenerateReqInput._normalize_rid expands "rid" into "rid_0", "rid_1",
+        # ...), and abort_request drops an ID it cannot find, so aborting the
+        # submitted one would be a no-op and every sample would keep running.
+        if sample_count > 1:
+            ids = [f"{sglang_request_id}_{i}" for i in range(sample_count)]
+        else:
+            ids = [sglang_request_id]
+        request_id_future.set_result(ids)
         return True
 
     async def _handle_cancellation(
@@ -1319,17 +1328,23 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
                 f"Cancellation or shutdown signal received for SGLang Request ID {sglang_request_id}, Context: {context.id()}"
             )
 
+            # Callers that predate parallel sampling resolve a bare ID.
+            sglang_request_ids = (
+                sglang_request_id
+                if isinstance(sglang_request_id, list)
+                else [sglang_request_id]
+            )
+
             # Call abort_request on the tokenizer_manager through the engine
             if (
                 hasattr(self.engine, "tokenizer_manager")
                 and self.engine.tokenizer_manager
             ):
-                logging.info(
-                    f"Calling SGLang abort_request for Request ID {sglang_request_id}"
-                )
-                self.engine.tokenizer_manager.abort_request(
-                    rid=sglang_request_id, abort_all=False
-                )
+                for rid in sglang_request_ids:
+                    logging.info(f"Calling SGLang abort_request for Request ID {rid}")
+                    self.engine.tokenizer_manager.abort_request(
+                        rid=rid, abort_all=False
+                    )
                 logging.info(f"Aborted Request ID: {context.id()}")
             else:
                 logging.error(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1232,6 +1232,39 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
 
         return bootstrap_host, bootstrap_port
 
+    @staticmethod
+    def _arm_cancellation(
+        request_id_future: asyncio.Future,
+        context: Context,
+        sglang_request_id: str,
+    ) -> bool:
+        """Arm the monitor for *sglang_request_id*, or report the client left.
+
+        SGLang drops an abort for a request it has not registered yet
+        (``TokenizerManager.abort_request`` returns early when the rid is
+        absent from ``rid_to_state``), and registration only happens on the
+        first iteration of the engine's generator, not when it is created.
+        A monitor armed before then can therefore fire into the void and leave
+        the request running with nobody waiting for it.
+
+        The monitor blocks on ``request_id_future``, so resolving it here is
+        what permits an abort. Returning False means the client is already
+        gone and the caller must abandon the stream without starting it: an
+        engine that never saw the request has nothing to abort.
+
+        Callers must not await between a True result and the first iteration
+        of the engine stream, so that registration cannot be overtaken.
+        """
+        # is_stopped() is "not live", so it already covers a killed context.
+        if context.is_stopped():
+            logging.info(
+                f"Client gone before submission, not starting SGLang Request ID "
+                f"{sglang_request_id} for Context: {context.id()}"
+            )
+            return False
+        request_id_future.set_result(sglang_request_id)
+        return True
+
     async def _handle_cancellation(
         self, request_id_future: asyncio.Future, context: Context
     ):

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -4,7 +4,7 @@
 import asyncio
 import logging
 import time
-from typing import Any, AsyncGenerator, AsyncIterator, Dict, List, Mapping, Optional
+from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional
 
 import numpy as np
 import sglang as sgl
@@ -416,7 +416,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         input_param: Dict[str, Any],
         context: Context,
         priority: int | None,
-    ) -> AsyncIterator[Dict[str, Any]]:
+    ) -> AsyncGenerator[Dict[str, Any], None]:
         """Build and dispatch one native SGLang request."""
         raise_if_unextracted_multimodal(request)
         input_ids = input_param.get("input_ids")
@@ -435,7 +435,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         native_request = build_native_generate_request(
             native_payload,
             input_ids=input_ids,
-            fallback_rid=context.trace_id or context.id(),
+            fallback_rid=self._submitted_request_id(context),
             priority=self._priority_kwargs(priority).get("priority"),
             bootstrap_host=bootstrap_info.get("bootstrap_host"),
             bootstrap_port=bootstrap_info.get("bootstrap_port"),
@@ -470,7 +470,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         if self._first_token_source is not None:
             self._first_token_source.bind(context, routing.get("dp_rank"))
         _raise_if_conditional_disagg_bypass(request)
-        trace_id = context.trace_id
+        sglang_request_id = self._submitted_request_id(context)
         input_param = self._get_input_param(request)
         priority = (request.get("routing") or {}).get("priority")
         native_payload = native_generate_payload(request)
@@ -482,7 +482,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 context,
                 priority,
             )
-            async for output in self._process_native_generate_stream(stream, context):
+            native_rid = native_payload.get("rid") or sglang_request_id
+            async for output in self._process_native_generate_stream(
+                stream, context, native_rid
+            ):
                 yield output
             return
 
@@ -540,7 +543,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 bootstrap_port=bootstrap_info["bootstrap_port"],
                 bootstrap_room=bootstrap_info["bootstrap_room"],
                 external_trace_header=trace_header,
-                rid=trace_id,
+                rid=sglang_request_id,
                 data_parallel_rank=dp_rank,
                 lora_path=lora_path,
                 **logprob_kwargs,
@@ -623,7 +626,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 **self._routed_experts_kwargs,
                 **mm_hashes_kwargs,
                 external_trace_header=trace_header,
-                rid=trace_id,
+                rid=sglang_request_id,
                 data_parallel_rank=dp_rank,
                 lora_path=lora_path,
                 **logprob_kwargs,
@@ -648,15 +651,34 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     yield out
 
+    @staticmethod
+    def _submitted_request_id(context: Context) -> str:
+        """The ID this worker's request was submitted to SGLang under.
+
+        Must match what ``generate`` passes as ``rid``; deriving it from the
+        context rather than from a response is the point, since a decode leg
+        whose KV transfer never completes emits no response to read it from.
+        """
+        return context.trace_id or context.id()
+
     async def _process_native_generate_stream(
         self,
-        stream_source: AsyncIterator[Dict[str, Any]],
+        stream_source: AsyncGenerator[Dict[str, Any], None],
         context: Context,
+        sglang_request_id: str | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Forward opaque SGLang chunks while retaining engine cancellation."""
         request_id_future: asyncio.Future[str] = asyncio.Future()
         first_output_seen = False
         async with self._cancellation_monitor(request_id_future, context):
+            # Armed from the submitted ID so a request that never produces
+            # output stays cancellable; falling back to the first response
+            # would leave a decode leg awaiting a KV handoff unabortable.
+            if sglang_request_id and not self._arm_cancellation(
+                request_id_future, context, sglang_request_id
+            ):
+                await stream_source.aclose()
+                return
             async for chunk in stream_source:
                 native_response = chunk["engine_data"]["sglang_response"]
                 if not request_id_future.done():
@@ -674,7 +696,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
     async def _process_token_stream(
         self,
-        stream_source: AsyncIterator[Dict[str, Any]],
+        stream_source: AsyncGenerator[Dict[str, Any], None],
         context: Context,
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
@@ -692,18 +714,26 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         Yields:
             Dict with token_ids and optional finish_reason.
         """
-        # Use Future pattern for request ID - will be set when first response arrives
+        # Armed from the submitted ID so the monitor can abort a request that
+        # never produces output -- which is exactly what a decode leg does when
+        # its prefill was cancelled and the KV handoff never lands.
         request_id_future: asyncio.Future[str] = asyncio.Future()
         first_output_seen = False
+        engine_id_logged = False
         async with self._cancellation_monitor(request_id_future, context):
+            if not self._arm_cancellation(
+                request_id_future, context, self._submitted_request_id(context)
+            ):
+                await stream_source.aclose()
+                return
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
-                # Extract SGLang request ID from the first response and set the future
-                if not request_id_future.done():
-                    sglang_request_id = meta_info.get("id")
-                    if sglang_request_id:
-                        request_id_future.set_result(sglang_request_id)
-                        logging.debug(f"New SGLang Request ID: {sglang_request_id}")
+                if not engine_id_logged:
+                    engine_id_logged = True
+                    logging.debug(
+                        "New SGLang Request ID: "
+                        f"{meta_info.get('id') or self._submitted_request_id(context)}"
+                    )
 
                 # Check cancellation before yielding to allow proper cleanup.
                 # This lets SGLang proceed to the second token generation, which will
@@ -830,18 +860,23 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         """
         request = request or {}
 
-        # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
         first_output_seen = False
+        engine_id_logged = False
         async with self._cancellation_monitor(request_id_future, context):
+            if not self._arm_cancellation(
+                request_id_future, context, self._submitted_request_id(context)
+            ):
+                await stream_source.aclose()
+                return
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
-                # Extract SGLang request ID from the first response and set the future
-                if not request_id_future.done():
-                    sglang_request_id = meta_info.get("id")
-                    if sglang_request_id:
-                        request_id_future.set_result(sglang_request_id)
-                        logging.debug(f"New SGLang Request ID: {sglang_request_id}")
+                if not engine_id_logged:
+                    engine_id_logged = True
+                    logging.debug(
+                        "New SGLang Request ID: "
+                        f"{meta_info.get('id') or self._submitted_request_id(context)}"
+                    )
 
                 # Check cancellation before yielding to allow proper cleanup.
                 # This lets SGLang proceed to the second token generation, which will

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -494,14 +494,23 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 context,
                 priority,
             )
+            # The native payload carries its own sampling params, so the
+            # sample count comes from there rather than from the Dynamo view.
+            native_sampling = native_payload.get("sampling_params")
+            native_samples = 1
+            if isinstance(native_sampling, Mapping):
+                native_samples = native_sampling.get("n") or 1
             async for output in self._process_native_generate_stream(
-                stream, context, native_rid
+                stream, context, native_rid, native_samples
             ):
                 yield output
             return
 
         priority_kwargs = self._priority_kwargs(priority)
         sampling_params = self._build_sampling_params(request)
+        # SGLang expands one submitted ID into one per sample, so the
+        # monitor has to know how many to abort.
+        sample_count = sampling_params.get("n") or 1
         logprob_kwargs = self._build_logprob_kwargs(request)
         metadata_uploader = self._metadata_uploader_from_request(request)
 
@@ -650,6 +659,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
                     metadata_uploader=metadata_uploader,
+                    sample_count=sample_count,
                 ):
                     yield out
             else:
@@ -659,6 +669,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     request=request,
                     user_stop_token_ids=user_stop_token_ids,
                     metadata_uploader=metadata_uploader,
+                    sample_count=sample_count,
                 ):
                     yield out
 
@@ -677,6 +688,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         stream_source: AsyncGenerator[Dict[str, Any], None],
         context: Context,
         sglang_request_id: str | None = None,
+        sample_count: int = 1,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Forward opaque SGLang chunks while retaining engine cancellation."""
         request_id_future: asyncio.Future[str] = asyncio.Future()
@@ -686,7 +698,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # output stays cancellable; falling back to the first response
             # would leave a decode leg awaiting a KV handoff unabortable.
             if sglang_request_id and not self._arm_cancellation(
-                request_id_future, context, sglang_request_id
+                request_id_future, context, sglang_request_id, sample_count
             ):
                 await stream_source.aclose()
                 return
@@ -712,6 +724,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
+        sample_count: int = 1,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
 
@@ -733,7 +746,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         engine_id_logged = False
         async with self._cancellation_monitor(request_id_future, context):
             if not self._arm_cancellation(
-                request_id_future, context, self._submitted_request_id(context)
+                request_id_future,
+                context,
+                self._submitted_request_id(context),
+                sample_count,
             ):
                 await stream_source.aclose()
                 return
@@ -859,6 +875,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         request: Dict[str, Any] | None = None,
         user_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
+        sample_count: int = 1,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process text-based stream output in OpenAI format.
 
@@ -876,7 +893,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         engine_id_logged = False
         async with self._cancellation_monitor(request_id_future, context):
             if not self._arm_cancellation(
-                request_id_future, context, self._submitted_request_id(context)
+                request_id_future,
+                context,
+                self._submitted_request_id(context),
+                sample_count,
             ):
                 await stream_source.aclose()
                 return

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -416,8 +416,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         input_param: Dict[str, Any],
         context: Context,
         priority: int | None,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
-        """Build and dispatch one native SGLang request."""
+    ) -> tuple[str, AsyncGenerator[Dict[str, Any], None]]:
+        """Build and dispatch one native SGLang request.
+
+        Returns the ID the request was submitted under together with its
+        stream, so cancellation aborts exactly what was submitted rather than
+        a separately derived guess at it.
+        """
         raise_if_unextracted_multimodal(request)
         input_ids = input_param.get("input_ids")
         if not isinstance(input_ids, list):
@@ -446,7 +451,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             routed_dp_rank=routing.get("dp_rank"),
             lora_path=self._resolve_lora(request),
         )
-        return native_generate_stream(self.engine, native_request)
+        if not isinstance(native_request.rid, str):
+            # A caller may supply its own rid in the opaque native payload.
+            # abort_request takes a single key, so anything else would leave
+            # the request uncancellable; the prefill handler rejects it too.
+            raise ValueError(
+                "SGLang decode requires a single request ID to remain cancellable"
+            )
+        return native_request.rid, native_generate_stream(self.engine, native_request)
 
     async def generate(
         self, request: Dict[str, Any], context: Context
@@ -475,14 +487,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         priority = (request.get("routing") or {}).get("priority")
         native_payload = native_generate_payload(request)
         if native_payload is not None:
-            stream = self._native_generate_stream(
+            native_rid, stream = self._native_generate_stream(
                 request,
                 native_payload,
                 input_param,
                 context,
                 priority,
             )
-            native_rid = native_payload.get("rid") or sglang_request_id
             async for output in self._process_native_generate_stream(
                 stream, context, native_rid
             ):

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
 from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
@@ -87,6 +86,10 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         validate_disagg_parallel_sampling(request)
         logging.debug(f"New Request ID: {context.id()}")
         trace_id = context.trace_id
+        # Submit under an ID we already know. A prefill worker's first output
+        # only arrives after prefill and the KV handoff, so deriving the ID
+        # from that output leaves the whole prefill uncancellable.
+        sglang_request_id = trace_id or context.id()
 
         if "request" in request:
             # DisaggPreprocessedRequest format
@@ -175,7 +178,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             native_request = build_native_generate_request(
                 native_payload,
                 input_ids=input_ids,
-                fallback_rid=trace_id or context.id(),
+                fallback_rid=sglang_request_id,
                 priority=priority_kwargs.get("priority"),
                 sampling_overrides={"n": 1, "max_new_tokens": 1},
                 bootstrap_host=bootstrap_host,
@@ -185,6 +188,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 routed_dp_rank=dp_rank,
                 lora_path=lora_path,
             )
+            if not isinstance(native_request.rid, str):
+                raise ValueError(
+                    "SGLang prefill requires a single request ID to remain cancellable"
+                )
+            sglang_request_id = native_request.rid
             results = native_generate_stream(self.engine, native_request)
         else:
             results = await self.engine.async_generate(
@@ -197,7 +205,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 bootstrap_port=bootstrap_port,
                 bootstrap_room=bootstrap_room,
                 external_trace_header=trace_header,
-                rid=trace_id,
+                rid=sglang_request_id,
                 data_parallel_rank=dp_rank,
                 lora_path=lora_path,
                 **priority_kwargs,
@@ -218,33 +226,42 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             "disaggregated_params": bootstrap_info,
         }
 
-        task = asyncio.create_task(self._consume_results(results, context))
+        task = asyncio.create_task(
+            self._consume_results(results, sglang_request_id, context)
+        )
         self._consume_tasks.add(task)
         task.add_done_callback(self._consume_tasks.discard)
 
         await task
 
     async def _consume_results(
-        self, results: AsyncIterator[Any], context: Context
+        self,
+        results: AsyncGenerator[Any, None],
+        sglang_request_id: str,
+        context: Context,
     ) -> None:
         """Consume async generator results without processing.
 
         Args:
             results: Async generator from engine.async_generate.
+            sglang_request_id: The ID this request was submitted under.
             context: Context object for cancellation handling.
         """
-        # Use Future pattern for request ID - will be set when first response arrives
+        # Armed from the ID the request was submitted under, not from the first
+        # response: a prefill worker's first output only arrives after prefill
+        # and the KV handoff, so reading the ID from it would leave the whole
+        # prefill uncancellable.
         request_id_future: asyncio.Future[str] = asyncio.Future()
         async with self._cancellation_monitor(request_id_future, context):
-            async for res in results:
-                # Extract SGLang request ID from the first response and set the future
-                if not request_id_future.done():
-                    meta_info = res.get("meta_info", {})
-                    sglang_request_id = meta_info.get("id")
-                    if sglang_request_id:
-                        request_id_future.set_result(sglang_request_id)
-                        logging.debug(f"New Prefill Request ID: {sglang_request_id}")
-
-                # Note: No explicit cancellation checks needed here.
-                # When abort_request is called by the cancellation monitor,
-                # SGLang will terminate this async generator automatically.
+            if not self._arm_cancellation(
+                request_id_future, context, sglang_request_id
+            ):
+                await results.aclose()
+                return
+            # Drained, not inspected: the prefill worker's output is only the
+            # handoff, which the router already read. Keeping the drain running
+            # lets an accepted transfer finish. No explicit cancellation check
+            # is needed -- once the monitor calls abort_request, SGLang ends
+            # this generator itself.
+            async for _ in results:
+                pass

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -63,7 +63,9 @@ async def test_cancellation_monitor_rechecks_shutdown_after_cleanup():
     handler._handle_cancellation = set_shutdown_when_cancelled
     request_id_future = asyncio.get_running_loop().create_future()
     request_id_future.set_result("sglang-request-id")
-    context = SimpleNamespace(id=lambda: "request-id")
+    context = SimpleNamespace(
+        id=lambda: "request-id", trace_id=None, is_stopped=lambda: False
+    )
 
     with pytest.raises(EngineShutdown, match="shut down during token generation"):
         async with handler._cancellation_monitor(request_id_future, context):
@@ -268,7 +270,9 @@ async def test_shutdown_abort_chunk_raises_engine_shutdown(processor_name):
     handler = _new_decode_handler()
     handler.shutdown_event = asyncio.Event()
     handler.shutdown_event.set()
-    context = SimpleNamespace(id=lambda: "request-id")
+    context = SimpleNamespace(
+        id=lambda: "request-id", trace_id=None, is_stopped=lambda: False
+    )
 
     async def stream():
         yield {
@@ -296,6 +300,7 @@ async def test_shutdown_during_abort_metadata_upload_raises_engine_shutdown(
     handler.shutdown_event = asyncio.Event()
     context = SimpleNamespace(
         id=lambda: "request-id",
+        trace_id=None,
         is_stopped=lambda: False,
         notify_first_token=lambda: None,
     )
@@ -663,6 +668,11 @@ async def _stream(items):
 
 
 class _Context:
+    trace_id = "decode-trace"
+
+    def id(self):
+        return "decode-context"
+
     def is_stopped(self):
         return False
 

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
@@ -23,6 +23,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
+    pytest.mark.timeout(30),
 ]
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
@@ -165,3 +165,54 @@ async def test_prefill_not_submitted_when_the_client_has_already_gone():
 
     assert not started, "the engine stream was started for a client already gone"
     assert not aborts, "aborted an rid the engine had never registered"
+
+
+@pytest.mark.asyncio
+async def test_parallel_sampling_aborts_every_sample_id():
+    """Parallel sampling replaces the submitted ID with one per sample.
+
+    ``GenerateReqInput._normalize_rid`` turns a string ``rid`` into
+    ``rid_0``, ``rid_1``, ..., and ``abort_request`` drops an ID it has not
+    registered, so aborting the ID the request was submitted under cancels
+    nothing and every sample keeps running after the client disconnects.
+    """
+    aborts: list[str] = []
+
+    class _TokenizerManager:
+        def abort_request(self, *, rid, abort_all):
+            aborts.append(rid)
+
+    handler = _handler(SimpleNamespace(tokenizer_manager=_TokenizerManager()))
+    context = _CancelableContext("request-id")
+    future: asyncio.Future = asyncio.Future()
+
+    assert handler._arm_cancellation(future, context, "request-id", 3)
+
+    monitor = asyncio.create_task(handler._handle_cancellation(future, context))
+    await asyncio.sleep(0)
+    context.cancel()
+    await asyncio.wait_for(monitor, timeout=2)
+
+    assert aborts == ["request-id_0", "request-id_1", "request-id_2"]
+
+
+@pytest.mark.asyncio
+async def test_single_sample_aborts_the_submitted_id_unchanged():
+    aborts: list[str] = []
+
+    class _TokenizerManager:
+        def abort_request(self, *, rid, abort_all):
+            aborts.append(rid)
+
+    handler = _handler(SimpleNamespace(tokenizer_manager=_TokenizerManager()))
+    context = _CancelableContext("request-id")
+    future: asyncio.Future = asyncio.Future()
+
+    assert handler._arm_cancellation(future, context, "request-id")
+
+    monitor = asyncio.create_task(handler._handle_cancellation(future, context))
+    await asyncio.sleep(0)
+    context.cancel()
+    await asyncio.wait_for(monitor, timeout=2)
+
+    assert aborts == ["request-id"]

--- a/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_prefill_handler.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cancellation behaviour of the disaggregated SGLang prefill handler.
+
+A prefill worker's first output only arrives after prefill and the KV handoff,
+so anything that learns the engine request ID from that output cannot abort
+during prefill at all -- which is the whole window a disconnecting client cares
+about.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
+
+
+class _CancelableContext:
+    """Minimal Context stand-in whose cancellation is level-triggered.
+
+    The real binding is sticky: a request cancelled before the monitor starts
+    still fires. Modelling that matters, otherwise a test can pass against an
+    implementation that would miss an early disconnect in production.
+    """
+
+    def __init__(self, request_id: str, *, trace_id: str | None = None):
+        self._request_id = request_id
+        self.trace_id = trace_id
+        self._cancelled = asyncio.Event()
+
+    def id(self) -> str:
+        return self._request_id
+
+    def trace_headers(self) -> dict[str, str]:
+        return {}
+
+    def async_killed_or_stopped(self) -> asyncio.Task[bool]:
+        return asyncio.create_task(self._cancelled.wait())
+
+    def is_stopped(self) -> bool:
+        return self._cancelled.is_set()
+
+    def is_killed(self) -> bool:
+        return False
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+
+
+def _handler(engine) -> PrefillWorkerHandler:
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = engine
+    handler.shutdown_event = None
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_prefill_submits_under_a_known_request_id():
+    captured: dict = {}
+
+    async def empty_results():
+        if False:  # pragma: no cover - an async generator that yields nothing
+            yield {}
+
+    class _Engine:
+        async def async_generate(self, **kwargs):
+            captured.update(kwargs)
+            return empty_results()
+
+    handler = _handler(_Engine())
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler.enable_trace = False
+    handler._consume_tasks = set()
+    handler._generate_bootstrap_room = lambda: 17
+    handler._get_input_param = lambda request: {"input_ids": request["token_ids"]}
+    handler._resolve_lora = lambda request: None
+    handler._priority_kwargs = lambda priority: {}
+
+    stream = handler.generate(
+        {"request": {"token_ids": [1, 2, 3], "routing": {}}, "sampling_params": {}},
+        _CancelableContext("request-id"),
+    )
+    await anext(stream)
+    await stream.aclose()
+
+    # Without this the handler would submit with rid=None and have nothing to
+    # abort until the engine echoed an ID back after the handoff.
+    assert captured["rid"] == "request-id"
+
+
+@pytest.mark.asyncio
+async def test_prefill_aborts_during_prefill_before_any_output():
+    rid = "request-id"
+    aborts: list[tuple[str, bool]] = []
+    consuming = asyncio.Event()
+    aborted = asyncio.Event()
+
+    class _TokenizerManager:
+        def abort_request(self, *, rid, abort_all):
+            aborts.append((rid, abort_all))
+            aborted.set()
+
+    async def results():
+        # Models a long prefill: the generator is live but produces nothing
+        # until the abort lands.
+        consuming.set()
+        await aborted.wait()
+        return
+        yield {}  # pragma: no cover - unreachable, marks this an async generator
+
+    handler = _handler(SimpleNamespace(tokenizer_manager=_TokenizerManager()))
+    context = _CancelableContext(rid)
+
+    consumer = asyncio.create_task(handler._consume_results(results(), rid, context))
+    await asyncio.wait_for(consuming.wait(), timeout=1)
+
+    context.cancel()
+    await asyncio.wait_for(consumer, timeout=2)
+
+    assert aborts == [(rid, False)]
+
+
+@pytest.mark.asyncio
+async def test_prefill_not_submitted_when_the_client_has_already_gone():
+    """The abort must not be armed before the engine has registered the rid.
+
+    SGLang registers a request on the first iteration of its generator, not
+    when the generator is built, and drops an abort naming an rid it has not
+    registered. Arming the monitor at submission therefore let an already
+    disconnected client produce an abort that went nowhere, followed by a
+    prefill that ran to completion regardless.
+    """
+    started = False
+    aborts: list[str] = []
+
+    class _TokenizerManager:
+        def abort_request(self, *, rid, abort_all):
+            aborts.append(rid)
+
+    async def results():
+        nonlocal started
+        started = True
+        yield {}
+
+    handler = _handler(SimpleNamespace(tokenizer_manager=_TokenizerManager()))
+    context = _CancelableContext("request-id")
+    context.cancel()
+
+    await asyncio.wait_for(
+        handler._consume_results(results(), "request-id", context), timeout=2
+    )
+
+    assert not started, "the engine stream was started for a client already gone"
+    assert not aborts, "aborted an rid the engine had never registered"

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -759,7 +759,7 @@ async def init_llm_worker(
         # transfer with no receiver until kv_transfer_timeout_ms expires, which
         # blocks the context server for far longer than finishing the prefill
         # would have. Before that point the abort is clean.
-        runtime_config.prefill_cancel_until = "pre_commit"
+        runtime_config.prefill_cancel_until = "pre_handoff"
         publish_trtllm_token_budget(runtime_config, config.max_seq_len)
 
         kv_cache_block_size = config.kv_block_size

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -754,6 +754,12 @@ async def init_llm_worker(
         runtime_config = ModelRuntimeConfig()
         runtime_config.kv_state_endpoint = config.kv_state_endpoint
         runtime_config.context_length = config.max_seq_len
+        # A context request that has returned its handoff parameters is holding
+        # KV for the generation server to collect. Aborting it there leaves the
+        # transfer with no receiver until kv_transfer_timeout_ms expires, which
+        # blocks the context server for far longer than finishing the prefill
+        # would have. Before that point the abort is clean.
+        runtime_config.prefill_cancel_until = "pre_commit"
         publish_trtllm_token_budget(runtime_config, config.max_seq_len)
 
         kv_cache_block_size = config.kv_block_size

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -892,6 +892,10 @@ async def register_vllm_model(
     runtime_config.kv_state_endpoint = config.kv_state_endpoint
     if state_agent_enabled:
         runtime_config.kv_event_source_mode = "state_agent_v2"
+    # vLLM aborts a prefill promptly at any point the router can reach, and
+    # releases KV it had already committed for a decode worker that never
+    # collects it, so there is no window the router needs to avoid.
+    runtime_config.prefill_cancel_until = "anytime"
 
     # Add tool/reasoning parsers for decode/aggregated workers. Prefill
     # workers have no OpenAI surface and don't run a parser — key off

--- a/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
@@ -14,8 +14,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.vllm.args import parse_args
-from dynamo.vllm.backend_args import (
+pytest.importorskip("vllm.distributed.kv_events")
+
+from dynamo.vllm.args import parse_args  # noqa: E402
+from dynamo.vllm.backend_args import (  # noqa: E402
     DisaggregationMode,
     DynamoVllmArgGroup,
     DynamoVllmConfig,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -10,6 +10,7 @@ use dynamo_kv_router::protocols::{
 use dynamo_runtime::protocols::EndpointId;
 use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
+use llm_rs::local_model::runtime_config::PrefillCancelUntil;
 use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
 use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
 use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
@@ -103,6 +104,36 @@ impl ModelRuntimeConfig {
     #[setter]
     fn set_total_kv_blocks(&mut self, total_kv_blocks: u64) {
         self.inner.total_kv_blocks = Some(total_kv_blocks);
+    }
+
+    /// Declare how long this worker's prefill request stays cancellable after
+    /// the client disconnects: "anytime", "pre_commit", or "never".
+    ///
+    /// Leaving this unset marks the worker as not supporting prefill
+    /// cancellation, which is the behaviour of every worker that predates it.
+    #[setter]
+    fn set_prefill_cancel_until(&mut self, value: Option<&str>) -> PyResult<()> {
+        self.inner.prefill_cancel_until = match value {
+            None => None,
+            Some("anytime") => Some(PrefillCancelUntil::Anytime),
+            Some("pre_commit") => Some(PrefillCancelUntil::PreCommit),
+            Some("never") => Some(PrefillCancelUntil::Never),
+            Some(other) => {
+                return Err(PyErr::new::<PyException, _>(format!(
+                    "invalid prefill_cancel_until {other:?};                      expected one of: anytime, pre_commit, never"
+                )));
+            }
+        };
+        Ok(())
+    }
+
+    #[getter]
+    fn get_prefill_cancel_until(&self) -> Option<&'static str> {
+        self.inner.prefill_cancel_until.map(|value| match value {
+            PrefillCancelUntil::Anytime => "anytime",
+            PrefillCancelUntil::PreCommit => "pre_commit",
+            PrefillCancelUntil::Never => "never",
+        })
     }
 
     #[setter]

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -107,7 +107,7 @@ impl ModelRuntimeConfig {
     }
 
     /// Declare how long this worker's prefill request stays cancellable after
-    /// the client disconnects: "anytime", "pre_commit", or "never".
+    /// the client disconnects: "anytime", "pre_handoff", or "never".
     ///
     /// Leaving this unset marks the worker as not supporting prefill
     /// cancellation, which is the behaviour of every worker that predates it.
@@ -116,11 +116,11 @@ impl ModelRuntimeConfig {
         self.inner.prefill_cancel_until = match value {
             None => None,
             Some("anytime") => Some(PrefillCancelUntil::Anytime),
-            Some("pre_commit") => Some(PrefillCancelUntil::PreCommit),
+            Some("pre_handoff") => Some(PrefillCancelUntil::PreHandoff),
             Some("never") => Some(PrefillCancelUntil::Never),
             Some(other) => {
                 return Err(PyErr::new::<PyException, _>(format!(
-                    "invalid prefill_cancel_until {other:?};                      expected one of: anytime, pre_commit, never"
+                    "invalid prefill_cancel_until {other:?};                      expected one of: anytime, pre_handoff, never"
                 )));
             }
         };
@@ -131,7 +131,7 @@ impl ModelRuntimeConfig {
     fn get_prefill_cancel_until(&self) -> Option<&'static str> {
         self.inner.prefill_cancel_until.map(|value| match value {
             PrefillCancelUntil::Anytime => "anytime",
-            PrefillCancelUntil::PreCommit => "pre_commit",
+            PrefillCancelUntil::PreHandoff => "pre_handoff",
             PrefillCancelUntil::Never => "never",
         })
     }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -891,6 +891,9 @@ class ModelRuntimeConfig:
     kv_transfer_preferred_weight: float | None
     bootstrap_host: str | None
     bootstrap_port: int | None
+    prefill_cancel_until: str | None
+    """How long a remote prefill stays cancellable: "anytime", "pre_commit",
+    or "never". None means undeclared and is treated as "never"."""
 
     def __init__(self) -> None: ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -892,7 +892,7 @@ class ModelRuntimeConfig:
     bootstrap_host: str | None
     bootstrap_port: int | None
     prefill_cancel_until: str | None
-    """How long a remote prefill stays cancellable: "anytime", "pre_commit",
+    """How long a remote prefill stays cancellable: "anytime", "pre_handoff",
     or "never". None means undeclared and is treated as "never"."""
 
     def __init__(self) -> None: ...

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -39,8 +39,8 @@ use crate::{
         shared_cache::HicacheSharedKvCache,
     },
     local_model::runtime_config::{
-        DisaggregatedEndpoint, ModelRuntimeConfig, VLLM_INFERENCE_V1_GENERATE_CAPABILITY,
-        topology_taint,
+        DisaggregatedEndpoint, ModelRuntimeConfig, PrefillCancelUntil,
+        VLLM_INFERENCE_V1_GENERATE_CAPABILITY, topology_taint,
     },
     lora::state_tracker::LoraWorkerProjection,
     lora::{LoraFilter, LoraRoutingTable, LoraStateTracker, load_estimator::LoadEstimator},
@@ -2539,6 +2539,21 @@ impl ModelManager {
         let rx = self.runtime_configs.get(endpoint_id)?;
         let configs = rx.borrow();
         Some(configs.get(&worker_id)?.data_parallel_size)
+    }
+
+    /// How a specific prefill worker wants client cancellation handled.
+    ///
+    /// Returns the worker's declared policy, or `None` when the worker is
+    /// unknown or predates the capability. Callers must treat `None` as "do not
+    /// cancel", so that a legacy worker keeps its existing behaviour.
+    pub fn get_prefill_cancel_policy(
+        &self,
+        endpoint_id: &EndpointId,
+        worker_id: WorkerId,
+    ) -> Option<PrefillCancelUntil> {
+        let rx = self.runtime_configs.get(endpoint_id)?;
+        let configs = rx.borrow();
+        configs.get(&worker_id)?.prefill_cancel_until
     }
 
     /// Whether any worker on this endpoint advertises a required KV-transfer topology policy.

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -32,7 +32,7 @@ where
         mut prefill_response: ManyOut<Annotated<LLMEngineOutput>>,
         tracker: Option<Arc<RequestTracker>>,
         task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
-        cancel_link: Option<super::PrefillCancelLink>,
+        cancel_link: Option<std::sync::Arc<super::PrefillCancelLink>>,
     ) -> Result<PrefillCompletion, PrefillError> {
         let Some(first_output) = prefill_response.next().await else {
             return Err(PrefillError::PrefillError(
@@ -158,7 +158,7 @@ where
         prefill_stream: ManyOut<Annotated<LLMEngineOutput>>,
         tracker: Option<Arc<RequestTracker>>,
         phase_transition_permit: OwnedSemaphorePermit,
-        cancel_link: Option<super::PrefillCancelLink>,
+        cancel_link: Option<std::sync::Arc<super::PrefillCancelLink>>,
     ) {
         let span = tracing::Span::current();
         let task_guard = self.task_guard.clone();
@@ -231,7 +231,10 @@ mod tests {
 
         let client = Context::new(()).context();
         let prefill = Context::new(()).context();
-        let link = super::super::PrefillCancelLink::new(client.clone(), prefill.clone());
+        let link = Arc::new(super::super::PrefillCancelLink::new(
+            client.clone(),
+            prefill.clone(),
+        ));
 
         PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
             response,

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -32,6 +32,7 @@ where
         mut prefill_response: ManyOut<Annotated<LLMEngineOutput>>,
         tracker: Option<Arc<RequestTracker>>,
         task_guard: Option<dynamo_runtime::engine::EngineContextGuard>,
+        cancel_link: Option<super::PrefillCancelLink>,
     ) -> Result<PrefillCompletion, PrefillError> {
         let Some(first_output) = prefill_response.next().await else {
             return Err(PrefillError::PrefillError(
@@ -87,6 +88,11 @@ where
         } else {
             tokio::spawn(async move {
                 let _task_guard = task_guard;
+                // Held here, not by the caller: this drain is what actually
+                // outlives PrefillRouter::generate on the bootstrap path, so a
+                // client disconnect has to keep reaching the prefill worker for
+                // as long as it runs.
+                let _cancel_link = cancel_link;
                 while prefill_response.next().await.is_some() {}
             });
         }
@@ -152,13 +158,16 @@ where
         prefill_stream: ManyOut<Annotated<LLMEngineOutput>>,
         tracker: Option<Arc<RequestTracker>>,
         phase_transition_permit: OwnedSemaphorePermit,
+        cancel_link: Option<super::PrefillCancelLink>,
     ) {
         let span = tracing::Span::current();
         let task_guard = self.task_guard.clone();
         tokio::spawn(
             async move {
                 drop(phase_transition_permit);
-                match Self::consume_prefill_stream(prefill_stream, tracker, task_guard).await {
+                match Self::consume_prefill_stream(prefill_stream, tracker, task_guard, cancel_link)
+                    .await
+                {
                     Ok(_) => tracing::debug!("Prefill background task completed"),
                     Err(error) => tracing::warn!("Prefill background task error: {error:?}"),
                 }
@@ -174,7 +183,9 @@ mod tests {
     use futures::stream;
     use serde_json::json;
 
-    use dynamo_runtime::pipeline::{ResponseStream, context::Controller};
+    use dynamo_runtime::pipeline::{
+        AsyncEngineContextProvider, Context, ResponseStream, context::Controller,
+    };
 
     use super::*;
 
@@ -192,6 +203,54 @@ mod tests {
             disaggregated_params: Some(json!({})),
             ..Default::default()
         })
+    }
+
+    #[tokio::test]
+    async fn bootstrap_drain_keeps_cancellation_reaching_the_prefill_worker() {
+        // consume_prefill_stream returns as soon as it sees the handoff and
+        // leaves an inner task draining the rest, so that inner task is what
+        // outlives PrefillRouter::generate. A link held by the caller instead
+        // dies milliseconds after dispatch and the prefill silently stops being
+        // cancellable -- which is not visible in end-to-end latency, because the
+        // decode side tears the request down anyway.
+        let first = Annotated::from_data(LLMEngineOutput {
+            disaggregated_params: Some(json!({
+                "bootstrap_host": "127.0.0.1",
+                "bootstrap_port": 1,
+                "bootstrap_room": "test",
+                "ctx_request_id": 42,
+            })),
+            ..Default::default()
+        });
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let stream = stream::iter([first]).chain(stream::once(async move {
+            let _ = release_rx.await;
+            Annotated::from_data(LLMEngineOutput::default())
+        }));
+        let response = ResponseStream::new(Box::pin(stream), Arc::new(Controller::default()));
+
+        let client = Context::new(()).context();
+        let prefill = Context::new(()).context();
+        let link = super::super::PrefillCancelLink::new(client.clone(), prefill.clone());
+
+        PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
+            response,
+            None,
+            None,
+            Some(link),
+        )
+        .await
+        .unwrap();
+
+        // The handoff has been returned and the caller has moved on, but the
+        // drain is still running, so a disconnect now must still reach prefill.
+        client.stop_generating();
+        tokio::time::timeout(std::time::Duration::from_secs(1), prefill.stopped())
+            .await
+            .expect("cancellation stopped reaching prefill once the drain took over");
+        assert!(prefill.is_stopped());
+
+        release_tx.send(()).unwrap();
     }
 
     #[tokio::test]
@@ -220,6 +279,7 @@ mod tests {
             response,
             None,
             Some(task_guard),
+            None,
         )
         .await
         .unwrap();
@@ -242,6 +302,7 @@ mod tests {
             prefill_stream(vec![Annotated::from_error("prefill failed")]),
             Some(tracker.clone()),
             None,
+            None,
         )
         .await;
 
@@ -262,6 +323,7 @@ mod tests {
                 Annotated::from_error("prefill stream failed"),
             ]),
             Some(tracker.clone()),
+            None,
             None,
         )
         .await;
@@ -291,6 +353,7 @@ mod tests {
                 prefill_stream(vec![Annotated::from_data(output)]),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -317,6 +380,7 @@ mod tests {
             prefill_stream(vec![Annotated::from_data(output)]),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -336,6 +400,7 @@ mod tests {
         };
         let result = PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
             prefill_stream(vec![Annotated::from_data(output)]),
+            None,
             None,
             None,
         )
@@ -361,6 +426,7 @@ mod tests {
             };
             let result = PrefillRouter::<DefaultWorkerSelector>::consume_prefill_stream(
                 prefill_stream(vec![Annotated::from_data(output)]),
+                None,
                 None,
                 None,
             )

--- a/lib/llm/src/kv_router/prefill_router/cancellation.rs
+++ b/lib/llm/src/kv_router/prefill_router/cancellation.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Propagating client cancellation into a remote prefill request.
+//!
+//! How long a prefill stays cancellable is a per-worker property, because
+//! engines differ in what happens to KV that was committed for a decode leg
+//! which never collects it: some release it, others hold it until a transfer
+//! timeout expires, which costs far more than letting the prefill finish. The
+//! worker declares its window through
+//! [`PrefillCancelUntil`](crate::local_model::runtime_config::PrefillCancelUntil);
+//! this module owns the machinery that honours it.
+
+use std::sync::Arc;
+
+use dynamo_runtime::engine::AsyncEngineContext;
+
+/// Propagates client cancellation to a remote prefill request, revocably.
+///
+/// `AsyncEngineContext::link_child` is permanent, but the safe window for
+/// cancelling a prefill ends at different points per engine, so this has to be
+/// revocable. `stopped()`/`killed()` are level-triggered, so a client that
+/// disappeared while the request was being constructed still fires here rather
+/// than being missed.
+pub(super) struct PrefillCancelLink {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PrefillCancelLink {
+    pub(super) fn new(
+        parent: Arc<dyn AsyncEngineContext>,
+        child: Arc<dyn AsyncEngineContext>,
+    ) -> Self {
+        let task = tokio::spawn(async move {
+            parent.stopped().await;
+            child.stop();
+        });
+        Self { task }
+    }
+
+    /// Stop propagating. Used once a worker's safe window has closed: past that
+    /// point the KV is committed and aborting the prefill orphans it, which
+    /// costs more than letting the prefill run to completion.
+    pub(super) fn revoke(self) {
+        self.task.abort();
+    }
+}
+
+impl Drop for PrefillCancelLink {
+    fn drop(&mut self) {
+        // The task holds an Arc of the client context, which owns the watch
+        // sender that `stopped()` waits on, so it cannot observe that sender
+        // being dropped -- it would only ever exit on a real cancellation. A
+        // request that completes normally is never cancelled (the HTTP layer
+        // only kills the context on an unexpected close), so without this the
+        // task and both contexts leak once per successful request.
+        self.task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
+
+    #[tokio::test]
+    async fn propagates_client_cancellation_to_prefill() {
+        let parent = Context::new(()).context();
+        let child = Context::new(()).context();
+        let _link = PrefillCancelLink::new(parent.clone(), child.clone());
+
+        parent.stop_generating();
+        tokio::time::timeout(std::time::Duration::from_secs(1), child.stopped())
+            .await
+            .expect("prefill context did not observe client cancellation");
+        assert!(child.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn fires_for_a_client_that_left_before_linking() {
+        // stopped()/killed() are level-triggered, so a client that disconnected
+        // while the prefill request was still being constructed must not be
+        // missed. This is the race an atomic link_child call would lose.
+        let parent = Context::new(()).context();
+        parent.stop_generating();
+
+        let child = Context::new(()).context();
+        let _link = PrefillCancelLink::new(parent, child.clone());
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), child.stopped())
+            .await
+            .expect("prefill context did not observe an already-cancelled client");
+        assert!(child.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn revoked_link_leaves_prefill_running() {
+        // Past the handoff commitment a PreCommit worker must be left alone:
+        // aborting there orphans KV that the decode leg still needs to collect.
+        let parent = Context::new(()).context();
+        let child = Context::new(()).context();
+        PrefillCancelLink::new(parent.clone(), child.clone()).revoke();
+
+        parent.stop_generating();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !child.is_stopped(),
+            "revoked link still cancelled the prefill request"
+        );
+    }
+
+    #[tokio::test]
+    async fn task_exits_when_the_request_finishes_normally() {
+        // A request that completes normally is never stopped or killed: the
+        // HTTP layer only kills the context on an unexpected close
+        // (http/service/disconnect.rs). The propagation task must not outlive
+        // the request anyway, or every successful disaggregated request leaks a
+        // task plus the contexts it holds.
+        let parent_ctx = Context::new(());
+        let parent = parent_ctx.context();
+        let child = Context::new(()).context();
+        let link = PrefillCancelLink::new(parent.clone(), child.clone());
+
+        // The request finishes: the router drops its handle to the link.
+        drop(link);
+        drop(parent_ctx);
+        drop(parent);
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !child.is_stopped(),
+            "a normally-finished request must not cancel its prefill"
+        );
+        assert_eq!(
+            Arc::strong_count(&child),
+            1,
+            "propagation task still holds the prefill context, so it never exited"
+        );
+    }
+}

--- a/lib/llm/src/kv_router/prefill_router/cancellation.rs
+++ b/lib/llm/src/kv_router/prefill_router/cancellation.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_declared_window_is_linked() {
-        for policy in [PrefillCancelUntil::Anytime, PrefillCancelUntil::PreCommit] {
+        for policy in [PrefillCancelUntil::Anytime, PrefillCancelUntil::PreHandoff] {
             let client = Context::new(()).context();
             let prefill = Context::new(()).context();
 
@@ -155,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn revoked_link_leaves_prefill_running() {
-        // Past the handoff commitment a PreCommit worker must be left alone:
+        // Past the handoff commitment a PreHandoff worker must be left alone:
         // aborting there orphans KV that the decode leg still needs to collect.
         let parent = Context::new(()).context();
         let child = Context::new(()).context();

--- a/lib/llm/src/kv_router/prefill_router/cancellation.rs
+++ b/lib/llm/src/kv_router/prefill_router/cancellation.rs
@@ -15,6 +15,24 @@ use std::sync::Arc;
 
 use dynamo_runtime::engine::AsyncEngineContext;
 
+use crate::local_model::runtime_config::PrefillCancelUntil;
+
+/// Link client cancellation to a prefill request, if the worker allows it.
+///
+/// Returns `None` for a worker whose window is [`PrefillCancelUntil::Never`],
+/// which includes every worker that declares nothing. That case must not be
+/// expressed by linking and revoking later: the link fires the moment it
+/// exists, so a client that disconnects during prefill would already have
+/// cancelled a worker that never opted in. The policy therefore has to be known
+/// before anything is linked, which means after worker selection.
+pub(super) fn arm_for(
+    policy: PrefillCancelUntil,
+    client: Arc<dyn AsyncEngineContext>,
+    prefill: Arc<dyn AsyncEngineContext>,
+) -> Option<Arc<PrefillCancelLink>> {
+    (policy != PrefillCancelUntil::Never).then(|| Arc::new(PrefillCancelLink::new(client, prefill)))
+}
+
 /// Propagates client cancellation to a remote prefill request, revocably.
 ///
 /// `AsyncEngineContext::link_child` is permanent, but the safe window for
@@ -41,7 +59,12 @@ impl PrefillCancelLink {
     /// Stop propagating. Used once a worker's safe window has closed: past that
     /// point the KV is committed and aborting the prefill orphans it, which
     /// costs more than letting the prefill run to completion.
-    pub(super) fn revoke(self) {
+    ///
+    /// Takes `&self` because the link is shared: on the bootstrap path a drain
+    /// task holds it so cancellation still reaches the worker while the stream
+    /// is consumed, and revoking has to work from the routing side regardless
+    /// of who else is holding a reference.
+    pub(super) fn revoke(&self) {
         self.task.abort();
     }
 }
@@ -94,6 +117,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_undeclared_worker_is_never_linked() {
+        // A worker that declares nothing is Never, and Never has to mean "no
+        // link at all" rather than "link, then revoke": the link propagates as
+        // soon as it exists, so revoking after the handoff would be far too
+        // late for a client that disconnected during prefill. Getting this
+        // wrong silently makes every legacy worker cancellable.
+        let client = Context::new(()).context();
+        let prefill = Context::new(()).context();
+
+        let link = arm_for(PrefillCancelUntil::Never, client.clone(), prefill.clone());
+        assert!(link.is_none(), "a Never worker must not be linked");
+
+        client.stop_generating();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !prefill.is_stopped(),
+            "an undeclared worker was cancelled during prefill"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_declared_window_is_linked() {
+        for policy in [PrefillCancelUntil::Anytime, PrefillCancelUntil::PreCommit] {
+            let client = Context::new(()).context();
+            let prefill = Context::new(()).context();
+
+            let _link = arm_for(policy, client.clone(), prefill.clone())
+                .unwrap_or_else(|| panic!("{policy:?} declares a window and must be linked"));
+
+            client.stop_generating();
+            tokio::time::timeout(std::time::Duration::from_secs(1), prefill.stopped())
+                .await
+                .unwrap_or_else(|_| panic!("{policy:?} did not propagate cancellation"));
+        }
+    }
+
+    #[tokio::test]
     async fn revoked_link_leaves_prefill_running() {
         // Past the handoff commitment a PreCommit worker must be left alone:
         // aborting there orphans KV that the decode leg still needs to collect.
@@ -121,7 +181,6 @@ mod tests {
         let child = Context::new(()).context();
         let link = PrefillCancelLink::new(parent.clone(), child.clone());
 
-        // The request finishes: the router drops its handle to the link.
         drop(link);
         drop(parent_ctx);
         drop(parent);

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -175,18 +175,6 @@ pub enum PrefillQueryOutcome {
     },
 }
 
-impl PrefillOutcome {
-    /// The prefill worker that served this request, when one was selected.
-    /// `Terminal` completed without a handoff, so it has no worker to consult.
-    fn worker_id(&self) -> Option<u64> {
-        match self {
-            PrefillOutcome::Bootstrap { worker_id, .. }
-            | PrefillOutcome::Completed { worker_id, .. } => Some(*worker_id),
-            PrefillOutcome::Terminal { .. } => None,
-        }
-    }
-}
-
 enum PrefillCompletion {
     Handoff {
         result: PrefillResult,
@@ -474,28 +462,37 @@ where
         let router = &binding.router;
         let endpoint_id = &binding.endpoint_id;
 
-        // Propagate client cancellation into the remote prefill request. Every
-        // engine measured so far tolerates being cancelled during prefill, so
-        // this is linked before the worker is known; the worker's declared
-        // policy can only shorten the window, which is handled after dispatch.
-        let cancel_link = std::sync::Mutex::new(Some(PrefillCancelLink::new(
-            engine_ctx.clone(),
-            prefill_context.context(),
-        )));
+        // Propagating client cancellation into the remote prefill request is a
+        // per-worker decision, so the link cannot be armed before the worker is
+        // known: arming first would make a worker that declares nothing -- and
+        // is therefore treated as never cancellable -- cancellable during
+        // prefill, which is exactly the window this is about. Arming after
+        // selection costs nothing, because `stopped()` is level-triggered: a
+        // client that already went away fires as soon as the link exists.
+        let prefill_ctx = prefill_context.context();
+        let cancel_link: std::sync::Mutex<Option<(PrefillCancelUntil, Arc<PrefillCancelLink>)>> =
+            std::sync::Mutex::new(None);
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {
             let (prepared, prefill_stream) = router
                 .select_and_dispatch_prefill(prefill_context, |request, target| {
                     self.prepare_prefill_dispatch(request, target, endpoint_id)
                 })
                 .await?;
+            let cancel_policy = self
+                .model_manager
+                .get_prefill_cancel_policy(endpoint_id, prepared.worker_id)
+                .unwrap_or(PrefillCancelUntil::Never);
+            let link =
+                cancellation::arm_for(cancel_policy, engine_ctx.clone(), prefill_ctx.clone());
+            if let Some(link) = &link {
+                *cancel_link.lock().unwrap() = Some((cancel_policy, link.clone()));
+            }
             let topology_constraints = prepared.topology_constraints;
             let outcome = if let Some(bootstrap_info) = prepared.bootstrap_info {
-                self.spawn_prefill_task(
-                    prefill_stream,
-                    tracker,
-                    prefill_phase_barrier,
-                    cancel_link.lock().unwrap().take(),
-                );
+                // The drain gets its own reference rather than ownership: a
+                // PreCommit worker still has to be revocable from the routing
+                // side once the handoff parameters come back.
+                self.spawn_prefill_task(prefill_stream, tracker, prefill_phase_barrier, link);
                 PrefillOutcome::Bootstrap {
                     bootstrap_info,
                     worker_id: prepared.worker_id,
@@ -561,18 +558,11 @@ where
         // worker has committed KV for the decode leg to collect. Workers that
         // declare PreCommit stop being cancellable here: aborting past this
         // point orphans that KV until a transfer timeout reclaims it, which
-        // costs far more than letting the prefill finish. A worker that
-        // declares nothing is treated as not cancellable at all, so adding this
-        // capability cannot change an existing deployment's behaviour.
-        let cancel_policy = outcome
-            .worker_id()
-            .and_then(|worker_id| {
-                self.model_manager
-                    .get_prefill_cancel_policy(endpoint_id, worker_id)
-            })
-            .unwrap_or(PrefillCancelUntil::Never);
-        if cancel_policy != PrefillCancelUntil::Anytime
-            && let Some(link) = cancel_link.lock().unwrap().take()
+        // costs far more than letting the prefill finish. Revoking works even
+        // though a drain task may hold the same link, which is why it is shared
+        // rather than moved.
+        if let Some((cancel_policy, link)) = cancel_link.lock().unwrap().take()
+            && cancel_policy != PrefillCancelUntil::Anytime
         {
             link.revoke();
         }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -490,7 +490,7 @@ where
             let topology_constraints = prepared.topology_constraints;
             let outcome = if let Some(bootstrap_info) = prepared.bootstrap_info {
                 // The drain gets its own reference rather than ownership: a
-                // PreCommit worker still has to be revocable from the routing
+                // PreHandoff worker still has to be revocable from the routing
                 // side once the handoff parameters come back.
                 self.spawn_prefill_task(prefill_stream, tracker, prefill_phase_barrier, link);
                 PrefillOutcome::Bootstrap {
@@ -499,11 +499,16 @@ where
                 }
             } else {
                 drop(prefill_phase_barrier);
+                // The link goes to the drain too: when bootstrap is detected
+                // from the first response rather than at dispatch,
+                // consume_prefill_stream spawns a background drain that
+                // outlives this call, and cancellation has to keep reaching
+                // prefill for as long as that runs.
                 let completion = Self::consume_prefill_stream(
                     prefill_stream,
                     tracker,
                     self.task_guard.clone(),
-                    None,
+                    link,
                 )
                 .await?;
 
@@ -556,7 +561,7 @@ where
 
         // The prefill request has now returned its handoff parameters, so the
         // worker has committed KV for the decode leg to collect. Workers that
-        // declare PreCommit stop being cancellable here: aborting past this
+        // declare PreHandoff stop being cancellable here: aborting past this
         // point orphans that KV until a transfer timeout reclaims it, which
         // costs far more than letting the prefill finish. Revoking works even
         // though a drain task may hold the same link, which is why it is shared

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -31,7 +31,7 @@ use futures::stream::{self, StreamExt};
 use crate::{
     discovery::ModelManager,
     kv_router::{RoutingHost, WorkerSelectorFactory},
-    local_model::runtime_config::ModelRuntimeConfig,
+    local_model::runtime_config::{ModelRuntimeConfig, PrefillCancelUntil},
     protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
@@ -43,9 +43,12 @@ use crate::{
 
 mod activation;
 mod admission;
+mod cancellation;
 mod conditional_bypass;
 mod query;
 pub use query::PrefillReservation;
+
+use cancellation::PrefillCancelLink;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -170,6 +173,18 @@ pub enum PrefillQueryOutcome {
     QueueRejected {
         rejection: QueueRejection,
     },
+}
+
+impl PrefillOutcome {
+    /// The prefill worker that served this request, when one was selected.
+    /// `Terminal` completed without a handoff, so it has no worker to consult.
+    fn worker_id(&self) -> Option<u64> {
+        match self {
+            PrefillOutcome::Bootstrap { worker_id, .. }
+            | PrefillOutcome::Completed { worker_id, .. } => Some(*worker_id),
+            PrefillOutcome::Terminal { .. } => None,
+        }
+    }
 }
 
 enum PrefillCompletion {
@@ -458,6 +473,15 @@ where
 
         let router = &binding.router;
         let endpoint_id = &binding.endpoint_id;
+
+        // Propagate client cancellation into the remote prefill request. Every
+        // engine measured so far tolerates being cancelled during prefill, so
+        // this is linked before the worker is known; the worker's declared
+        // policy can only shorten the window, which is handled after dispatch.
+        let cancel_link = std::sync::Mutex::new(Some(PrefillCancelLink::new(
+            engine_ctx.clone(),
+            prefill_context.context(),
+        )));
         let prefill_result: Result<(PrefillOutcome, Option<RoutingConstraints>)> = async {
             let (prepared, prefill_stream) = router
                 .select_and_dispatch_prefill(prefill_context, |request, target| {
@@ -466,16 +490,25 @@ where
                 .await?;
             let topology_constraints = prepared.topology_constraints;
             let outcome = if let Some(bootstrap_info) = prepared.bootstrap_info {
-                self.spawn_prefill_task(prefill_stream, tracker, prefill_phase_barrier);
+                self.spawn_prefill_task(
+                    prefill_stream,
+                    tracker,
+                    prefill_phase_barrier,
+                    cancel_link.lock().unwrap().take(),
+                );
                 PrefillOutcome::Bootstrap {
                     bootstrap_info,
                     worker_id: prepared.worker_id,
                 }
             } else {
                 drop(prefill_phase_barrier);
-                let completion =
-                    Self::consume_prefill_stream(prefill_stream, tracker, self.task_guard.clone())
-                        .await?;
+                let completion = Self::consume_prefill_stream(
+                    prefill_stream,
+                    tracker,
+                    self.task_guard.clone(),
+                    None,
+                )
+                .await?;
 
                 match completion {
                     PrefillCompletion::Handoff {
@@ -503,6 +536,7 @@ where
             Ok((outcome, topology_constraints))
         }
         .await;
+
         let (outcome, topology_constraints) = match prefill_result {
             Ok(result) => result,
             Err(error) => {
@@ -522,6 +556,30 @@ where
                 return Err(error);
             }
         };
+
+        // The prefill request has now returned its handoff parameters, so the
+        // worker has committed KV for the decode leg to collect. Workers that
+        // declare PreCommit stop being cancellable here: aborting past this
+        // point orphans that KV until a transfer timeout reclaims it, which
+        // costs far more than letting the prefill finish. A worker that
+        // declares nothing is treated as not cancellable at all, so adding this
+        // capability cannot change an existing deployment's behaviour.
+        let cancel_policy = outcome
+            .worker_id()
+            .and_then(|worker_id| {
+                self.model_manager
+                    .get_prefill_cancel_policy(endpoint_id, worker_id)
+            })
+            .unwrap_or(PrefillCancelUntil::Never);
+        if cancel_policy != PrefillCancelUntil::Anytime
+            && let Some(link) = cancel_link.lock().unwrap().take()
+        {
+            link.revoke();
+        }
+        // Any link still held here belongs to a path where prefill already
+        // finished, so dropping it ends the propagation task rather than
+        // leaving it waiting on a request that will never be cancelled.
+        drop(cancel_link);
 
         // A prefill request can terminate before the backend establishes a KV
         // handoff (for example, EOS on the one-token context step). Native

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -190,6 +190,25 @@ pub enum ToolCallArgumentsFormat {
     JsonObject,
 }
 
+/// How long a worker's prefill request may be cancelled after the client goes away.
+///
+/// In disaggregated serving the prefill worker commits KV for a decode worker to
+/// collect. Engines differ in whether aborting after that commitment is safe:
+/// some release the blocks, others hold them until a transfer timeout expires,
+/// which costs far more than letting the prefill finish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PrefillCancelUntil {
+    /// Cancellation is safe at any point the router can observe.
+    Anytime,
+    /// Cancellation is safe only until the worker returns its handoff
+    /// parameters. After that the KV is committed and aborting orphans it.
+    PreCommit,
+    /// The worker does not support prefill cancellation.
+    #[default]
+    Never,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Validate)]
 #[validate(schema(function = "validate_model_runtime_config"))]
 /// Runtime-resolved metadata published by a worker after its engine starts.
@@ -289,6 +308,15 @@ pub struct ModelRuntimeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kv_state_endpoint: Option<EndpointId>,
 
+    /// How long this worker's prefill request may be cancelled once the client
+    /// disconnects.
+    ///
+    /// `None` indicates a legacy worker that does not declare this capability;
+    /// consumers must treat it as [`PrefillCancelUntil::Never`] so that adding
+    /// this field cannot change the behaviour of an existing deployment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefill_cancel_until: Option<PrefillCancelUntil>,
+
     /// Mapping of engine-specific runtime configs
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub runtime_data: HashMap<String, serde_json::Value>,
@@ -373,6 +401,7 @@ impl Default for ModelRuntimeConfig {
     fn default() -> Self {
         Self {
             context_length: None,
+            prefill_cancel_until: None,
             total_kv_blocks: None,
             max_num_seqs: None,
             max_num_batched_tokens: None,

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -203,7 +203,7 @@ pub enum PrefillCancelUntil {
     Anytime,
     /// Cancellation is safe only until the worker returns its handoff
     /// parameters. After that the KV is committed and aborting orphans it.
-    PreCommit,
+    PreHandoff,
     /// The worker does not support prefill cancellation.
     #[default]
     Never,

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -17,9 +17,11 @@ import pytest
 
 from tests.fault_tolerance.cancellation.utils import (
     DynamoFrontendProcess,
+    poll_for_any_pattern,
     poll_for_pattern,
     read_streaming_responses,
     send_cancellable_request,
+    send_completion_request,
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
@@ -29,6 +31,10 @@ from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
 logger = logging.getLogger(__name__)
+
+# Small enough that the request stays inside prefill for the whole test:
+# a long prompt with few output tokens is dominated by the prefill phase.
+PREFILL_CANCELLATION_MAX_TOKENS = 128
 
 pytestmark = [
     pytest.mark.fault_tolerance,
@@ -418,4 +424,143 @@ def test_request_cancellation_sglang_decode_cancel(
                     worker_system_port=prefill_worker.system_port,
                     expected_count=0,
                     component="prefill",
+                )
+
+
+@pytest.mark.timeout(300)  # 3x average
+@pytest.mark.gpu_2
+@pytest.mark.pre_merge
+def test_request_cancellation_sglang_prefill_cancel(
+    request, runtime_services_dynamic_ports, predownload_models
+):
+    """
+    End-to-end test for request cancellation during the prefill phase.
+
+    Both legs must be torn down together. SGLang dispatches decode as soon as
+    prefill hands back bootstrap info, so the decode worker is already parked on
+    the bootstrap room waiting for a KV transfer. Aborting only the prefill leg
+    leaves that receiver waiting on a sender that will never arrive, which
+    wedges the pair: measured directly, a following request did not complete
+    within 240s and the workers stopped accepting connections while still
+    reporting healthy.
+
+    That failure is silent in every signal except latency, so this test asserts
+    the abort reaches *both* workers and that the deployment still serves
+    afterwards. A health check alone would not catch it.
+
+    Note: This test requires 2 GPUs to run decode and prefill workers on
+    separate GPUs.
+    """
+
+    decode_system_port = allocate_port(DynamoPortRange.SERVE.value)
+    request.addfinalizer(lambda port=decode_system_port: deallocate_port(port))
+    prefill_system_port = allocate_port(DynamoPortRange.SERVE.value)
+    request.addfinalizer(lambda port=prefill_system_port: deallocate_port(port))
+
+    with DynamoFrontendProcess(request) as frontend:
+        logger.info("Frontend started successfully")
+
+        with DynamoWorkerProcess(
+            request,
+            system_port=decode_system_port,
+            frontend_port=frontend.frontend_port,
+            mode="decode",
+        ) as decode_worker:
+            logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
+
+            with DynamoWorkerProcess(
+                request,
+                system_port=prefill_system_port,
+                frontend_port=frontend.frontend_port,
+                mode="prefill",
+            ) as prefill_worker:
+                logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
+
+                # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
+                time.sleep(2)
+
+                logger.info(
+                    "Testing completion request cancellation during prefill phase..."
+                )
+
+                # A long prompt with max_tokens=1 keeps the request inside
+                # prefill long enough for the cancel to land before any token.
+                cancellable_req = send_cancellable_request(
+                    frontend.frontend_port,
+                    "completion",
+                    use_long_prompt=True,
+                    max_tokens=PREFILL_CANCELLATION_MAX_TOKENS,
+                )
+
+                request_id, prefill_log_offset = poll_for_pattern(
+                    process=prefill_worker,
+                    pattern="New Request ID: ",
+                    match_type="contains",
+                    cancellable_request=cancellable_req,
+                )
+
+                cancellable_req.cancel()
+                logger.info(f"Cancelled request ID: {request_id} during prefill")
+
+                # The prefill leg must actually be aborted, not merely detached.
+                poll_for_pattern(
+                    process=prefill_worker,
+                    pattern="Calling SGLang abort_request",
+                    log_offset=prefill_log_offset,
+                    match_type="contains",
+                    max_wait_ms=15000,
+                    poll_interval_ms=50,
+                )
+
+                # And so must the decode leg, whose receiver would otherwise be
+                # left parked on the bootstrap room. This is the assertion that
+                # distinguishes a safe cancellation from the wedge.
+                #
+                # Two outcomes are both correct, and which one happens is a
+                # race: the decode leg is dispatched as soon as prefill returns
+                # bootstrap info, so the cancel either reaches a decode request
+                # already submitted to the engine (abort) or arrives first and
+                # the request is never submitted at all. Requiring the abort
+                # specifically would test the race, not the property.
+                poll_for_any_pattern(
+                    process=decode_worker,
+                    patterns=[
+                        "Calling SGLang abort_request",
+                        "Client gone before submission",
+                    ],
+                    max_wait_ms=15000,
+                    poll_interval_ms=50,
+                )
+
+                logger.info(
+                    "Completion request cancellation during prefill phase "
+                    "detected on both workers"
+                )
+
+                # The wedge showed up as unbounded latency, not as an error, so
+                # check the pair still serves rather than just that it is up.
+                for attempt in range(3):
+                    followup = send_completion_request(
+                        prompt="hello",
+                        max_tokens=4,
+                        frontend_port=frontend.frontend_port,
+                    )
+                    followup.wait()
+                    response = followup.get_response()
+                    assert response.status_code == 200, (
+                        f"Request {attempt} after prefill cancellation failed "
+                        f"with HTTP {response.status_code}; the prefill/decode "
+                        "pair appears wedged."
+                    )
+
+                verify_frontend_cancellation_metrics(
+                    frontend_port=frontend.frontend_port,
+                    request_type="completion",
+                    expected_count=1,
+                )
+                verify_runtime_cancellation_metrics(
+                    worker_system_port=prefill_worker.system_port,
+                    expected_count=1,
+                    component="prefill",
+                    max_wait_ms=15000,
                 )

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -30,6 +30,13 @@ from tests.utils.managed_process import ManagedProcess, check_health_ready
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
+# A stranded KV transfer does not fail loudly: the deployment keeps answering,
+# just late, and TRT-LLM only reclaims at kv_transfer_timeout_ms (60s default).
+# Bounding the follow-up below that turns "eventually returned 200" into a
+# failure, which is the symptom a wedge actually produces.
+FOLLOWUP_TIMEOUT_S = 30.0
+
+
 logger = logging.getLogger(__name__)
 
 # Small enough that the request stays inside prefill for the whole test:
@@ -496,6 +503,8 @@ def test_request_cancellation_sglang_prefill_cancel(
                     process=prefill_worker,
                     pattern="New Request ID: ",
                     match_type="contains",
+                    max_wait_ms=10000,
+                    poll_interval_ms=50,
                     cancellable_request=cancellable_req,
                 )
 
@@ -544,6 +553,7 @@ def test_request_cancellation_sglang_prefill_cancel(
                         prompt="hello",
                         max_tokens=4,
                         frontend_port=frontend.frontend_port,
+                        timeout_s=FOLLOWUP_TIMEOUT_S,
                     )
                     followup.wait()
                     response = followup.get_response()

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -365,7 +365,7 @@ def test_request_cancellation_trtllm_prefill_cancel(
     the system properly handles the cancellation and cleans up resources on the prefill worker.
     Since the request is cancelled before prefill completes, the decode worker never receives it.
 
-    TRT-LLM declares ``prefill_cancel_until="pre_commit"``: a context request is
+    TRT-LLM declares ``prefill_cancel_until="pre_handoff"``: a context request is
     only cancellable until it returns its handoff parameters. Past that point
     the KV is committed for the generation server and aborting would orphan it
     until kv_transfer_timeout_ms (60s by default) reclaims it, which is why this

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -22,6 +22,7 @@ from tests.fault_tolerance.cancellation.utils import (
     poll_for_pattern,
     read_streaming_responses,
     send_cancellable_request,
+    send_completion_request,
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
@@ -346,7 +347,6 @@ def test_request_cancellation_trtllm_decode_cancel(
                 )
 
 
-@pytest.mark.skip(reason="TRT-LLM prefill cancellation is disabled due to reliability")
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_prefill_cancel(
     request, runtime_services_dynamic_ports, predownload_models
@@ -357,6 +357,12 @@ def test_request_cancellation_trtllm_prefill_cancel(
     This test verifies that when a request is cancelled by the client during the prefill phase,
     the system properly handles the cancellation and cleans up resources on the prefill worker.
     Since the request is cancelled before prefill completes, the decode worker never receives it.
+
+    TRT-LLM declares ``prefill_cancel_until="pre_commit"``: a context request is
+    only cancellable until it returns its handoff parameters. Past that point
+    the KV is committed for the generation server and aborting would orphan it
+    until kv_transfer_timeout_ms (60s by default) reclaims it, which is why this
+    test also checks the deployment still serves promptly afterwards.
 
     Timing (Last Run: 2025-12-09): ~115s total (2 workers at 45% GPU each)
     - Engine initialization: ~92s (frontend: 2s, prefill worker: 45s, decode worker: 45s sequential)
@@ -453,6 +459,22 @@ def test_request_cancellation_trtllm_prefill_cancel(
                     worker_system_port=prefill_worker.system_port,
                     expected_count=1,
                     component="prefill",
+                )
+
+                # A stranded KV transfer does not fail loudly -- it holds the
+                # context server until the transceiver timeout expires, so it
+                # shows up as latency on whatever runs next rather than as an
+                # error. Check that directly.
+                followup = send_completion_request(
+                    prompt="hello",
+                    max_tokens=4,
+                    frontend_port=frontend.frontend_port,
+                )
+                followup.wait()
+                response = followup.get_response()
+                assert response.status_code == 200, (
+                    f"Request after prefill cancellation failed with HTTP "
+                    f"{response.status_code}"
                 )
 
 

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -31,6 +31,13 @@ from tests.utils.managed_process import ManagedProcess, check_health_ready
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
+# A stranded KV transfer does not fail loudly: the deployment keeps answering,
+# just late, and TRT-LLM only reclaims at kv_transfer_timeout_ms (60s default).
+# Bounding the follow-up below that turns "eventually returned 200" into a
+# failure, which is the symptom a wedge actually produces.
+FOLLOWUP_TIMEOUT_S = 30.0
+
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -469,6 +476,7 @@ def test_request_cancellation_trtllm_prefill_cancel(
                     prompt="hello",
                     max_tokens=4,
                     frontend_port=frontend.frontend_port,
+                    timeout_s=FOLLOWUP_TIMEOUT_S,
                 )
                 followup.wait()
                 response = followup.get_response()

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -36,6 +36,13 @@ from tests.utils.managed_process import ManagedProcess, check_health_ready
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
 
+# A stranded KV transfer does not fail loudly: the deployment keeps answering,
+# just late, and TRT-LLM only reclaims at kv_transfer_timeout_ms (60s default).
+# Bounding the follow-up below that turns "eventually returned 200" into a
+# failure, which is the symptom a wedge actually produces.
+FOLLOWUP_TIMEOUT_S = 30.0
+
+
 logger = logging.getLogger(__name__)
 
 CANCELLATION_MAX_TOKENS = 2048
@@ -471,14 +478,11 @@ def test_request_cancellation_vllm_prefill_cancel(
     A client that disconnects before the first token must stop the prefill
     worker, rather than leaving it to finish work nobody is waiting for.
 
-    This inverts the contract this test previously asserted (PR #7489), which
-    let the prefill run to completion to avoid leaking KV on a torn-down NIXL
-    transfer. That trade-off no longer applies to vLLM: it aborts promptly and
-    releases KV that was already committed for a decode worker which never
-    collects it, so the worker declares ``prefill_cancel_until="anytime"`` and
-    the router propagates cancellation to the prefill request. The leak the old
-    contract guarded against is still checked below, via the post-cancel
-    requests.
+    vLLM declares ``prefill_cancel_until="anytime"`` because an aborted prefill
+    frees its blocks in the same scheduler step and never arms the KV lease that
+    a normal completion would, so cancelling cannot strand a transfer. The
+    post-cancel requests below guard that: stranded KV shows up as latency, not
+    as an error, so a bounded follow-up is what would catch it.
 
     Timing (Last Run: 2026-08-28): ~108s [nats] / ~123s [tcp] (requires 2 GPUs)
     - Engine initialization: ~23s (decode + prefill workers)
@@ -564,6 +568,7 @@ def test_request_cancellation_vllm_prefill_cancel(
                         prompt="hello",
                         max_tokens=4,
                         frontend_port=frontend.frontend_port,
+                        timeout_s=FOLLOWUP_TIMEOUT_S,
                     )
                     followup.wait()
                     response = followup.get_response()

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -20,8 +20,8 @@ from tests.fault_tolerance.cancellation.utils import (
     DynamoFrontendProcess,
     poll_for_pattern,
     read_streaming_responses,
-    read_worker_generate_summary,
     send_cancellable_request,
+    send_completion_request,
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
@@ -453,8 +453,9 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
                 verify_runtime_cancellation_metrics(
                     worker_system_port=prefill_worker.system_port,
-                    expected_count=0,
+                    expected_count=1,
                     component="prefill",
+                    max_wait_ms=15000,
                 )
 
 
@@ -467,13 +468,17 @@ def test_request_cancellation_vllm_prefill_cancel(
     """
     End-to-end test for request cancellation during prefill phase.
 
-    This test verifies that when a client disconnects during the prefill
-    phase in a disaggregated setup, the prefill worker still runs the
-    request to completion so KV blocks are released via the normal path
-    (rather than leaking on a torn-down NIXL transfer), and decode routing
-    still proceeds so the KV-transfer-complete guard can free the blocks.
+    A client that disconnects before the first token must stop the prefill
+    worker, rather than leaving it to finish work nobody is waiting for.
 
-    Reference: PR ai-dynamo/dynamo#7489
+    This inverts the contract this test previously asserted (PR #7489), which
+    let the prefill run to completion to avoid leaking KV on a torn-down NIXL
+    transfer. That trade-off no longer applies to vLLM: it aborts promptly and
+    releases KV that was already committed for a decode worker which never
+    collects it, so the worker declares ``prefill_cancel_until="anytime"`` and
+    the router propagates cancellation to the prefill request. The leak the old
+    contract guarded against is still checked below, via the post-cancel
+    requests.
 
     Timing (Last Run: 2026-08-28): ~108s [nats] / ~123s [tcp] (requires 2 GPUs)
     - Engine initialization: ~23s (decode + prefill workers)
@@ -519,10 +524,12 @@ def test_request_cancellation_vllm_prefill_cancel(
                 cancellable_req.cancel()
                 logger.info(f"Cancelled request ID: {request_id} during prefill")
 
-                # Prefill must complete despite client disconnect.
+                # The prefill worker must be told to stop, not run to
+                # completion. This is the log line the abort monitor emits
+                # before calling engine.abort().
                 poll_for_pattern(
                     process=prefill_worker,
-                    pattern=f"Prefill completed for request {request_id}",
+                    pattern=f"Aborting Prefill Request ID: {request_id}",
                     log_offset=prefill_log_offset,
                     match_type="contains",
                     max_wait_ms=15000,
@@ -548,23 +555,23 @@ def test_request_cancellation_vllm_prefill_cancel(
                     max_wait_ms=5000,
                     poll_interval_ms=100,
                 )
-                summary = read_worker_generate_summary(
-                    worker_system_port=prefill_worker.system_port,
-                    component="prefill",
-                )
-                logger.info(f"Prefill generate summary: {summary}")
-                assert summary["duration_count"] == 1.0, (
-                    f"Prefill histogram count={summary['duration_count']} — "
-                    "request was aborted mid-flight."
-                )
-                assert summary["duration_sum"] >= 0.1, (
-                    f"Prefill generate took only {summary['duration_sum']}s — "
-                    "suspiciously short."
-                )
-                assert summary["response_bytes"] > 0, (
-                    "Prefill sent 0 response bytes — handler exited before "
-                    "yielding KV-transfer params."
-                )
+                # The worker must still be able to serve after the abort. This
+                # is what the old "let prefill finish" contract was protecting:
+                # if aborting stranded the KV it had committed for a decode
+                # worker, these would slow down or fail.
+                for attempt in range(3):
+                    followup = send_completion_request(
+                        prompt="hello",
+                        max_tokens=4,
+                        frontend_port=frontend.frontend_port,
+                    )
+                    followup.wait()
+                    response = followup.get_response()
+                    assert response.status_code == 200, (
+                        f"Request {attempt} after prefill cancellation failed "
+                        f"with HTTP {response.status_code}; aborting prefill "
+                        "appears to have damaged the deployment."
+                    )
 
                 # Verify cancellation metrics. The decode-side counter
                 # increments in tcp/client.rs:347 only after the reader loop

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -458,11 +458,13 @@ def test_request_cancellation_vllm_decode_cancel(
                     expected_count=1,
                     max_wait_ms=15000,
                 )
+                # The prefill finished before decode began, so the router has
+                # already dropped its cancellation link: a disconnect during
+                # decode reaches only the decode worker.
                 verify_runtime_cancellation_metrics(
                     worker_system_port=prefill_worker.system_port,
-                    expected_count=1,
+                    expected_count=0,
                     component="prefill",
-                    max_wait_ms=15000,
                 )
 
 
@@ -589,13 +591,16 @@ def test_request_cancellation_vllm_prefill_cancel(
                     request_type="completion",
                     expected_count=1,
                 )
+                # This test cancels before a handoff exists, so the prefill is
+                # what gets cancelled. Decode is never dispatched, which is the
+                # difference from the decode-cancel test above.
                 verify_runtime_cancellation_metrics(
-                    worker_system_port=decode_worker.system_port,
+                    worker_system_port=prefill_worker.system_port,
                     expected_count=1,
+                    component="prefill",
                     max_wait_ms=15000,
                 )
                 verify_runtime_cancellation_metrics(
-                    worker_system_port=prefill_worker.system_port,
+                    worker_system_port=decode_worker.system_port,
                     expected_count=0,
-                    component="prefill",
                 )

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -179,6 +179,25 @@ class CancellableRequest:
                 f"HTTP {status_code}: {response_body}"
             )
 
+    def wait(self, timeout_s: float = 60.0) -> None:
+        """Block until the request has finished.
+
+        ``post`` runs on a background thread, so a non-streaming caller has
+        nothing to read until it finishes; ``get_response`` would return None.
+        A streaming caller does not need this, since requests populates the
+        response once the headers arrive.
+
+        Raises:
+            AssertionError: if the request has not finished within timeout_s,
+                which is what a wedged worker looks like from the client side.
+        """
+        thread = self._request_thread
+        if thread is None:
+            raise RuntimeError("wait() called before post()")
+        thread.join(timeout_s)
+        if thread.is_alive():
+            raise AssertionError(f"Request did not complete within {timeout_s}s")
+
     def get_response(self):
         """Get the response or raise exception if there was one"""
         if self._cancelled:
@@ -578,6 +597,42 @@ def strip_ansi_codes(text: str) -> str:
     """Remove ANSI color codes from text"""
     ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
     return ansi_escape.sub("", text)
+
+
+def poll_for_any_pattern(
+    process: ManagedProcess,
+    patterns: list[str],
+    log_offset: int = 0,
+    max_wait_ms: int = 500,
+    poll_interval_ms: int = 5,
+) -> tuple[str, int]:
+    """Poll a process log until any one of *patterns* appears.
+
+    For assertions where several distinct log lines are all correct outcomes,
+    so requiring one specific line would make the test depend on a race rather
+    than on the property under test.
+
+    Returns:
+        Tuple of (matched pattern, new log offset).
+    """
+    max_iterations = max_wait_ms // poll_interval_ms
+    current_offset = log_offset
+
+    for iteration in range(max_iterations):
+        log_content = read_log_content(process.log_path)
+        for line in log_content[current_offset:].split("\n"):
+            clean_line = strip_ansi_codes(line).strip()
+            for pattern in patterns:
+                if pattern in clean_line:
+                    logger.info(f"Found pattern '{pattern}' at iteration {iteration}")
+                    return pattern, len(log_content)
+        current_offset = len(log_content)
+        time.sleep(poll_interval_ms / 1000.0)
+
+    raise AssertionError(
+        f"Failed to find any of {patterns} after {max_iterations} "
+        f"iterations ({max_wait_ms}ms)"
+    )
 
 
 def poll_for_pattern(


### PR DESCRIPTION
## Summary

A client that disconnects before the first token did not stop the remote prefill
request. `PrefillRouter` builds it with `Context::with_id_and_metadata`, which shares
no cancellation state with the client context, so the prefill worker kept running
work nobody was waiting for. Measured on 1.4.1 with a disconnect before first token
and a short request queued behind it: vLLM blocked 54.66s, TRT-LLM 12.90s, SGLang
11.34s, with zero aborts reaching any engine even though the frontend detected every
disconnect.

How long a prefill stays *safely* cancellable turns out to be a per-engine property,
so this declares it rather than assuming it. In disaggregated serving the prefill
worker commits KV for a decode worker to collect. vLLM releases those blocks when
nobody collects; TRT-LLM holds them until `kv_transfer_timeout_ms` expires. Cancelling
a TRT-LLM context request *after* it has returned its handoff parameters therefore
costs far more than letting the prefill finish — measured at 17 stranded transfers and
a following request that timed out at 240s, versus about 13s of prefill saved.

`ModelRuntimeConfig` gains `prefill_cancel_until` with three values:

| Value | Meaning | Declared by |
|---|---|---|
| `anytime` | cancellable through the whole prefill | vLLM, SGLang |
| `pre_handoff` | cancellable until the handoff params are returned | TRT-LLM |
| `never` | never cancelled remotely | anything undeclared |

`None` means a worker that predates the capability and is treated as `never`, so this
cannot change the behaviour of an existing deployment. The router links the client
context to the prefill request through a **revocable** task rather than `link_child`,
which is permanent, and revokes it at the handoff boundary for `pre_handoff` workers.
The link is looked up through `ModelManager` rather than the KV router, so it also
applies to non-KV prefill routing.

### SGLang needed a handler fix too

Both SGLang handlers learned their engine request ID from `meta_info` on the first
response. A prefill worker's first response only arrives *after* prefill and the KV
handoff, and a decode leg whose handoff never lands produces no response at all — so
in both cases the cancellation monitor waited for an ID that never came.

Both now submit under an ID known up front. Arming the monitor with it has to wait for
one thing: `TokenizerManager.abort_request` silently drops an abort naming an rid not
yet in `rid_to_state`, and the rid is registered on the *first iteration* of the
engine's generator, not when the generator is built. Arming at submission let an
already-disconnected client fire an abort into the void while the request ran to
completion anyway. The monitor is now armed at the point the handler commits to
iterating, with no `await` in between, so registration cannot be overtaken; when the
client is already gone the generator is closed unstarted, and an engine that never saw
the request has nothing to abort. (SGLang's own `/abort_request` endpoint papers over
the same race with a fixed two-second sleep.)

**Fixing only the prefill leg is worse than fixing neither.** SGLang dispatches decode
as soon as prefill returns bootstrap info, so the decode worker is already parked on
the bootstrap room; aborting just the sender leaves that receiver waiting on a handoff
that will never arrive. Measured with prefill cancelled alone, a following request did
not complete within 240s and only 2 of 5 later requests succeeded — while the frontend
and both workers kept reporting healthy.

## Validation

Engine-native behaviour was characterised first, on the upstream engine containers, to
decide what each backend may safely declare. Dynamo end-to-end runs then used a probe
that fires N long requests, disconnects before first token, and measures how long a
following short request is blocked against how much prefill was still owed — a
head-of-line-blocking metric that is engine-agnostic.

| Backend | Policy | Blocking | Prefill owed if ignored | Recovery |
|---|---|---|---|---|
| vLLM | `anytime` | 0.009s | 46.48s | 5/5 |
| SGLang | `anytime` | 0.005s | 10.07s | 5/5 |
| TRT-LLM | `pre_handoff` | 0.010s | 12.94s | 5/5 |

For SGLang the run also confirms the mechanism directly: exactly one `abort_request`
per cancelled request on **both** workers (9 and 9), matching bootstrap-room aborts on
each side, and zero `rid_to_state` misses. TRT-LLM aborted 25 of 26 prefills with no
stranded transfers, and the generation server only ever saw the uncancelled requests.

- 40 Rust tests in `dynamo-llm`, including four for the revocable link and a regression
  test that the bootstrap drain keeps cancellation reaching the prefill worker
- Full SGLang unit suite: 502 passed, 1 skipped
- The new race regression test is mutation-checked: restoring the arm-at-submission
  ordering fails it
- `cargo fmt`, `cargo clippy -p dynamo-llm`, and pre-commit hooks clean on changed files

## Notes for reviewers

- **`kv_transfer_timeout_ms` is a backstop here, not the mitigation.** Measured on TRT-LLM
  1.3.0rc22: aborting a context request *after* it has committed its KV is a no-op — the blocks are
  reclaimed only when `kv_transfer_timeout_ms` expires, identical to simply abandoning the request
  (21.03s vs 21.02s at a 20000ms setting; 6.02s vs 6.02s at 5000ms), while `abort()` returns in
  0.0001s. Aborting *before* commit works normally (0.01s, 3/3).
  Dynamo does not reach that state. It deliberately never cancels decode routing when the client
  disconnects (`lib/llm/src/kv_router/prefill_router/mod.rs:594-605` — "Blocking decode here
  orphans the transfer (no receiver) and leaks KV blocks permanently"), and the TRT-LLM decode
  handler defers its abort until the first token, i.e. until the transfer has completed
  (`components/src/dynamo/trtllm/request_handlers/handler_base.py:188-225`, `:1317-1323`). A
  receiver therefore always attaches and collects, and the context-side KV is freed by the normal
  path. Verified end to end, 6/6 runs with the disconnect landing 0.25s after the handoff marker:
  decode was dispatched in 2-3ms, the transfer completed 0.76-0.82s later against a 20000ms budget,
  and **zero** `"exceeded configured timeout"` lines appeared across 51 prefill requests. A following
  13822-token request was admitted in ~1.01s against a 0.75s no-target baseline — the ~0.26s delta
  is the legitimate wait for collection, roughly 80x below what a `kv_transfer_timeout_ms` pin would
  cost, and the instrument cleanly separates 0.52 / 0.75 / 1.01s so a 20s pin would be unmissable.
  A control disconnecting *during* prefill aborts the context worker 3/3 and never dispatches
  decode, so the absence of an abort in the target runs is the revoke working rather than a broken
  cancel path.
  So the transfer timeout bounds the residual case where that guarantee fails — decode worker dies,
  dispatch fails — rather than the ordinary cancellation path. Keeping it bounded is still sensible;
  the 60s default is generous for most deployments.

- **`tests/fault_tolerance/cancellation/test_vllm.py` inverts the contract set by #7489**, which let
  the prefill run to completion to avoid leaking KV on a torn-down NIXL transfer. That PR's own
  phase table calls phase 1 (prefill computing) cancel-safe and only phase 2 (KV transfer) unsafe;
  it gave up phase 1 because there was no way to tell the phases apart. `pre_handoff` is that
  mechanism, so TRT-LLM keeps the phase-2 protection unchanged.

- **vLLM's abort/lease disjointness is structural; its transfer safety is not.** The structural part
  is solid: block IDs are advertised to a peer only through the completed branch of
  `request_finished`, the abort branch returns `(False, None)` without `kv_transfer_params`
  (`nixl/pull_scheduler.py:234-243` vs `:277-291`), lease-arming and abort are mutually exclusive
  sides of one status test, and the worker asserts it (`nixl/pull_worker.py:101-104`, "We should
  never get an abort after setting an expiry timer"). An abort during prefill frees blocks in the
  same scheduler step; an abort after completion is a no-op.
  It is worth being accurate about the rest, though: when the decode side never collects, vLLM also
  pins the producer's blocks — for `kv_lease_duration`, default **30s**
  (`nixl/base_scheduler.py:75-79`), heartbeat-extendable. And nothing guards a peer's in-flight read
  against the producer reallocating that memory: no per-request registration pinning, no refcounts,
  no generation counters; the lease sweep frees unconditionally
  (`nixl/base_worker.py:2647-2665`) and a late notification is only detected after the fact
  ("Potentially invalid KV blocks for unrecognized request %s were retrieved by a decode worker",
  `nixl/pull_worker.py:570-578`). A decode leg stuck in `WAITING_FOR_REMOTE_KVS` has no
  scheduler-level timeout at all. None of this is made worse by this PR — it is the backdrop the
  `anytime` declaration sits against.

- **SGLang `anytime`: what was measured, and the envelope it holds in.** Cancelling during prefill
  with both legs aborted is clean — 0.005s head-of-line blocking against 10.95s of prefill still
  owed, matching bootstrap-room aborts on each worker, 5/5 follow-ups. Cancelling mid-transfer is
  also clean on cleanup: 20/20 runs with the abort proved 1.2-3.6ms into the transfer window, full
  two-sided release (the ungated `disagg_kv_sender.abort()` on the inflight-queue path, not the
  `pending_bootstrap`-gated waiting-queue one), metadata buffers returned to a full pool on all 131
  releases, and a 38k-token request still served normally after 10 consecutive cancels.
  Three caveats belong on the record:
  1. Aborts are still silently dropped in a window between `_init_req_state` and
     `_send_one_request`, where the tokenizer-manager guard passes but the scheduler has no record
     of the request yet (`tokenizer_manager.py:646`, `scheduler.py:4030-4070`). Not reachable with
     the default synchronous tokenizer; reachable under `--enable-dynamic-batch-tokenizer`,
     `--tokenizer-worker-num > 1` (where the rid guard is bypassed outright), or multimodal. Worst
     case is today's behaviour — the request runs to completion.
  2. The transfer itself is never cancelled. The room reports `Failed` at abort and then `Success`
     12.5-343ms later: RDMA writes completing into pages both sides already freed, in 20/20 runs.
     Under 75-80% pool occupancy those freed pages *are* handed to other requests inside that window
     (146-159 times per run, as soon as 1.3ms after release). Despite that, no cross-contamination
     appeared in 5600 outputs and SGLang 0.5.18's own metadata room-mismatch detector never fired.
     The likely reason is that on cuda-IPC the writes physically land sub-millisecond and the gap is
     scheduler polling latency, not data motion — which makes this a fabric-dependent negative.
  3. A reproducible ~1% perturbation of *other* requests' greedy outputs, specific to mid-transfer
     aborts: 35/3600 deviating from baseline versus 0/3600 across three controls at identical
     concurrency (load-only, abort-before-transfer, abort-after-Success), with deterministic
     inference enabled. Not explained by the instrumented KV-page or metadata-slot reuse; live
     candidates are prefill-side page recycling or a batch-invariance gap on the
     `handle_inflight_transfer_failure` path. Open.
  The evidence envelope for SGLang is single-node, cuda-IPC, TP=1, Qwen3-0.6B. Multi-node network
  RDMA and TP>1 are untested.

- This overlaps #13703, which fixes the SGLang prefill leg only. The measurement above is why this
  one also fixes the decode leg.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable prefill cancellation policies: anytime, before handoff, or never.
  - Client cancellation now propagates to remote prefill and decode processing.
  - Cancellation behavior is supported across SGLang, vLLM, and TRT-LLM runtimes.
  - Requests canceled during prefill are cleaned up safely, while completed handoffs continue uninterrupted.

- **Bug Fixes**
  - Improved handling of cancellation races and already-canceled requests.
  - Confirmed services continue accepting new completion requests after cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
