### PR TITLE
feat(observability): add buffered JSONL output to FPM recorder

### DIFF
--- a/components/src/dynamo/common/recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/recv_forward_pass_metrics.py
@@ -189,6 +189,7 @@ def main() -> None:
 async def _run_with_signals(args: argparse.Namespace) -> None:
     loop = asyncio.get_running_loop()
     task = asyncio.current_task()
+    assert task is not None  # This coroutine is always executed inside a Task.
     loop.add_signal_handler(signal.SIGTERM, task.cancel)
     try:
         await run(args)

--- a/components/src/dynamo/common/recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/recv_forward_pass_metrics.py
@@ -27,20 +27,37 @@ Usage:
     python -m dynamo.common.recv_forward_pass_metrics \\
         --namespace dynamo --component backend --endpoint generate \\
         --save-plot metrics.png
+
+    # Buffered capture without per-message logging (existing files are refused)
+    python -m dynamo.common.recv_forward_pass_metrics \\
+        --namespace dynamo --output fpm.jsonl --flush-interval 1
+
+Output is compact JSONL: {"received_at_ns": <Unix nanoseconds>, "metrics": <FPM>}.
+The timestamp is taken by the receiver, not the engine. --log-metrics also prints
+each message when recording. Flush writes Python buffers, not fsync; SIGKILL or
+machine failure can lose buffered data. Counter gaps are diagnostics, not proof
+of lossless delivery (publisher-side drops before sequence assignment are invisible).
 """
 
 import argparse
 import asyncio
 import json
 import logging
+import math
 import os
+import signal
 import time
+from contextlib import aclosing, nullcontext
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import BinaryIO
 
 import matplotlib
 import matplotlib.pyplot as plt
 import msgspec
 
 from dynamo.common.forward_pass_metrics import ForwardPassMetrics, decode
+from dynamo.llm import FpmEventSubscriber
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -86,7 +103,14 @@ def _save_plot(path: str, history: list[tuple[float, ForwardPassMetrics]]) -> No
     logger.info("Plot saved to %s (%d data points)", path, len(history))
 
 
-def main() -> None:
+def _positive_seconds(value: str) -> float:
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError("must be finite and greater than zero")
+    return seconds
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Receive ForwardPassMetrics from the Dynamo event plane"
     )
@@ -128,14 +152,50 @@ def main() -> None:
         default=None,
         help="Save a time-series plot to the given PNG path on exit (recv mode only)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write compact JSONL to a new file (recv mode only); disables "
+        "per-message logging unless --log-metrics is set",
+    )
+    parser.add_argument(
+        "--flush-interval",
+        type=_positive_seconds,
+        default=1.0,
+        help="Flush the output buffer every N seconds, including while idle (default: 1)",
+    )
+    parser.add_argument(
+        "--log-metrics",
+        action="store_true",
+        help="Also log individual messages when --output is set",
+    )
+    args = parser.parse_args(argv)
+    if args.output is not None and args.mode != "recv":
+        parser.error("--output requires --mode recv; tracking only samples snapshots")
+    return args
 
-    asyncio.run(run(args))
+
+def main() -> None:
+    args = _parse_args()
+    try:
+        asyncio.run(_run_with_signals(args))
+    except KeyboardInterrupt:
+        logger.info("Stopped.")
+
+
+async def _run_with_signals(args: argparse.Namespace) -> None:
+    loop = asyncio.get_running_loop()
+    task = asyncio.current_task()
+    loop.add_signal_handler(signal.SIGTERM, task.cancel)
+    try:
+        await run(args)
+    except asyncio.CancelledError:
+        logger.info("Stopped.")
+    finally:
+        loop.remove_signal_handler(signal.SIGTERM)
 
 
 async def run(args: argparse.Namespace) -> None:
-    from dynamo.llm import FpmEventSubscriber
-
     loop = asyncio.get_running_loop()
     runtime = DistributedRuntime(loop, args.discovery_backend, args.request_plane)
     endpoint = runtime.endpoint(f"{args.namespace}.{args.component}.{args.endpoint}")
@@ -166,35 +226,111 @@ async def _run_recv(subscriber, args: argparse.Namespace) -> None:
     json_encoder = msgspec.json.Encoder()
     history: list[tuple[float, ForwardPassMetrics]] = []
     start_time: float | None = None
+    stats = _RecordingStats()
+    output_context = (
+        args.output.open("xb", buffering=1024 * 1024)
+        if args.output is not None
+        else nullcontext(None)
+    )
 
     try:
-        while True:
-            data = await asyncio.to_thread(subscriber.recv)
-            if data is None:
-                logger.info("Stream closed.")
-                break
-            metrics = decode(data)
-            if metrics is None:
-                continue
+        with output_context as output:
+            async with aclosing(
+                _receive(subscriber, output, args.flush_interval)
+            ) as stream:
+                async for data, received_at_ns in stream:
+                    metrics = decode(data)
+                    if metrics is None:
+                        stats.rejected += 1
+                        continue
+                    stats.observe(metrics)
+                    if output is not None:
+                        output.write(
+                            json_encoder.encode(
+                                {
+                                    "received_at_ns": received_at_ns,
+                                    "metrics": metrics,
+                                }
+                            )
+                            + b"\n"
+                        )
 
-            now = time.monotonic()
-            if start_time is None:
-                start_time = now
+                    if args.save_plot:
+                        now = time.monotonic()
+                        if start_time is None:
+                            start_time = now
+                        history.append((now - start_time, metrics))
 
-            if args.save_plot:
-                history.append((now - start_time, metrics))
-
-            pretty = json.loads(json_encoder.encode(metrics))
-            logger.info(
-                "[worker=%s dp=%d counter=%d] %s",
-                metrics.worker_id,
-                metrics.dp_rank,
-                metrics.counter_id,
-                json.dumps(pretty, indent=2),
-            )
+                    if output is None or args.log_metrics:
+                        pretty = json.loads(json_encoder.encode(metrics))
+                        logger.info(
+                            "[worker=%s dp=%d counter=%d] %s",
+                            metrics.worker_id,
+                            metrics.dp_rank,
+                            metrics.counter_id,
+                            json.dumps(pretty, indent=2),
+                        )
     finally:
+        logger.info(
+            "FPM capture: messages=%d rejected=%d streams=%d counter_gaps=%d "
+            "non_increasing_counters=%d (not a lossless-delivery guarantee)",
+            stats.messages,
+            stats.rejected,
+            len(stats.last_counter),
+            stats.counter_gaps,
+            stats.non_increasing_counters,
+        )
         if args.save_plot and history:
             _save_plot(args.save_plot, history)
+
+
+@dataclass
+class _RecordingStats:
+    messages: int = 0
+    rejected: int = 0
+    counter_gaps: int = 0
+    non_increasing_counters: int = 0
+    last_counter: dict[tuple[str, int], int] = field(default_factory=dict)
+
+    def observe(self, metrics: ForwardPassMetrics) -> None:
+        self.messages += 1
+        key = (metrics.worker_id, metrics.dp_rank)
+        previous = self.last_counter.get(key)
+        if previous is not None:
+            if metrics.counter_id > previous + 1:
+                self.counter_gaps += metrics.counter_id - previous - 1
+            elif metrics.counter_id <= previous:
+                # Could be a duplicate, reordering or producer restart. Do not
+                # label it as definite loss; rebase to the observed counter.
+                self.non_increasing_counters += 1
+        self.last_counter[key] = metrics.counter_id
+
+
+async def _receive(subscriber, output: BinaryIO | None, flush_interval: float):
+    """Keep one blocking receive in flight; flush even if no publisher is active."""
+    pending = None
+    next_flush = time.monotonic() + flush_interval
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.create_task(asyncio.to_thread(subscriber.recv))
+            timeout = max(0.0, next_flush - time.monotonic()) if output else None
+            done, _ = await asyncio.wait({pending}, timeout=timeout)
+            if output is not None and time.monotonic() >= next_flush:
+                output.flush()
+                next_flush = time.monotonic() + flush_interval
+            if done:
+                data = pending.result()
+                pending = None
+                if data is None:
+                    break
+                yield data, time.time_ns()
+    finally:
+        # Cancelling to_thread alone does not stop its blocking Rust receive.
+        # Unblock it before asyncio.run() joins the executor on process shutdown.
+        subscriber.shutdown()
+        if pending is not None:
+            await pending
 
 
 async def _run_tracking(subscriber, args: argparse.Namespace) -> None:

--- a/components/src/dynamo/common/recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/recv_forward_pass_metrics.py
@@ -304,9 +304,11 @@ class _RecordingStats:
             if metrics.counter_id > previous + 1:
                 self.counter_gaps += metrics.counter_id - previous - 1
             elif metrics.counter_id <= previous:
-                # Could be a duplicate, reordering or producer restart. Do not
-                # label it as definite loss; rebase to the observed counter.
+                # Could be a duplicate, reordering or producer restart. Keep
+                # the high-water mark: a restart cannot be distinguished here,
+                # and rebasing would turn delayed messages into artificial gaps.
                 self.non_increasing_counters += 1
+                return
         self.last_counter[key] = metrics.counter_id
 
 

--- a/components/src/dynamo/common/recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/recv_forward_pass_metrics.py
@@ -52,16 +52,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import BinaryIO
 
-import matplotlib
-import matplotlib.pyplot as plt
 import msgspec
 
 from dynamo.common.forward_pass_metrics import ForwardPassMetrics, decode
 from dynamo.llm import FpmEventSubscriber
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
-
-matplotlib.use("Agg")
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -72,6 +68,13 @@ def _save_plot(path: str, history: list[tuple[float, ForwardPassMetrics]]) -> No
     if not history:
         logger.warning("No data collected, skipping plot.")
         return
+
+    # Plotting is optional: runtime images used for capture need not contain
+    # matplotlib or its dependencies. Load them only for --save-plot.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
 
     ts = [t for t, _ in history]
     num_prefill = [m.scheduled_requests.num_prefill_requests for _, m in history]

--- a/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import builtins
+import importlib
 import io
 import logging
 import queue
@@ -21,6 +23,19 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.timeout(10),
 ]
+
+
+def test_capture_import_does_not_require_plotting(monkeypatch):
+    original_import = builtins.__import__
+
+    def without_matplotlib(name, *args, **kwargs):
+        if name == "matplotlib" or name.startswith("matplotlib."):
+            raise ModuleNotFoundError("plotting is unavailable in this runtime")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_matplotlib)
+    importlib.reload(recorder)
+    assert recorder._parse_args([]).output is None
 
 
 class Subscriber:

--- a/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
@@ -95,7 +95,7 @@ def test_existing_file_is_not_overwritten(tmp_path):
     assert path.read_bytes() == b"previous capture\n"
 
 
-@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+@pytest.mark.parametrize("value", ["0", "nan"])
 def test_invalid_flush_interval(value):
     with pytest.raises(SystemExit):
         recorder._parse_args(["--flush-interval", value])

--- a/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
@@ -125,7 +125,7 @@ def test_stream_counter_diagnostics():
         (0, "b", 0),
         (103, "a", 0),
         (0, "a", 0),
-        (1, "a", 0),
+        (104, "a", 0),
     ]:
         stats.observe(
             ForwardPassMetrics(worker_id=worker, dp_rank=dp, counter_id=counter)

--- a/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
+++ b/components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import io
+import logging
+import queue
+import signal
+import threading
+from unittest.mock import Mock
+
+import msgspec
+import pytest
+
+from dynamo.common import recv_forward_pass_metrics as recorder
+from dynamo.common.forward_pass_metrics import ForwardPassMetrics, encode
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.timeout(10),
+]
+
+
+class Subscriber:
+    def __init__(self, messages=()):
+        self.messages = queue.Queue()
+        for message in messages:
+            self.messages.put(message)
+        self.started = threading.Event()
+        self.waiting = threading.Event()
+        self.stopped = False
+
+    def recv(self):
+        self.started.set()
+        if self.messages.empty():
+            self.waiting.set()
+        return self.messages.get()
+
+    def shutdown(self):
+        self.stopped = True
+        self.messages.put(None)
+
+
+def payload(counter=0, worker="worker-a", dp_rank=0):
+    return encode(
+        ForwardPassMetrics(
+            worker_id=worker,
+            dp_rank=dp_rank,
+            counter_id=counter,
+            wall_time=0.001,
+        )
+    )
+
+
+def test_jsonl_capture_is_compact_and_quiet(tmp_path, caplog):
+    path = tmp_path / "fpm.jsonl"
+    args = recorder._parse_args(["--output", str(path)])
+    subscriber = Subscriber([payload(20), payload(21), None])
+    with caplog.at_level(logging.INFO):
+        asyncio.run(recorder._run_recv(subscriber, args))
+    lines = path.read_bytes().splitlines()
+    assert len(lines) == 2
+    records = [msgspec.json.decode(line) for line in lines]
+    assert [r["metrics"]["counter_id"] for r in records] == [20, 21]
+    assert all(isinstance(r["received_at_ns"], int) for r in records)
+    assert all(r["received_at_ns"] > 0 for r in records)
+    assert "[worker=" not in caplog.text
+    assert "messages=2 rejected=0 streams=1 counter_gaps=0" in caplog.text
+    assert subscriber.stopped
+
+
+def test_existing_file_is_not_overwritten(tmp_path):
+    path = tmp_path / "existing.jsonl"
+    path.write_bytes(b"previous capture\n")
+    args = recorder._parse_args(["--output", str(path)])
+    with pytest.raises(FileExistsError):
+        asyncio.run(recorder._run_recv(Subscriber(), args))
+    assert path.read_bytes() == b"previous capture\n"
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_invalid_flush_interval(value):
+    with pytest.raises(SystemExit):
+        recorder._parse_args(["--flush-interval", value])
+
+
+def test_tracking_rejects_output():
+    with pytest.raises(SystemExit):
+        recorder._parse_args(["--mode", "tracking", "--output", "unused.jsonl"])
+
+
+@pytest.mark.parametrize("save", [False, True])
+def test_debug_logging_remains_available(tmp_path, caplog, save):
+    argv = ["--output", str(tmp_path / "fpm.jsonl"), "--log-metrics"] if save else []
+    args = recorder._parse_args(argv)
+    with caplog.at_level(logging.INFO):
+        asyncio.run(recorder._run_recv(Subscriber([payload(), None]), args))
+    assert "[worker=worker-a dp=0 counter=0]" in caplog.text
+
+
+def test_stream_counter_diagnostics():
+    stats = recorder._RecordingStats()
+    # A late subscription must not count messages before the first observation.
+    for counter, worker, dp in [
+        (100, "a", 0),
+        (103, "a", 0),
+        (7, "a", 1),
+        (0, "b", 0),
+        (103, "a", 0),
+        (0, "a", 0),
+        (1, "a", 0),
+    ]:
+        stats.observe(
+            ForwardPassMetrics(worker_id=worker, dp_rank=dp, counter_id=counter)
+        )
+    assert stats.messages == 7
+    assert stats.counter_gaps == 2
+    assert stats.non_increasing_counters == 2
+    assert len(stats.last_counter) == 3
+
+
+def test_invalid_payload_is_counted(tmp_path, caplog):
+    args = recorder._parse_args(["--output", str(tmp_path / "fpm.jsonl")])
+    with caplog.at_level(logging.INFO):
+        asyncio.run(recorder._run_recv(Subscriber([b"\xc1", payload(), None]), args))
+    assert "messages=1 rejected=1" in caplog.text
+
+
+def test_flush_while_idle_does_not_spawn_more_receivers():
+    subscriber = Subscriber()
+    subscriber.recv = Mock(wraps=subscriber.recv)
+    output = io.BytesIO()
+    output.flush = Mock(side_effect=subscriber.shutdown)
+
+    async def receive():
+        return [item async for item in recorder._receive(subscriber, output, 0.001)]
+
+    assert asyncio.run(receive()) == []
+    assert output.flush.called
+    assert subscriber.recv.call_count == 1
+
+
+def test_cancellation_unblocks_receiver_and_closes_file(tmp_path):
+    args = recorder._parse_args(["--output", str(tmp_path / "fpm.jsonl")])
+    subscriber = Subscriber([payload()])
+
+    async def cancel():
+        task = asyncio.create_task(recorder._run_recv(subscriber, args))
+        await asyncio.to_thread(subscriber.waiting.wait)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(cancel())
+    assert subscriber.stopped
+    records = args.output.read_bytes().splitlines()
+    assert len(records) == 1
+    assert msgspec.json.decode(records[0])["metrics"]["counter_id"] == 0
+
+
+def test_write_failure_propagates_and_stops_subscriber():
+    args = recorder._parse_args([])
+    output = io.BytesIO()
+    output.write = Mock(side_effect=OSError("disk full"))
+    args.output = Mock()
+    args.output.open.return_value = output
+    subscriber = Subscriber([payload()])
+    with pytest.raises(OSError, match="disk full"):
+        asyncio.run(recorder._run_recv(subscriber, args))
+    assert output.closed
+    assert subscriber.stopped
+
+
+def test_sigterm_cancels_run_and_removes_handler(monkeypatch):
+    async def exercise():
+        loop = asyncio.get_running_loop()
+        install = Mock()
+        remove = Mock()
+        monkeypatch.setattr(loop, "add_signal_handler", install)
+        monkeypatch.setattr(loop, "remove_signal_handler", remove)
+
+        async def interrupted_run(args):
+            install.call_args.args[1]()
+            await asyncio.Future()
+
+        monkeypatch.setattr(recorder, "run", interrupted_run)
+        await recorder._run_with_signals(recorder._parse_args([]))
+        assert install.call_args.args[0] == signal.SIGTERM
+        remove.assert_called_once_with(signal.SIGTERM)
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Summary

Add buffered JSONL recording to `python -m dynamo.common.recv_forward_pass_metrics`.

- `--output PATH` writes a new file exclusively (no overwrite), with one compact
  `{"received_at_ns": ..., "metrics": ...}` record per decoded FPM.
- Recording suppresses per-message pretty logging by default; `--log-metrics`
  opts back in. Existing no-output logging and optional plotting remain available.
- `--flush-interval` defaults to one second and also flushes while the publisher
  is idle. Clean stream closure, Ctrl+C and SIGTERM close the output. Unblock and
  join the single pending receive on shutdown rather than leaving an executor
  thread blocked in the Rust subscriber.
- Report received/rejected messages, streams, observed counter gaps and
  non-increasing counters. Reject output in tracking mode, which samples only
  the latest snapshot.

Example (same discovery environment as the workers):

```bash
python -m dynamo.common.recv_forward_pass_metrics \
  --namespace agentx-glm52 --component backend --endpoint generate \
  --discovery-backend file --request-plane tcp \
  --output fpm.jsonl --flush-interval 1
```

This is a consumer-only change: no inference-engine or publisher modifications.
Writes are buffered, not fsynced. SIGKILL/machine failure may lose buffered data.
Sequence diagnostics cannot establish losslessness: drops before publisher-side
sequence assignment and events before subscription remain invisible. Slow storage
can still back up the existing subscriber. Use local storage for perf experiments.

## Validation

- 14 CPU-only unit tests (consolidated equivalent invalid-interval cases): compact recording, quiet/default/opt-in logging,
  overwrite refusal, CLI validation, stream-specific counters, malformed records,
  idle flush with one outstanding receive, cancellation with final buffered data,
  write-failure propagation/cleanup, SIGTERM handler cancellation/removal,
  and capture imports without optional matplotlib dependencies.
- Computelab runtime preflight exposed an incomplete matplotlib installation
  (missing pyparsing). Plotting imports are now deferred to --save-plot; the
  disk-only recorder starts successfully without changing engine dependencies.
- Full-repository pre-commit checks and final changed-file checks passed.
- Local synthetic microbenchmark: 30,000 records written and decoded back with
  all counters checked; 15,678,890 bytes in 8.00 seconds (~3,749 messages/s).
  Includes fake source serialization, the Python receive loop, and local buffered
  disk output; excludes actual event-plane/network transport and fsync. This is
  roughly 60x the ~63 messages/s expected in our single-worker B200 c4 replay,
  not a claim about GPU inference overhead or lossless network capture.
- FPM emission on/off GPU performance comparison remains a separate experiment.


## Related Issues

No linked issue; this adds the disk capture needed for FPM emission performance experiments.

## Where should the reviewer start?

Start with `_run_recv` and `_receive` in `components/src/dynamo/common/recv_forward_pass_metrics.py`, then the lifecycle tests in `components/src/dynamo/common/tests/test_recv_forward_pass_metrics.py`.
