### PR TITLE
fix(metrics): restore documented histogram bucket env var names

### DIFF
--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -515,16 +515,16 @@ See the [KServe gRPC Frontend](../../developer-guide/knowledge-base/modular-comp
 
 ### Histogram buckets
 
-The frontend's six latency and size histograms use log-spaced buckets, rounded to two significant figures, always starting with a `0` edge. Each histogram is tuned by three environment variables that share a prefix: `_MIN` and `_MAX` bound the range, and `_COUNT` is the total number of bucket edges **including** that leading `0`, so `COUNT - 1` edges are spread across the range and `MAX` is the top one. The inter-token latency default of `13` therefore means `0` plus twelve log-spaced edges. These have no CLI equivalent, and they are read once while the frontend builds its metrics, so changing one requires a restart.
+The frontend's six latency and size histograms use log-spaced buckets, rounded to two significant figures, always starting with a `0` edge. Each histogram is tuned by three environment variables that share a prefix: `_MIN` and `_MAX` bound the range, and `_COUNT` is the total number of bucket edges **including** that leading `0`, so `COUNT - 1` edges are spread across the range. The inter-token latency default of `13` therefore means `0` plus twelve log-spaced edges. Every edge, including the top one, is rounded to two significant figures, so the highest exported edge is `MAX` rounded rather than `MAX` itself — see the `Top le` column below. These have no CLI equivalent, and they are read once while the frontend builds its metrics, so changing one requires a restart.
 
-| Histogram | Variable prefix | Min | Max | Count |
-|---|---|---|---|---|
-| `dynamo_frontend_request_duration_seconds` | `DYN_METRICS_REQUEST_DURATION` | `1.0` | `512.0` | `10` |
-| `dynamo_frontend_input_sequence_tokens` | `DYN_METRICS_INPUT_SEQUENCE` | `50.0` | `128000.0` | `12` |
-| `dynamo_frontend_output_sequence_tokens` | `DYN_METRICS_OUTPUT_SEQUENCE` | `50.0` | `32000.0` | `10` |
-| `dynamo_frontend_time_to_first_token_seconds` | `DYN_METRICS_TTFT` | `0.001` | `480.0` | `18` |
-| `dynamo_frontend_inter_token_latency_seconds` | `DYN_METRICS_ITL` | `0.001` | `2.0` | `13` |
-| `dynamo_frontend_embedding_latency_seconds` | `DYN_METRICS_EMBEDDING_LATENCY` | `0.001` | `10.0` | `14` |
+| Histogram | Variable prefix | Min | Max | Count | Top `le` |
+|---|---|---|---|---|---|
+| `dynamo_frontend_request_duration_seconds` | `DYN_METRICS_REQUEST_DURATION` | `1.0` | `512.0` | `10` | `510` |
+| `dynamo_frontend_input_sequence_tokens` | `DYN_METRICS_INPUT_SEQUENCE` | `50.0` | `128000.0` | `12` | `130000` |
+| `dynamo_frontend_output_sequence_tokens` | `DYN_METRICS_OUTPUT_SEQUENCE` | `50.0` | `32000.0` | `10` | `32000` |
+| `dynamo_frontend_time_to_first_token_seconds` | `DYN_METRICS_TTFT` | `0.001` | `480.0` | `18` | `480` |
+| `dynamo_frontend_inter_token_latency_seconds` | `DYN_METRICS_ITL` | `0.001` | `2.0` | `13` | `2` |
+| `dynamo_frontend_embedding_latency_seconds` | `DYN_METRICS_EMBEDDING_LATENCY` | `0.001` | `10.0` | `14` | `10` |
 
 For example, to raise the inter-token latency ceiling from 2 seconds to 80:
 
@@ -532,6 +532,8 @@ For example, to raise the inter-token latency ceiling from 2 seconds to 80:
 export DYN_METRICS_ITL_MAX=80
 export DYN_METRICS_ITL_COUNT=20
 ```
+
+Rounding can move the top edge either way, so pick a `MAX` that is already two significant figures if you need an exact ceiling. `MAX=123` exports `le=120` and sends observations from 120 to 123 into `+Inf`; `MAX=131072` exports `le=130000`. Two of the defaults above are affected: request duration is set to `512` but exports `510`, and input sequence is set to `128000` but exports `130000`.
 
 `dynamo_frontend_cached_tokens` shares the input sequence buckets, so `DYN_METRICS_INPUT_SEQUENCE_*` changes both histograms.
 

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -513,6 +513,44 @@ See the [KServe gRPC Frontend](../../developer-guide/knowledge-base/modular-comp
   Environment variable: `DYN_DUMP_CONFIG_TO`
 </ParamField>
 
+### Histogram buckets
+
+The frontend's six latency and size histograms use log-spaced buckets, rounded to two significant figures, always starting with a `0` edge. Each histogram is tuned by three environment variables that share a prefix: `_MIN` and `_MAX` bound the range, and `_COUNT` sets how many edges are generated across it. These have no CLI equivalent, and they are read once while the frontend builds its metrics, so changing one requires a restart.
+
+| Histogram | Variable prefix | Min | Max | Count |
+|---|---|---|---|---|
+| `dynamo_frontend_request_duration_seconds` | `DYN_METRICS_REQUEST_DURATION` | `1.0` | `512.0` | `10` |
+| `dynamo_frontend_input_sequence_tokens` | `DYN_METRICS_INPUT_SEQUENCE` | `50.0` | `128000.0` | `12` |
+| `dynamo_frontend_output_sequence_tokens` | `DYN_METRICS_OUTPUT_SEQUENCE` | `50.0` | `32000.0` | `10` |
+| `dynamo_frontend_time_to_first_token_seconds` | `DYN_METRICS_TTFT` | `0.001` | `480.0` | `18` |
+| `dynamo_frontend_inter_token_latency_seconds` | `DYN_METRICS_ITL` | `0.001` | `2.0` | `13` |
+| `dynamo_frontend_embedding_latency_seconds` | `DYN_METRICS_EMBEDDING_LATENCY` | `0.001` | `10.0` | `14` |
+
+For example, to raise the inter-token latency ceiling from 2 seconds to 80:
+
+```bash
+DYN_METRICS_ITL_MAX=80
+DYN_METRICS_ITL_COUNT=20
+```
+
+`dynamo_frontend_cached_tokens` shares the input sequence buckets, so `DYN_METRICS_INPUT_SEQUENCE_*` changes both histograms.
+
+A configuration is rejected, with a warning, unless `MIN` is greater than zero, `MIN` is less than `MAX`, and `COUNT` is between 1 and 512. Rejected values fall back to the defaults above. A value that cannot be parsed at all also warns and falls back. Because rounding to two significant figures can collapse neighboring edges, a high `COUNT` over a narrow range yields fewer buckets than requested; the frontend warns when that removes more than a tenth of them.
+
+Bucket edges appear directly in the `le` label, which is the only reliable way to confirm a setting took effect:
+
+```bash
+curl -s localhost:8000/metrics | grep dynamo_frontend_inter_token_latency_seconds_bucket
+```
+
+<Warning>
+  Prometheus cannot compute `histogram_quantile` across series with different `le` sets, so changing any of these values makes the new data non-comparable with data already scraped, and dashboards show a discontinuity at the restart. Bucket count also drives cardinality: each edge is a separate series per value of the `model` label.
+</Warning>
+
+<Note>
+  From v0.8.0 until this release these variables were read under a doubled prefix, as in `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`, so the names in the table above had no effect on those versions. The doubled names still work but now log a deprecation warning, and support for them will be removed in a future release. Rename them to the forms above. Configurations written against v0.7.1 or earlier work again without change.
+</Note>
+
 ## Tokenizer
 
 <ParamField path="--tokenizer" type="string" default="default">

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -515,7 +515,7 @@ See the [KServe gRPC Frontend](../../developer-guide/knowledge-base/modular-comp
 
 ### Histogram buckets
 
-The frontend's six latency and size histograms use log-spaced buckets, rounded to two significant figures, always starting with a `0` edge. Each histogram is tuned by three environment variables that share a prefix: `_MIN` and `_MAX` bound the range, and `_COUNT` sets how many edges are generated across it. These have no CLI equivalent, and they are read once while the frontend builds its metrics, so changing one requires a restart.
+The frontend's six latency and size histograms use log-spaced buckets, rounded to two significant figures, always starting with a `0` edge. Each histogram is tuned by three environment variables that share a prefix: `_MIN` and `_MAX` bound the range, and `_COUNT` is the total number of bucket edges **including** that leading `0`, so `COUNT - 1` edges are spread across the range and `MAX` is the top one. The inter-token latency default of `13` therefore means `0` plus twelve log-spaced edges. These have no CLI equivalent, and they are read once while the frontend builds its metrics, so changing one requires a restart.
 
 | Histogram | Variable prefix | Min | Max | Count |
 |---|---|---|---|---|
@@ -535,11 +535,18 @@ export DYN_METRICS_ITL_COUNT=20
 
 `dynamo_frontend_cached_tokens` shares the input sequence buckets, so `DYN_METRICS_INPUT_SEQUENCE_*` changes both histograms.
 
-A configuration is rejected, with a warning, unless `MIN` is greater than zero, `MIN` is less than `MAX`, and `COUNT` is between 1 and 512. Rejected values fall back to the defaults above. A value that cannot be parsed at all also warns and falls back. Because rounding to two significant figures can collapse neighboring edges, a high `COUNT` over a narrow range yields fewer buckets than requested; the frontend warns when that removes more than a tenth of them.
+A histogram's configuration is validated as a set: `MIN` must be above zero, below `MAX`, and `COUNT` must be between 1 and 512. If any part fails, the frontend warns and reverts **all three** values for that histogram together — setting `DYN_METRICS_ITL_MIN=5` against the default `MAX` of `2.0` also discards a perfectly valid `DYN_METRICS_ITL_COUNT=20`.
 
-Bucket edges appear directly in the `le` label, which is the only reliable way to confirm a setting took effect:
+A value that cannot be parsed at all is handled per variable, not as a set: it warns, that one variable falls back to its default, and the others still apply.
+
+Use `COUNT` of at least 2. `COUNT=1` passes validation but produces the leading `0` edge and nothing else, which ignores `MIN` and `MAX` and puts every observation in `+Inf`. Because rounding to two significant figures can collapse neighboring edges, a high `COUNT` over a narrow range also yields fewer buckets than requested; the frontend warns when that removes more than a tenth of them.
+
+Bucket edges appear directly in the `le` label, which is the only reliable way to confirm a setting took effect. These histograms are labeled by `model`, so a series exists only after a request has populated it — on a freshly restarted frontend the command below prints nothing, which means "no data yet", not "the setting was ignored". Send a request first:
 
 ```bash
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"<model>","messages":[{"role":"user","content":"hi"}],"max_tokens":8}' > /dev/null
+
 curl -s localhost:8000/metrics | grep dynamo_frontend_inter_token_latency_seconds_bucket
 ```
 

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -529,8 +529,8 @@ The frontend's six latency and size histograms use log-spaced buckets, rounded t
 For example, to raise the inter-token latency ceiling from 2 seconds to 80:
 
 ```bash
