### PR TITLE
perf(runtime): use four configurable ZMQ I/O threads

### DIFF
--- a/docs/fern/pages/reference/components/runtime-configuration.mdx
+++ b/docs/fern/pages/reference/components/runtime-configuration.mdx
@@ -164,6 +164,17 @@ Unless a field is marked environment-only, it has both a CLI flag and an environ
   NATS or ZMQ broker mode.
 </ParamField>
 
+<ParamField path="DYN_ZMQ_IO_THREADS" type="integer" default="4">
+  Number of libzmq background I/O threads in the process-wide event-plane context. All event-plane
+  PUB/SUB sockets in a frontend or worker process share this context. This setting does not change
+  the Tokio runtime size or the number of KV indexer threads.
+
+  Set a positive integer before starting the process. Dynamo reads the value when it first creates
+  the shared context; invalid values fail context initialization. Restart the process to change it.
+  Set `1` to restore the previous single-thread setting. This variable does not affect NATS or ZMQ
+  contexts created outside the shared event-plane transport.
+</ParamField>
+
 <ParamField path="--connector" type="string" default="null">
   KV-cache transfer connector. Accepts zero or more values. Deprecated for vLLM — use `--kv-transfer-config` instead. For TRT-LLM, valid options are `nixl`, `lmcache`, `kvbm`, `null`, and `none`.
 

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use lru::LruCache;
@@ -476,21 +476,17 @@ impl EventPublisher {
                     let advertised_host = event_plane_host_from_env()?;
                     let (pub_transport, actual_bind_endpoint) = std::thread::spawn({
                         let topic = topic.clone();
-                        move || {
+                        move || -> Result<(ZmqPubTransport, String)> {
                             let rt = tokio::runtime::Builder::new_current_thread()
                                 .enable_all()
                                 .build()
-                                .expect("Failed to create Tokio runtime for ZMQ");
+                                .context("Failed to create Tokio runtime for ZMQ")?;
 
-                            rt.block_on(async move {
-                                zmq_transport::ZmqPubTransport::bind("tcp://0.0.0.0:0", &topic)
-                                    .await
-                                    .expect("Failed to bind ZMQ publisher")
-                            })
+                            rt.block_on(ZmqPubTransport::bind("tcp://0.0.0.0:0", &topic))
                         }
                     })
                     .join()
-                    .expect("Failed to join ZMQ initialization thread");
+                    .map_err(|_| anyhow::anyhow!("ZMQ initialization thread panicked"))??;
 
                     let public_endpoint =
                         direct_zmq_public_endpoint(advertised_host, &actual_bind_endpoint)?;

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -738,7 +738,7 @@ mod tests {
             let context = super::configured_zmq_context(value.map(OsStr::new)).unwrap();
             assert_eq!(context.get_io_threads().unwrap(), expected);
         }
-        for value in ["0", "-1", "invalid", "", "2147483648"] {
+        for value in ["0", "invalid", "2147483648"] {
             assert!(super::configured_zmq_context(Some(OsStr::new(value))).is_err());
         }
         #[cfg(unix)]

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -14,12 +14,14 @@
 //! - Frame 2: sequence (8 bytes, u64 big-endian) - for fast deduplication
 //! - Frame 3: Binary frame (5-byte header + EventEnvelope payload)
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use std::sync::{Arc, OnceLock};
+use once_cell::sync::OnceCell;
+use std::ffi::OsStr;
+use std::sync::Arc;
 use thiserror::Error;
 use tmq::{
     AsZmqSocket, Context, Message, Multipart, SocketBuilder,
@@ -33,30 +35,32 @@ use tokio_util::task::AbortOnDropHandle;
 ///
 /// libzmq spawns background I/O threads per `Context`, so all PUB/SUB sockets
 /// share one. `zmq::Context` is reference-counted; clones drive the same context.
-fn shared_zmq_context() -> Context {
-    static CONTEXT: OnceLock<Context> = OnceLock::new();
+fn shared_zmq_context() -> Result<Context> {
+    static CONTEXT: OnceCell<Context> = OnceCell::new();
     CONTEXT
-        .get_or_init(|| {
+        .get_or_try_init(|| {
             let value = std::env::var_os("DYN_ZMQ_IO_THREADS");
-            let value = value.as_ref().map(|value| {
-                value
-                    .to_str()
-                    .expect("DYN_ZMQ_IO_THREADS must be a positive integer")
-            });
-            configured_zmq_context(value).expect("failed to configure event-plane ZMQ I/O threads")
+            configured_zmq_context(value.as_deref())
         })
-        .clone()
+        .cloned()
 }
 
-fn configured_zmq_context(value: Option<&str>) -> Result<Context> {
-    let io_threads = value.unwrap_or("4").parse::<i32>()?;
+fn configured_zmq_context(value: Option<&OsStr>) -> Result<Context> {
+    let io_threads = value
+        .unwrap_or_else(|| OsStr::new("4"))
+        .to_str()
+        .context("DYN_ZMQ_IO_THREADS must be valid UTF-8")?
+        .parse::<i32>()
+        .context("DYN_ZMQ_IO_THREADS must be a positive integer")?;
     anyhow::ensure!(
         io_threads > 0,
         "DYN_ZMQ_IO_THREADS must be a positive integer"
     );
     let context = Context::new();
     // Configure the process-wide context before creating any PUB/SUB sockets.
-    context.set_io_threads(io_threads)?;
+    context
+        .set_io_threads(io_threads)
+        .context("failed to apply DYN_ZMQ_IO_THREADS to the event-plane ZMQ context")?;
     tracing::info!(io_threads, "Configured shared event-plane ZMQ context");
     Ok(context)
 }
@@ -192,7 +196,7 @@ impl ZmqPubTransport {
             endpoint.to_string()
         };
 
-        let ctx = shared_zmq_context();
+        let ctx = shared_zmq_context()?;
         let socket = bind_tmq_socket(configure_publish_builder(publish(&ctx)), &actual_endpoint)?;
 
         tracing::info!(
@@ -217,7 +221,7 @@ impl ZmqPubTransport {
 
     /// Connect to single broker XSUB endpoint (broker mode)
     pub async fn connect(xsub_endpoint: &str, topic: &str) -> Result<Self> {
-        let ctx = shared_zmq_context();
+        let ctx = shared_zmq_context()?;
         let socket = connect_tmq_socket(configure_publish_builder(publish(&ctx)), xsub_endpoint)?;
 
         tracing::info!(
@@ -240,7 +244,7 @@ impl ZmqPubTransport {
             anyhow::bail!("Cannot connect to zero endpoints");
         };
 
-        let ctx = shared_zmq_context();
+        let ctx = shared_zmq_context()?;
         let socket = connect_tmq_socket(configure_publish_builder(publish(&ctx)), first_endpoint)?;
 
         for endpoint in endpoints {
@@ -464,7 +468,7 @@ impl ZmqSubTransport {
 
     fn connect_socket_with_rcvhwm(endpoint: &str, topic: &str, rcvhwm: i32) -> Result<Subscribe> {
         anyhow::ensure!(rcvhwm > 0, "ZMQ receive HWM must be greater than zero");
-        let ctx = shared_zmq_context();
+        let ctx = shared_zmq_context()?;
         let socket = connect_tmq_socket(
             configure_subscribe_builder_with_hwm(subscribe(&ctx), rcvhwm),
             endpoint,
@@ -588,7 +592,7 @@ impl ZmqSubTransport {
             anyhow::bail!("Cannot connect to zero endpoints");
         };
 
-        let ctx = shared_zmq_context();
+        let ctx = shared_zmq_context()?;
         let socket =
             connect_tmq_socket(configure_subscribe_builder(subscribe(&ctx)), first_endpoint)?
                 .subscribe(topic.as_bytes())?;
@@ -730,12 +734,17 @@ impl EventTransportRx for ZmqSubTransport {
 mod tests {
     #[test]
     fn configures_zmq_io_threads() {
-        for (value, expected) in [(None, 4), (Some("1"), 1), (Some("4"), 4)] {
-            let context = super::configured_zmq_context(value).unwrap();
+        for (value, expected) in [(None, 4), (Some("1"), 1)] {
+            let context = super::configured_zmq_context(value.map(OsStr::new)).unwrap();
             assert_eq!(context.get_io_threads().unwrap(), expected);
         }
         for value in ["0", "-1", "invalid", "", "2147483648"] {
-            assert!(super::configured_zmq_context(Some(value)).is_err());
+            assert!(super::configured_zmq_context(Some(OsStr::new(value))).is_err());
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            assert!(super::configured_zmq_context(Some(OsStr::from_bytes(b"\xff"))).is_err());
         }
     }
 

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -35,7 +35,30 @@ use tokio_util::task::AbortOnDropHandle;
 /// share one. `zmq::Context` is reference-counted; clones drive the same context.
 fn shared_zmq_context() -> Context {
     static CONTEXT: OnceLock<Context> = OnceLock::new();
-    CONTEXT.get_or_init(Context::new).clone()
+    CONTEXT
+        .get_or_init(|| {
+            let value = std::env::var_os("DYN_ZMQ_IO_THREADS");
+            let value = value.as_ref().map(|value| {
+                value
+                    .to_str()
+                    .expect("DYN_ZMQ_IO_THREADS must be a positive integer")
+            });
+            configured_zmq_context(value).expect("failed to configure event-plane ZMQ I/O threads")
+        })
+        .clone()
+}
+
+fn configured_zmq_context(value: Option<&str>) -> Result<Context> {
+    let io_threads = value.unwrap_or("4").parse::<i32>()?;
+    anyhow::ensure!(
+        io_threads > 0,
+        "DYN_ZMQ_IO_THREADS must be a positive integer"
+    );
+    let context = Context::new();
+    // Configure the process-wide context before creating any PUB/SUB sockets.
+    context.set_io_threads(io_threads)?;
+    tracing::info!(io_threads, "Configured shared event-plane ZMQ context");
+    Ok(context)
 }
 
 /// High Water Mark (HWM) for ZMQ sockets.
@@ -705,6 +728,17 @@ impl EventTransportRx for ZmqSubTransport {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn configures_zmq_io_threads() {
+        for (value, expected) in [(None, 4), (Some("1"), 1), (Some("4"), 4)] {
+            let context = super::configured_zmq_context(value).unwrap();
+            assert_eq!(context.get_io_threads().unwrap(), expected);
+        }
+        for value in ["0", "-1", "invalid", "", "2147483648"] {
+            assert!(super::configured_zmq_context(Some(value)).is_err());
+        }
+    }
+
     use super::*;
     use crate::transports::event_plane::{EventEnvelope, MsgpackCodec};
     use std::collections::HashSet;


### PR DESCRIPTION
## Summary

Use four libzmq I/O threads by default in the process-wide shared event-plane context. Add `DYN_ZMQ_IO_THREADS` to override the positive thread count; set `1` to restore the old setting.

- Read the setting once, before creating PUB/SUB sockets, and log the effective count.
- Apply it to shared event-plane contexts in frontend and worker processes. Do not change Tokio or KV indexer thread counts, socket limits, message formats, or queues.
- Return configuration errors through the existing transport constructor `Result` paths instead of panicking. Invalid values, integer overflow, non-UTF-8 input, and context-setting failures identify `DYN_ZMQ_IO_THREADS` in the error. Cache only successful initialization. Direct-mode publisher setup also propagates runtime and bind errors through its initialization thread, and converts a thread panic into an error returned to the caller.

Event delivery and router freshness remain best-effort. The change adds receive capacity, not a freshness guarantee.

## Performance Evidence

Prior matched ARM measurements used two NUMA-local frontends, 2,048 mock workers, speedup 10, AgentX 336, concurrency 6,144, BPE threads 8, QUIC responses, replica sync, and 64 publishers per SUB socket. Only the frontend I/O-thread count changed between arms.

| Measurement | One I/O thread | Four I/O threads |
|---|---:|---:|
| Mean publisher-to-SUB age in final 20 seconds, FE0 / FE1 | 22.6 / 19.3 s | 5.26 / 4.40 ms |
| Received KV events/s, both frontends | 514,826 | 608,130 |
| Issued requests/s | 6,264.1 | 5,793.2 |
| Frontend CPU ms/issued request | 12.43 | 15.45 |

Four threads removed the growing receive backlog in this workload. They also processed more events per request, so CPU/request is not a like-for-like measure of ingest efficiency. Throughput was 7.5% lower in this one-pair comparison; this is not a throughput-win claim. Both arms had zero request errors or cancellations.

These measurements used identical diagnostic builds based on `c447a3f49b30f3987457760306053515c9b5de7e`, not this PR's newer base, `45e7111493787a67141721e4c5e323149b5e5a80`. Mockers remained at one I/O thread during the measurements. This PR makes four the process-wide default; the benchmark does not measure that default change on workers.

## Validation

- `cargo test --locked -p dynamo-runtime --lib transports::event_plane`: 45 passed.
- `cargo check --locked -p dynamo-runtime`: passed.
- `cargo clippy --locked -p dynamo-runtime --lib --tests -- -D warnings`: passed.
- The existing configuration test checks default four, explicit one, and one representative each for non-positive, malformed, overflowing, and Unix non-UTF-8 values. Redundant cases were removed; no new test functions, fixtures, or dependencies were added.
- Changed Rust file formatted; `git diff --check` passed. The earlier targeted docs lint and `fern check` results remain unchanged; this follow-up does not modify the docs.
- `fern docs broken-links` reports one existing link error in the unchanged `deepseek-v4-pro-0813.mdx` recipe, also present at the base SHA. No link errors were reported for the modified runtime configuration page.

## Where should the reviewer start?

`lib/runtime/src/transports/event_plane/zmq_transport.rs::shared_zmq_context` and `configured_zmq_context`.

## Related Issues

- [x] Confirmed — no related issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for the number of background messaging I/O threads.
  - The setting defaults to four threads and supports restoring single-thread behavior with a value of one.
  - Invalid settings return errors when the event-plane transport is initialized.

- **Documentation**
  - Documented configuration requirements, supported values, default behavior, and restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