-DYN_METRICS_ITL_MAX=80
-DYN_METRICS_ITL_COUNT=20
+export DYN_METRICS_ITL_MAX=80
+export DYN_METRICS_ITL_COUNT=20
 ```
 
 `dynamo_frontend_cached_tokens` shares the input sequence buckets, so `DYN_METRICS_INPUT_SEQUENCE_*` changes both histograms.
@@ -544,7 +544,7 @@ curl -s localhost:8000/metrics | grep dynamo_frontend_inter_token_latency_second
 ```
 
 <Warning>
-  Prometheus cannot compute `histogram_quantile` across series with different `le` sets, so changing any of these values makes the new data non-comparable with data already scraped, and dashboards show a discontinuity at the restart. Bucket count also drives cardinality: each edge is a separate series per value of the `model` label.
+  Changing any of these values makes new data non-comparable with data already scraped. `histogram_quantile` still returns a number when a query spans two different `le` layouts, but aggregating incompatible bucket layouts yields misleading quantiles rather than an error, so dashboards show a discontinuity at the restart that is easy to misread as a real latency change. Bucket count also drives cardinality: each edge is a separate series per value of the `model` label.
 </Warning>
 
 <Note>

--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -13,7 +13,7 @@ The `type` on each field below is a [Prometheus metric type](https://prometheus.
 
 - **counter** — a cumulative value that only increases (or resets to zero on restart), e.g. total requests.
 - **gauge** — a single value that can go up or down, e.g. in-flight requests.
-- **histogram** — samples observations into configurable buckets and exposes `_bucket`, `_sum`, and `_count` series, e.g. request duration. Labeled histograms/counters/gauges register a metric *family*, not one series.
+- **histogram** — samples observations into configurable buckets and exposes `_bucket`, `_sum`, and `_count` series, e.g. request duration. Labeled histograms/counters/gauges register a metric *family*, not one series. The frontend latency and sequence-length histograms take their bucket ranges from environment variables — see [Histogram buckets](../components/frontend-configuration.mdx#histogram-buckets).
 
 <Info>
   Labeled metrics (`HistogramVec`, `CounterVec`, `GaugeVec`) register a metric *family*, not individual time series. For request-populated metrics, a series for a given label combination appears at `/metrics` only after the first matching request. Other families create or remove series from runtime state; their entries below document those semantics.

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -410,6 +410,17 @@ fn validate_bucket_config(min: f64, max: f64, count: usize) -> bool {
         && count <= MAX_BUCKET_COUNT
 }
 
+/// How bucket settings are looked up. Injected rather than calling `std::env::var`
+/// directly so tests can supply values without mutating the process environment:
+/// concurrent `setenv`/`getenv` is undefined behavior on Unix, and many other tests in
+/// this module construct `Metrics` and read these same variables.
+type EnvLookup<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+/// The real lookup, used everywhere outside tests.
+fn system_env(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
 /// Read one histogram bucket setting, e.g. `DYN_METRICS_ITL_MAX`, from the environment.
 ///
 /// Falls back to the deprecated doubled form (`DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`)
@@ -418,16 +429,21 @@ fn validate_bucket_config(min: f64, max: f64, count: usize) -> bool {
 /// Returns `default` when neither name is set. A name that *is* set but cannot be
 /// parsed also returns `default`, but warns first: silently ignoring a typo makes
 /// the whole knob look like it does not exist.
-fn bucket_env_var<T: std::str::FromStr>(prefix: &str, suffix: &str, default: T) -> T {
+fn bucket_env_var<T: std::str::FromStr>(
+    env: EnvLookup<'_>,
+    prefix: &str,
+    suffix: &str,
+    default: T,
+) -> T {
     let name = format!("{prefix}_{suffix}");
-    let found = match std::env::var(&name) {
-        Ok(value) => Some((name, value)),
-        Err(_) => {
+    let found = match env(&name) {
+        Some(value) => Some((name, value)),
+        None => {
             let deprecated = format!(
                 "{}{prefix}_{suffix}",
                 env_metrics::DEPRECATED_HISTOGRAM_PREFIX
             );
-            std::env::var(&deprecated).ok().map(|value| {
+            env(&deprecated).map(|value| {
                 tracing::warn!(
                     deprecated = %deprecated,
                     replacement = %name,
@@ -455,6 +471,7 @@ fn bucket_env_var<T: std::str::FromStr>(prefix: &str, suffix: &str, default: T) 
 /// Parse histogram bucket configuration from environment variables
 /// Returns (min, max, count) with defaults if not specified
 fn parse_bucket_config(
+    env: EnvLookup<'_>,
     env_prefix: &str,
     default_min: f64,
     default_max: f64,
@@ -469,9 +486,9 @@ fn parse_bucket_config(
         );
         return (1.0, 10.0, 10);
     }
-    let mut min = bucket_env_var(env_prefix, "MIN", default_min);
-    let mut max = bucket_env_var(env_prefix, "MAX", default_max);
-    let mut count = bucket_env_var(env_prefix, "COUNT", default_count);
+    let mut min = bucket_env_var(env, env_prefix, "MIN", default_min);
+    let mut max = bucket_env_var(env, env_prefix, "MAX", default_max);
+    let mut count = bucket_env_var(env, env_prefix, "COUNT", default_count);
 
     if !validate_bucket_config(min, max, count) {
         tracing::warn!(
@@ -794,6 +811,12 @@ impl Metrics {
     /// Create Metrics with an explicit optional prefix. `None` uses the standard
     /// frontend prefix and does not read environment variables.
     pub fn new_with_prefix(metrics_prefix: Option<String>) -> Self {
+        Self::build(metrics_prefix, &system_env)
+    }
+
+    /// Real constructor. `env` is injected so tests can pin bucket configuration
+    /// without touching the process environment.
+    fn build(metrics_prefix: Option<String>, env: EnvLookup<'_>) -> Self {
         // TODO: Remove DYN_METRICS_PREFIX env-var override (added in PR #2432 for
         // NIM compatibility with the old "nv_llm_http_service_" prefix). No longer
         // needed — hardcode name_prefix::FRONTEND and drop the sanitize function.
@@ -861,8 +884,13 @@ impl Metrics {
         .unwrap();
 
         // Request duration buckets: configurable via DYN_METRICS_REQUEST_DURATION_{MIN,MAX,COUNT}
-        let (req_dur_min, req_dur_max, req_dur_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_REQUEST_DURATION, 1.0, 512.0, 10);
+        let (req_dur_min, req_dur_max, req_dur_count) = parse_bucket_config(
+            env,
+            env_metrics::DYN_METRICS_REQUEST_DURATION,
+            1.0,
+            512.0,
+            10,
+        );
         let request_duration_buckets =
             generate_log_buckets(req_dur_min, req_dur_max, req_dur_count);
 
@@ -877,8 +905,13 @@ impl Metrics {
         .unwrap();
 
         // Input sequence length buckets: configurable via DYN_METRICS_INPUT_SEQUENCE_{MIN,MAX,COUNT}
-        let (isl_min, isl_max, isl_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_INPUT_SEQUENCE, 50.0, 128000.0, 12);
+        let (isl_min, isl_max, isl_count) = parse_bucket_config(
+            env,
+            env_metrics::DYN_METRICS_INPUT_SEQUENCE,
+            50.0,
+            128000.0,
+            12,
+        );
         let input_sequence_buckets = generate_log_buckets(isl_min, isl_max, isl_count);
 
         let input_sequence_length = HistogramVec::new(
@@ -892,8 +925,13 @@ impl Metrics {
         .unwrap();
 
         // Output sequence length buckets: configurable via DYN_METRICS_OUTPUT_SEQUENCE_{MIN,MAX,COUNT}
-        let (osl_min, osl_max, osl_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_OUTPUT_SEQUENCE, 50.0, 32000.0, 10);
+        let (osl_min, osl_max, osl_count) = parse_bucket_config(
+            env,
+            env_metrics::DYN_METRICS_OUTPUT_SEQUENCE,
+            50.0,
+            32000.0,
+            10,
+        );
         let output_sequence_buckets = generate_log_buckets(osl_min, osl_max, osl_count);
 
         let output_sequence_length = HistogramVec::new(
@@ -917,7 +955,7 @@ impl Metrics {
 
         // Time to first token buckets: configurable via DYN_METRICS_TTFT_{MIN,MAX,COUNT}
         let (ttft_min, ttft_max, ttft_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_TTFT, 0.001, 480.0, 18);
+            parse_bucket_config(env, env_metrics::DYN_METRICS_TTFT, 0.001, 480.0, 18);
         let time_to_first_token_buckets = generate_log_buckets(ttft_min, ttft_max, ttft_count);
 
         let time_to_first_token = HistogramVec::new(
@@ -932,7 +970,7 @@ impl Metrics {
 
         // Inter-token latency buckets: configurable via DYN_METRICS_ITL_{MIN,MAX,COUNT}
         let (itl_min, itl_max, itl_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+            parse_bucket_config(env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
         let inter_token_latency_buckets = generate_log_buckets(itl_min, itl_max, itl_count);
 
         let inter_token_latency = HistogramVec::new(
@@ -949,8 +987,13 @@ impl Metrics {
         // sub-second (60-200 token inputs on L4-class GPUs land in the 5-50ms
         // range), so 1ms..10s on a log scale gives p50/p99 resolution that
         // the 1..512s `request_duration` buckets cannot.
-        let (emb_min, emb_max, emb_count) =
-            parse_bucket_config(env_metrics::DYN_METRICS_EMBEDDING_LATENCY, 0.001, 10.0, 14);
+        let (emb_min, emb_max, emb_count) = parse_bucket_config(
+            env,
+            env_metrics::DYN_METRICS_EMBEDDING_LATENCY,
+            0.001,
+            10.0,
+            14,
+        );
         let embedding_latency_buckets = generate_log_buckets(emb_min, emb_max, emb_count);
 
         let embedding_latency = HistogramVec::new(
@@ -2560,112 +2603,72 @@ mod tests {
         }
     }
 
-    // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
-    // `#[serial_test::serial]` (serialize against every other env-touching test in the
-    // binary, not just this module). A module-local mutex would be insufficient because
-    // `std::env::{set_var, remove_var}` race against `getenv` in any other thread.
-
-    /// Every ITL bucket variable, new and deprecated, cleared; `overrides` sets the ones a
-    /// test cares about. Clearing all of them matters: an inherited value a test does not
-    /// set — a `_MIN` above the `_MAX` under test, say — fails validation and reverts the
-    /// whole config, failing the assertion for a reason unrelated to what is being tested.
-    fn itl_env(overrides: &[(&'static str, &'static str)]) -> Vec<(&'static str, Option<String>)> {
-        let mut vars: Vec<(&'static str, Option<String>)> = [
-            "DYN_METRICS_ITL_MIN",
-            "DYN_METRICS_ITL_MAX",
-            "DYN_METRICS_ITL_COUNT",
-            "DYN_HISTOGRAM_DYN_METRICS_ITL_MIN",
-            "DYN_HISTOGRAM_DYN_METRICS_ITL_MAX",
-            "DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT",
-        ]
-        .into_iter()
-        .map(|name| (name, None))
-        .collect();
-        for (name, value) in overrides {
-            let slot = vars
-                .iter_mut()
-                .find(|(n, _)| n == name)
-                .expect("override names a variable outside the cleared set");
-            slot.1 = Some((*value).to_string());
+    /// A stand-in for the process environment. Tests inject this instead of calling
+    /// `temp_env`: mutating the real environment races the many other tests in this
+    /// module that construct `Metrics` and read these same variables, which on Unix is
+    /// an unsafe `setenv`/`getenv` race, not merely an ordering hazard.
+    fn fake_env<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| (*value).to_string())
         }
-        vars
     }
 
     #[test]
-    #[serial_test::serial]
     fn bucket_config_reads_the_documented_env_var_names() {
         // PR #4083 prepended DYN_HISTOGRAM_ to a prefix that already started with
         // DYN_METRICS_, so these names silently stopped working.
-        temp_env::with_vars(
-            itl_env(&[
-                ("DYN_METRICS_ITL_MIN", "0.002"),
-                ("DYN_METRICS_ITL_MAX", "80"),
-                ("DYN_METRICS_ITL_COUNT", "20"),
-            ]),
-            || {
-                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
-                assert_eq!(cfg, (0.002, 80.0, 20));
-            },
-        );
+        let env = fake_env(&[
+            ("DYN_METRICS_ITL_MIN", "0.002"),
+            ("DYN_METRICS_ITL_MAX", "80"),
+            ("DYN_METRICS_ITL_COUNT", "20"),
+        ]);
+        let cfg = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+        assert_eq!(cfg, (0.002, 80.0, 20));
     }
 
     #[test]
-    #[serial_test::serial]
     fn bucket_config_falls_back_to_the_deprecated_doubled_name() {
         // The doubled form was the only working name between #4083 and this fix, so it
         // stays supported for one release rather than silently reverting to defaults.
-        temp_env::with_vars(
-            itl_env(&[("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "80")]),
-            || {
-                let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
-                assert_eq!(max, 80.0);
-            },
-        );
+        let env = fake_env(&[("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "80")]);
+        let (_, max, _) = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+        assert_eq!(max, 80.0);
     }
 
     #[test]
-    #[serial_test::serial]
     fn bucket_config_prefers_the_new_name_over_the_deprecated_one() {
-        temp_env::with_vars(
-            itl_env(&[
-                ("DYN_METRICS_ITL_MAX", "80"),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "30"),
-            ]),
-            || {
-                let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
-                assert_eq!(max, 80.0);
-            },
-        );
+        let env = fake_env(&[
+            ("DYN_METRICS_ITL_MAX", "80"),
+            ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "30"),
+        ]);
+        let (_, max, _) = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+        assert_eq!(max, 80.0);
     }
 
     #[test]
-    #[serial_test::serial]
     fn bucket_config_falls_back_to_defaults_for_unset_and_unparseable_values() {
-        // Unparseable also warns, which is what makes a typo diagnosable; the warning
-        // itself is not asserted here, only that the default is preserved.
-        temp_env::with_vars(
-            itl_env(&[
-                ("DYN_METRICS_ITL_MIN", "not-a-number"),
-                ("DYN_METRICS_ITL_COUNT", "12.5"),
-            ]),
-            || {
-                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
-                assert_eq!(cfg, (0.001, 2.0, 13));
-            },
-        );
+        let env = fake_env(&[
+            ("DYN_METRICS_ITL_MIN", "not-a-number"),
+            ("DYN_METRICS_ITL_COUNT", "12.5"),
+        ]);
+        let cfg = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+        assert_eq!(cfg, (0.001, 2.0, 13));
     }
 
     #[test]
-    #[serial_test::serial]
     fn bucket_config_rejects_a_parseable_but_invalid_combination() {
-        // min >= max parses fine but cannot produce buckets, so the whole set reverts.
-        temp_env::with_vars(
-            itl_env(&[("DYN_METRICS_ITL_MIN", "5"), ("DYN_METRICS_ITL_MAX", "1")]),
-            || {
-                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
-                assert_eq!(cfg, (0.001, 2.0, 13));
-            },
-        );
+        // min >= max parses fine but cannot produce buckets, so the whole set reverts —
+        // including a COUNT that was valid on its own.
+        let env = fake_env(&[
+            ("DYN_METRICS_ITL_MIN", "5"),
+            ("DYN_METRICS_ITL_MAX", "1"),
+            ("DYN_METRICS_ITL_COUNT", "20"),
+        ]);
+        let cfg = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+        assert_eq!(cfg, (0.001, 2.0, 13));
     }
 
     /// Upper bounds of a histogram's buckets, i.e. the `le` label values that a
@@ -2685,39 +2688,32 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn itl_ceiling_env_var_reaches_the_exported_le_labels() {
-        // End to end: the documented name must move the `le` labels that
-        // dashboards actually read, which is the only reliable confirmation operators have.
-        let mut vars = itl_env(&[
+        let env = fake_env(&[
             ("DYN_METRICS_ITL_MAX", "80"),
             ("DYN_METRICS_ITL_COUNT", "20"),
         ]);
-        // The name prefix would otherwise change which metric family to look for.
-        vars.push(("DYN_METRICS_PREFIX", None));
-        temp_env::with_vars(vars, || {
-            let registry = Registry::new();
-            let metrics = Metrics::new();
-            metrics.register(&registry).unwrap();
-            metrics
-                .inter_token_latency
-                .with_label_values(&["m"])
-                .observe(0.5);
+        let registry = Registry::new();
+        let metrics = Metrics::build(None, &env);
+        metrics.register(&registry).unwrap();
+        metrics
+            .inter_token_latency
+            .with_label_values(&["m"])
+            .observe(0.5);
 
-            let bounds = bucket_upper_bounds(
-                &registry,
-                &format!(
-                    "{}_{}",
-                    name_prefix::FRONTEND,
-                    frontend_service::INTER_TOKEN_LATENCY_SECONDS
-                ),
-            );
-            assert_eq!(
-                bounds.last().copied(),
-                Some(80.0),
-                "top finite bucket should follow DYN_METRICS_ITL_MAX, got {bounds:?}"
-            );
-        });
+        let bounds = bucket_upper_bounds(
+            &registry,
+            &format!(
+                "{}_{}",
+                name_prefix::FRONTEND,
+                frontend_service::INTER_TOKEN_LATENCY_SECONDS
+            ),
+        );
+        assert_eq!(
+            bounds.last().copied(),
+            Some(80.0),
+            "top finite bucket should follow DYN_METRICS_ITL_MAX, got {bounds:?}"
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2565,17 +2565,43 @@ mod tests {
     // binary, not just this module). A module-local mutex would be insufficient because
     // `std::env::{set_var, remove_var}` race against `getenv` in any other thread.
 
+    /// Every ITL bucket variable, new and deprecated, cleared; `overrides` sets the ones a
+    /// test cares about. Clearing all of them matters: an inherited value a test does not
+    /// set — a `_MIN` above the `_MAX` under test, say — fails validation and reverts the
+    /// whole config, failing the assertion for a reason unrelated to what is being tested.
+    fn itl_env(overrides: &[(&'static str, &'static str)]) -> Vec<(&'static str, Option<String>)> {
+        let mut vars: Vec<(&'static str, Option<String>)> = [
+            "DYN_METRICS_ITL_MIN",
+            "DYN_METRICS_ITL_MAX",
+            "DYN_METRICS_ITL_COUNT",
+            "DYN_HISTOGRAM_DYN_METRICS_ITL_MIN",
+            "DYN_HISTOGRAM_DYN_METRICS_ITL_MAX",
+            "DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT",
+        ]
+        .into_iter()
+        .map(|name| (name, None))
+        .collect();
+        for (name, value) in overrides {
+            let slot = vars
+                .iter_mut()
+                .find(|(n, _)| n == name)
+                .expect("override names a variable outside the cleared set");
+            slot.1 = Some((*value).to_string());
+        }
+        vars
+    }
+
     #[test]
     #[serial_test::serial]
     fn bucket_config_reads_the_documented_env_var_names() {
         // PR #4083 prepended DYN_HISTOGRAM_ to a prefix that already started with
         // DYN_METRICS_, so these names silently stopped working.
         temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MIN", Some("0.002")),
-                ("DYN_METRICS_ITL_MAX", Some("80")),
-                ("DYN_METRICS_ITL_COUNT", Some("20")),
-            ],
+            itl_env(&[
+                ("DYN_METRICS_ITL_MIN", "0.002"),
+                ("DYN_METRICS_ITL_MAX", "80"),
+                ("DYN_METRICS_ITL_COUNT", "20"),
+            ]),
             || {
                 let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
                 assert_eq!(cfg, (0.002, 80.0, 20));
@@ -2589,10 +2615,7 @@ mod tests {
         // The doubled form was the only working name between #4083 and this fix, so it
         // stays supported for one release rather than silently reverting to defaults.
         temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MAX", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", Some("80")),
-            ],
+            itl_env(&[("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "80")]),
             || {
                 let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
                 assert_eq!(max, 80.0);
@@ -2604,10 +2627,10 @@ mod tests {
     #[serial_test::serial]
     fn bucket_config_prefers_the_new_name_over_the_deprecated_one() {
         temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MAX", Some("80")),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", Some("30")),
-            ],
+            itl_env(&[
+                ("DYN_METRICS_ITL_MAX", "80"),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "30"),
+            ]),
             || {
                 let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
                 assert_eq!(max, 80.0);
@@ -2621,14 +2644,10 @@ mod tests {
         // Unparseable also warns, which is what makes a typo diagnosable; the warning
         // itself is not asserted here, only that the default is preserved.
         temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MIN", Some("not-a-number")),
-                ("DYN_METRICS_ITL_MAX", None),
-                ("DYN_METRICS_ITL_COUNT", Some("12.5")),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MIN", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
-            ],
+            itl_env(&[
+                ("DYN_METRICS_ITL_MIN", "not-a-number"),
+                ("DYN_METRICS_ITL_COUNT", "12.5"),
+            ]),
             || {
                 let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
                 assert_eq!(cfg, (0.001, 2.0, 13));
@@ -2641,14 +2660,7 @@ mod tests {
     fn bucket_config_rejects_a_parseable_but_invalid_combination() {
         // min >= max parses fine but cannot produce buckets, so the whole set reverts.
         temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MIN", Some("5")),
-                ("DYN_METRICS_ITL_MAX", Some("1")),
-                ("DYN_METRICS_ITL_COUNT", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MIN", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
-            ],
+            itl_env(&[("DYN_METRICS_ITL_MIN", "5"), ("DYN_METRICS_ITL_MAX", "1")]),
             || {
                 let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
                 assert_eq!(cfg, (0.001, 2.0, 13));
@@ -2677,38 +2689,35 @@ mod tests {
     fn itl_ceiling_env_var_reaches_the_exported_le_labels() {
         // End to end: the documented name must move the `le` labels that
         // dashboards actually read, which is the only reliable confirmation operators have.
-        temp_env::with_vars(
-            [
-                ("DYN_METRICS_ITL_MAX", Some("80")),
-                ("DYN_METRICS_ITL_COUNT", Some("20")),
-                ("DYN_METRICS_PREFIX", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
-                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
-            ],
-            || {
-                let registry = Registry::new();
-                let metrics = Metrics::new();
-                metrics.register(&registry).unwrap();
-                metrics
-                    .inter_token_latency
-                    .with_label_values(&["m"])
-                    .observe(0.5);
+        let mut vars = itl_env(&[
+            ("DYN_METRICS_ITL_MAX", "80"),
+            ("DYN_METRICS_ITL_COUNT", "20"),
+        ]);
+        // The name prefix would otherwise change which metric family to look for.
+        vars.push(("DYN_METRICS_PREFIX", None));
+        temp_env::with_vars(vars, || {
+            let registry = Registry::new();
+            let metrics = Metrics::new();
+            metrics.register(&registry).unwrap();
+            metrics
+                .inter_token_latency
+                .with_label_values(&["m"])
+                .observe(0.5);
 
-                let bounds = bucket_upper_bounds(
-                    &registry,
-                    &format!(
-                        "{}_{}",
-                        name_prefix::FRONTEND,
-                        frontend_service::INTER_TOKEN_LATENCY_SECONDS
-                    ),
-                );
-                assert_eq!(
-                    bounds.last().copied(),
-                    Some(80.0),
-                    "top finite bucket should follow DYN_METRICS_ITL_MAX, got {bounds:?}"
-                );
-            },
-        );
+            let bounds = bucket_upper_bounds(
+                &registry,
+                &format!(
+                    "{}_{}",
+                    name_prefix::FRONTEND,
+                    frontend_service::INTER_TOKEN_LATENCY_SECONDS
+                ),
+            );
+            assert_eq!(
+                bounds.last().copied(),
+                Some(80.0),
+                "top finite bucket should follow DYN_METRICS_ITL_MAX, got {bounds:?}"
+            );
+        });
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -410,6 +410,48 @@ fn validate_bucket_config(min: f64, max: f64, count: usize) -> bool {
         && count <= MAX_BUCKET_COUNT
 }
 
+/// Read one histogram bucket setting, e.g. `DYN_METRICS_ITL_MAX`, from the environment.
+///
+/// Falls back to the deprecated doubled form (`DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`)
+/// that PR #4083 introduced by accident, warning so operators can migrate.
+///
+/// Returns `default` when neither name is set. A name that *is* set but cannot be
+/// parsed also returns `default`, but warns first: silently ignoring a typo makes
+/// the whole knob look like it does not exist.
+fn bucket_env_var<T: std::str::FromStr>(prefix: &str, suffix: &str, default: T) -> T {
+    let name = format!("{prefix}_{suffix}");
+    let found = match std::env::var(&name) {
+        Ok(value) => Some((name, value)),
+        Err(_) => {
+            let deprecated = format!(
+                "{}{prefix}_{suffix}",
+                env_metrics::DEPRECATED_HISTOGRAM_PREFIX
+            );
+            std::env::var(&deprecated).ok().map(|value| {
+                tracing::warn!(
+                    deprecated = %deprecated,
+                    replacement = %name,
+                    "Deprecated histogram bucket environment variable; rename it, \
+                     support for the old name will be removed in a future release"
+                );
+                (deprecated, value)
+            })
+        }
+    };
+
+    match found {
+        None => default,
+        Some((name, value)) => value.parse::<T>().unwrap_or_else(|_| {
+            tracing::warn!(
+                env_var = %name,
+                value = %value,
+                "Could not parse histogram bucket environment variable, using default"
+            );
+            default
+        }),
+    }
+}
+
 /// Parse histogram bucket configuration from environment variables
 /// Returns (min, max, count) with defaults if not specified
 fn parse_bucket_config(
@@ -427,19 +469,9 @@ fn parse_bucket_config(
         );
         return (1.0, 10.0, 10);
     }
-    let env_prefix = format!("{}{}", env_metrics::HISTOGRAM_PREFIX, env_prefix);
-    let mut min = std::env::var(format!("{env_prefix}_MIN"))
-        .ok()
-        .and_then(|s| s.parse::<f64>().ok())
-        .unwrap_or(default_min);
-    let mut max = std::env::var(format!("{env_prefix}_MAX"))
-        .ok()
-        .and_then(|s| s.parse::<f64>().ok())
-        .unwrap_or(default_max);
-    let mut count = std::env::var(format!("{env_prefix}_COUNT"))
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(default_count);
+    let mut min = bucket_env_var(env_prefix, "MIN", default_min);
+    let mut max = bucket_env_var(env_prefix, "MAX", default_max);
+    let mut count = bucket_env_var(env_prefix, "COUNT", default_count);
 
     if !validate_bucket_config(min, max, count) {
         tracing::warn!(
@@ -729,7 +761,7 @@ impl Metrics {
     /// All histograms use log-spaced buckets rounded to 2 significant figures. Bucket configuration
     /// can be customized via environment variables (MIN: minimum value, MAX: maximum value, COUNT: number of buckets):
     ///
-    /// - `DYN_METRICS_REQUEST_DURATION_{MIN,MAX,COUNT}` - Request duration histogram (defaults: 1.0, 256.0, 10)
+    /// - `DYN_METRICS_REQUEST_DURATION_{MIN,MAX,COUNT}` - Request duration histogram (defaults: 1.0, 512.0, 10)
     /// - `DYN_METRICS_INPUT_SEQUENCE_{MIN,MAX,COUNT}` - Input sequence length histogram (defaults: 50.0, 128000.0, 12)
     /// - `DYN_METRICS_OUTPUT_SEQUENCE_{MIN,MAX,COUNT}` - Output sequence length histogram (defaults: 50.0, 32000.0, 10)
     /// - `DYN_METRICS_TTFT_{MIN,MAX,COUNT}` - Time to first token histogram (defaults: 0.001, 480.0, 18)
@@ -830,7 +862,7 @@ impl Metrics {
 
         // Request duration buckets: configurable via DYN_METRICS_REQUEST_DURATION_{MIN,MAX,COUNT}
         let (req_dur_min, req_dur_max, req_dur_count) =
-            parse_bucket_config("DYN_METRICS_REQUEST_DURATION", 1.0, 512.0, 10);
+            parse_bucket_config(env_metrics::DYN_METRICS_REQUEST_DURATION, 1.0, 512.0, 10);
         let request_duration_buckets =
             generate_log_buckets(req_dur_min, req_dur_max, req_dur_count);
 
@@ -846,7 +878,7 @@ impl Metrics {
 
         // Input sequence length buckets: configurable via DYN_METRICS_INPUT_SEQUENCE_{MIN,MAX,COUNT}
         let (isl_min, isl_max, isl_count) =
-            parse_bucket_config("DYN_METRICS_INPUT_SEQUENCE", 50.0, 128000.0, 12);
+            parse_bucket_config(env_metrics::DYN_METRICS_INPUT_SEQUENCE, 50.0, 128000.0, 12);
         let input_sequence_buckets = generate_log_buckets(isl_min, isl_max, isl_count);
 
         let input_sequence_length = HistogramVec::new(
@@ -861,7 +893,7 @@ impl Metrics {
 
         // Output sequence length buckets: configurable via DYN_METRICS_OUTPUT_SEQUENCE_{MIN,MAX,COUNT}
         let (osl_min, osl_max, osl_count) =
-            parse_bucket_config("DYN_METRICS_OUTPUT_SEQUENCE", 50.0, 32000.0, 10);
+            parse_bucket_config(env_metrics::DYN_METRICS_OUTPUT_SEQUENCE, 50.0, 32000.0, 10);
         let output_sequence_buckets = generate_log_buckets(osl_min, osl_max, osl_count);
 
         let output_sequence_length = HistogramVec::new(
@@ -885,7 +917,7 @@ impl Metrics {
 
         // Time to first token buckets: configurable via DYN_METRICS_TTFT_{MIN,MAX,COUNT}
         let (ttft_min, ttft_max, ttft_count) =
-            parse_bucket_config("DYN_METRICS_TTFT", 0.001, 480.0, 18);
+            parse_bucket_config(env_metrics::DYN_METRICS_TTFT, 0.001, 480.0, 18);
         let time_to_first_token_buckets = generate_log_buckets(ttft_min, ttft_max, ttft_count);
 
         let time_to_first_token = HistogramVec::new(
@@ -899,7 +931,8 @@ impl Metrics {
         .unwrap();
 
         // Inter-token latency buckets: configurable via DYN_METRICS_ITL_{MIN,MAX,COUNT}
-        let (itl_min, itl_max, itl_count) = parse_bucket_config("DYN_METRICS_ITL", 0.001, 2.0, 13);
+        let (itl_min, itl_max, itl_count) =
+            parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
         let inter_token_latency_buckets = generate_log_buckets(itl_min, itl_max, itl_count);
 
         let inter_token_latency = HistogramVec::new(
@@ -917,7 +950,7 @@ impl Metrics {
         // range), so 1ms..10s on a log scale gives p50/p99 resolution that
         // the 1..512s `request_duration` buckets cannot.
         let (emb_min, emb_max, emb_count) =
-            parse_bucket_config("DYN_METRICS_EMBEDDING_LATENCY", 0.001, 10.0, 14);
+            parse_bucket_config(env_metrics::DYN_METRICS_EMBEDDING_LATENCY, 0.001, 10.0, 14);
         let embedding_latency_buckets = generate_log_buckets(emb_min, emb_max, emb_count);
 
         let embedding_latency = HistogramVec::new(
@@ -2525,6 +2558,157 @@ mod tests {
                 buckets[i]
             );
         }
+    }
+
+    // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
+    // `#[serial_test::serial]` (serialize against every other env-touching test in the
+    // binary, not just this module). A module-local mutex would be insufficient because
+    // `std::env::{set_var, remove_var}` race against `getenv` in any other thread.
+
+    #[test]
+    #[serial_test::serial]
+    fn bucket_config_reads_the_documented_env_var_names() {
+        // PR #4083 prepended DYN_HISTOGRAM_ to a prefix that already started with
+        // DYN_METRICS_, so these names silently stopped working.
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MIN", Some("0.002")),
+                ("DYN_METRICS_ITL_MAX", Some("80")),
+                ("DYN_METRICS_ITL_COUNT", Some("20")),
+            ],
+            || {
+                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+                assert_eq!(cfg, (0.002, 80.0, 20));
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bucket_config_falls_back_to_the_deprecated_doubled_name() {
+        // The doubled form was the only working name between #4083 and this fix, so it
+        // stays supported for one release rather than silently reverting to defaults.
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MAX", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", Some("80")),
+            ],
+            || {
+                let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+                assert_eq!(max, 80.0);
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bucket_config_prefers_the_new_name_over_the_deprecated_one() {
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MAX", Some("80")),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", Some("30")),
+            ],
+            || {
+                let (_, max, _) = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+                assert_eq!(max, 80.0);
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bucket_config_falls_back_to_defaults_for_unset_and_unparseable_values() {
+        // Unparseable also warns, which is what makes a typo diagnosable; the warning
+        // itself is not asserted here, only that the default is preserved.
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MIN", Some("not-a-number")),
+                ("DYN_METRICS_ITL_MAX", None),
+                ("DYN_METRICS_ITL_COUNT", Some("12.5")),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MIN", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
+            ],
+            || {
+                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+                assert_eq!(cfg, (0.001, 2.0, 13));
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bucket_config_rejects_a_parseable_but_invalid_combination() {
+        // min >= max parses fine but cannot produce buckets, so the whole set reverts.
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MIN", Some("5")),
+                ("DYN_METRICS_ITL_MAX", Some("1")),
+                ("DYN_METRICS_ITL_COUNT", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MIN", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
+            ],
+            || {
+                let cfg = parse_bucket_config(env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
+                assert_eq!(cfg, (0.001, 2.0, 13));
+            },
+        );
+    }
+
+    /// Upper bounds of a histogram's buckets, i.e. the `le` label values that a
+    /// dashboard's `histogram_quantile` query sees on `/metrics`.
+    fn bucket_upper_bounds(registry: &Registry, metric_name: &str) -> Vec<f64> {
+        registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == metric_name)
+            .expect("histogram not registered")
+            .get_metric()[0]
+            .get_histogram()
+            .get_bucket()
+            .iter()
+            .map(|b| b.upper_bound())
+            .collect()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn itl_ceiling_env_var_reaches_the_exported_le_labels() {
+        // End to end: the documented name must move the `le` labels that
+        // dashboards actually read, which is the only reliable confirmation operators have.
+        temp_env::with_vars(
+            [
+                ("DYN_METRICS_ITL_MAX", Some("80")),
+                ("DYN_METRICS_ITL_COUNT", Some("20")),
+                ("DYN_METRICS_PREFIX", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", None),
+                ("DYN_HISTOGRAM_DYN_METRICS_ITL_COUNT", None),
+            ],
+            || {
+                let registry = Registry::new();
+                let metrics = Metrics::new();
+                metrics.register(&registry).unwrap();
+                metrics
+                    .inter_token_latency
+                    .with_label_values(&["m"])
+                    .observe(0.5);
+
+                let bounds = bucket_upper_bounds(
+                    &registry,
+                    &format!(
+                        "{}_{}",
+                        name_prefix::FRONTEND,
+                        frontend_service::INTER_TOKEN_LATENCY_SECONDS
+                    ),
+                );
+                assert_eq!(
+                    bounds.last().copied(),
+                    Some(80.0),
+                    "top finite bucket should follow DYN_METRICS_ITL_MAX, got {bounds:?}"
+                );
+            },
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -423,8 +423,8 @@ fn system_env(name: &str) -> Option<String> {
 
 /// Read one histogram bucket setting, e.g. `DYN_METRICS_ITL_MAX`, from the environment.
 ///
-/// Falls back to the deprecated doubled form (`DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`)
-/// that PR #4083 introduced by accident, warning so operators can migrate.
+/// Falls back to the deprecated doubled form (`DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`),
+/// warning so operators can migrate off it.
 ///
 /// Returns `default` when neither name is set. A name that *is* set but cannot be
 /// parsed also returns `default`, but warns first: silently ignoring a typo makes
@@ -2618,8 +2618,8 @@ mod tests {
 
     #[test]
     fn bucket_config_reads_the_documented_env_var_names() {
-        // PR #4083 prepended DYN_HISTOGRAM_ to a prefix that already started with
-        // DYN_METRICS_, so these names silently stopped working.
+        // These names were once read under an extra DYN_HISTOGRAM_ prefix, which
+        // silently stopped them working; they must resolve as documented.
         let env = fake_env(&[
             ("DYN_METRICS_ITL_MIN", "0.002"),
             ("DYN_METRICS_ITL_MAX", "80"),
@@ -2631,8 +2631,8 @@ mod tests {
 
     #[test]
     fn bucket_config_falls_back_to_the_deprecated_doubled_name() {
-        // The doubled form was the only working name between #4083 and this fix, so it
-        // stays supported for one release rather than silently reverting to defaults.
+        // The doubled form was the only name that worked for several releases, so it
+        // stays supported for one more rather than silently reverting to defaults.
         let env = fake_env(&[("DYN_HISTOGRAM_DYN_METRICS_ITL_MAX", "80")]);
         let (_, max, _) = parse_bucket_config(&env, env_metrics::DYN_METRICS_ITL, 0.001, 2.0, 13);
         assert_eq!(max, 80.0);

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -511,6 +511,12 @@ pub mod llm {
         /// `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`. The doubled form is still read as
         /// a fallback, with a warning, and will be removed in a future release.
         pub const DEPRECATED_HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
+
+        /// Former name of [`DEPRECATED_HISTOGRAM_PREFIX`], kept so that code outside
+        /// this workspace importing it keeps compiling. Remove together with the
+        /// doubled-name fallback.
+        #[deprecated(note = "use DEPRECATED_HISTOGRAM_PREFIX")]
+        pub const HISTOGRAM_PREFIX: &str = DEPRECATED_HISTOGRAM_PREFIX;
     }
 
     /// Forward-pass-metrics trace configuration.

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -505,11 +505,10 @@ pub mod llm {
 
         /// Deprecated prefix for the histogram bucket variables above.
         ///
-        /// PR #4083 centralized environment constants and began prepending this
-        /// to prefixes that already started with `DYN_METRICS_`, so the variables
-        /// silently became doubled names such as
-        /// `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`. The doubled form is still read as
-        /// a fallback, with a warning, and will be removed in a future release.
+        /// This was once prepended to prefixes that already started with
+        /// `DYN_METRICS_`, so the variables were read under doubled names such as
+        /// `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`. The doubled form is still accepted
+        /// as a fallback, with a warning, and will be removed in a future release.
         pub const DEPRECATED_HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
 
         /// Former name of [`DEPRECATED_HISTOGRAM_PREFIX`], kept so that code outside

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -487,9 +487,30 @@ pub mod llm {
         /// Custom metrics prefix (overrides default "dynamo_frontend")
         pub const DYN_METRICS_PREFIX: &str = "DYN_METRICS_PREFIX";
 
-        /// Histogram bucket configuration (pattern: `<PREFIX>_MIN`, `<PREFIX>_MAX`, `<PREFIX>_COUNT`)
-        /// Example: DYN_HISTOGRAM_TTFT_MIN, DYN_HISTOGRAM_TTFT_MAX, DYN_HISTOGRAM_TTFT_COUNT
-        pub const HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
+        /// Histogram bucket configuration prefixes. Each is suffixed with `_MIN`,
+        /// `_MAX`, or `_COUNT` to form the variable that tunes one frontend
+        /// histogram's log-spaced buckets, for example `DYN_METRICS_ITL_MAX`.
+        /// Values are read once, when the frontend builds its metrics.
+        pub const DYN_METRICS_REQUEST_DURATION: &str = "DYN_METRICS_REQUEST_DURATION";
+        /// See [`DYN_METRICS_REQUEST_DURATION`].
+        pub const DYN_METRICS_INPUT_SEQUENCE: &str = "DYN_METRICS_INPUT_SEQUENCE";
+        /// See [`DYN_METRICS_REQUEST_DURATION`].
+        pub const DYN_METRICS_OUTPUT_SEQUENCE: &str = "DYN_METRICS_OUTPUT_SEQUENCE";
+        /// See [`DYN_METRICS_REQUEST_DURATION`].
+        pub const DYN_METRICS_TTFT: &str = "DYN_METRICS_TTFT";
+        /// See [`DYN_METRICS_REQUEST_DURATION`].
+        pub const DYN_METRICS_ITL: &str = "DYN_METRICS_ITL";
+        /// See [`DYN_METRICS_REQUEST_DURATION`].
+        pub const DYN_METRICS_EMBEDDING_LATENCY: &str = "DYN_METRICS_EMBEDDING_LATENCY";
+
+        /// Deprecated prefix for the histogram bucket variables above.
+        ///
+        /// PR #4083 centralized environment constants and began prepending this
+        /// to prefixes that already started with `DYN_METRICS_`, so the variables
+        /// silently became doubled names such as
+        /// `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX`. The doubled form is still read as
+        /// a fallback, with a warning, and will be removed in a future release.
+        pub const DEPRECATED_HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
     }
 
     /// Forward-pass-metrics trace configuration.
@@ -1023,6 +1044,12 @@ mod tests {
             llm::DYN_TOKEN_ECHO_DELAY_MS,
             llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
             llm::metrics::DYN_METRICS_PREFIX,
+            llm::metrics::DYN_METRICS_REQUEST_DURATION,
+            llm::metrics::DYN_METRICS_INPUT_SEQUENCE,
+            llm::metrics::DYN_METRICS_OUTPUT_SEQUENCE,
+            llm::metrics::DYN_METRICS_TTFT,
+            llm::metrics::DYN_METRICS_ITL,
+            llm::metrics::DYN_METRICS_EMBEDDING_LATENCY,
             llm::audit::DYN_AUDIT_SINKS,
             llm::audit::DYN_AUDIT_FORCE_LOGGING,
             llm::audit::DYN_AUDIT_CAPACITY,


### PR DESCRIPTION
## Overview:

Frontend histogram bucket environment variables have done nothing since v0.8.0.

`parse_bucket_config` prepended `DYN_HISTOGRAM_` to prefixes that already started with `DYN_METRICS_`, so the variable actually read was `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX` while the doc comment said `DYN_METRICS_ITL_MAX`. An unset variable falls back to the default without logging, so the documented name was indistinguishable from the feature not existing.


## Details:

- Remove the doubled prefix. The documented names work again.
- Read the doubled form as a deprecated fallback with a warning, so configs written since v0.8.0 keep working.
- Use named constants at the call sites instead of bare string literals.
- Warn when a variable is set but unparseable. Previously silent.
- Doc comment: request-duration default `256.0` → `512.0`, matching the code since #8087.
- Document all six histograms in the frontend configuration reference. None were documented before.

Restored names, each taking `_MIN`, `_MAX` and `_COUNT`:

```
DYN_METRICS_REQUEST_DURATION_*
DYN_METRICS_INPUT_SEQUENCE_*
DYN_METRICS_OUTPUT_SEQUENCE_*
DYN_METRICS_TTFT_*
DYN_METRICS_ITL_*
DYN_METRICS_EMBEDDING_LATENCY_*
```

No default values change, so no existing `le` set moves and dashboards see no discontinuity.

## Where should the reviewer start?

`lib/llm/src/http/service/metrics.rs`:

- `bucket_env_var()` — new helper: lookup, deprecated fallback, parse warning.
- `parse_bucket_config()` — the one deleted concatenation line.

Everything else follows from those two.

## Validation

Six new tests in `metrics.rs` cover the restored names, the deprecated fallback, new-name precedence, unset and unparseable values, and a parseable-but-invalid combination. One is end-to-end: it registers the metrics and asserts the exported `le` labels. All six were re-run against the pre-fix code to confirm they fail on it.

| Check | Result |
| --- | --- |
| `cargo test -p dynamo-llm --lib http::service` | 287 passed |
| `cargo test -p dynamo-runtime --lib config::environment_names` | 2 passed |
| `cargo clippy -p dynamo-llm -p dynamo-runtime --all-targets` | clean |
| `docs_lint.py --scan docs` | 0 errors |

Also verified in a container against a live frontend, reading `/metrics` after a successful request:

| Environment | Exported buckets |
| --- | --- |
| _none_ | 13, top `le=2` |
| `DYN_METRICS_ITL_MAX=80` `DYN_METRICS_ITL_COUNT=20` | 20, top `le=80` |
| `DYN_HISTOGRAM_DYN_METRICS_ITL_MAX=80` | 20, top `le=80`, plus deprecation warning |
| both names set | new name wins |
| `DYN_METRICS_ITL_MAX=eighty` | warns, falls back to `le=2` |

## Related Issues

- Closes: DIS-2871
