### PR TITLE
fix(vllm): [cherry-pick 1.5.0] preserve mixed media on decode handoff

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -848,17 +848,30 @@ class VllmMultimodalRequestProcessor:
                 ]
                 has_mm_data = False
 
-            # Preserve the fallback: video/audio media is loaded again
-            # on decode because the handoff currently carries image metadata only.
-            if multi_modal_data is None and has_mm_data:
+            # Video/audio media is loaded again on decode because the handoff
+            # currently carries image metadata only. For mixed requests, merge
+            # it with the reconstructed Qwen image placeholder.
+            if has_mm_data:
                 mm_map = request["multi_modal_data"]
-                if mm_map.get(VIDEO_URL_KEY) or mm_map.get(AUDIO_URL_KEY):
-                    multi_modal_data = await self.extract_multimodal_data(
-                        request,
+                local_mm_map = {
+                    key: mm_map[key]
+                    for key in (VIDEO_URL_KEY, AUDIO_URL_KEY)
+                    if mm_map.get(key)
+                }
+                if local_mm_map:
+                    local_request = dict(request)
+                    local_request["multi_modal_data"] = local_mm_map
+                    local_mm_data = await self.extract_multimodal_data(
+                        local_request,
                         request_id,
                         context,
                         mm_processor_kwargs,
                     )
+                    if local_mm_data:
+                        if multi_modal_data is None:
+                            multi_modal_data = local_mm_data
+                        else:
+                            multi_modal_data.update(local_mm_data)
         elif mode == DisaggregationMode.AGGREGATED:
             pre_rendered = await self.try_receive_mm_kwargs(request)
             if pre_rendered is None:

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -982,6 +982,49 @@ async def test_qwen_decode_reconstructs_placeholder_embeddings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_qwen_decode_merges_placeholder_image_with_reloaded_video(monkeypatch):
+    processor = _processor()
+    image = {"placeholder": object()}
+    video = object()
+    processor.video_loader.load_video_batch.return_value = [video]
+    monkeypatch.setattr(
+        mod,
+        "construct_qwen_decode_mm_data",
+        lambda grid, shape, request_id: {"image": image},
+    )
+    video_items = [{"Url": "https://example.com/video.mp4"}]
+
+    prepared = await _prepare_prompt(
+        processor,
+        {
+            "token_ids": [1, 2],
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/image.png"}],
+                "video_url": video_items,
+            },
+            "prefill_result": {
+                "disaggregated_params": {
+                    "embedding_params": {
+                        "image_grid_thw": [[1, 2, 2]],
+                        "embeddings_shape": [1, 16],
+                    }
+                }
+            },
+        },
+        "request-mixed-decode",
+        None,
+        DisaggregationMode.DECODE,
+    )
+
+    assert prepared.prompt["multi_modal_data"] == {
+        "image": image,
+        "video": video,
+    }
+    processor.image_loader.load_image_batch.assert_not_awaited()
+    processor.video_loader.load_video_batch.assert_awaited_once_with(video_items, {})
+
+
+@pytest.mark.asyncio
 async def test_non_qwen_decode_uses_expanded_prompt_tokens():
     processor = _processor(model="llava-hf/llava-1.5-7b-hf")
 

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -21,6 +21,7 @@ from tests.utils.multimodal import (
     make_image_payload_b64,
     make_image_payload_cached_tokens,
     make_image_payload_uuid_passthrough,
+    make_mixed_image_video_payload,
     make_qwen35_custom_encoder_multi_image_payload,
     make_qwen35_custom_encoder_payload,
     make_video_payload,
@@ -281,7 +282,12 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
             ),
             "epd_video": TopologyConfig(
-                marks=[pytest.mark.post_merge, pytest.mark.installs_extra_dependencies],
+                # E/P/D regression gate: the decode handoff must retain both
+                # the reconstructed image placeholder and reloaded video.
+                marks=[
+                    pytest.mark.post_merge,
+                    pytest.mark.installs_extra_dependencies,
+                ],
                 timeout_s=600,
                 delayed_start=60,
                 single_gpu=True,
@@ -296,7 +302,22 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         "opencv-python-headless"
                     ],
                 },
-                tests=[MmCase(payload=make_video_payload(MULTIMODAL_VIDEO_EXPECTED))],
+                tests=[
+                    MmCase(
+                        suffix="mixed_frontend_decoding",
+                        payload=make_mixed_image_video_payload(
+                            MULTIMODAL_VIDEO_EXPECTED,
+                            frontend_decoding=True,
+                        ),
+                        followup_payloads=[
+                            make_video_payload(
+                                MULTIMODAL_VIDEO_EXPECTED,
+                                frontend_decoding=True,
+                            )
+                        ],
+                        extra_script_args=["--frontend-decoding"],
+                    )
+                ],
             ),
             "p_d": TopologyConfig(
                 marks=[pytest.mark.post_merge],

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -390,6 +390,36 @@ def make_video_payload(
     )
 
 
+def make_mixed_image_video_payload(
+    expected_response: list[str], *, frontend_decoding: bool = False
+) -> ChatPayload:
+    """Mixed image/video payload that requires usable video context."""
+    video_url = MULTIMODAL_VIDEO_URL if frontend_decoding else LOCAL_VIDEO_TEST_URI
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": (
+                    "Ignore the image. What shape appears in the video? "
+                    "Respond with only the shape."
+                ),
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": MULTIMODAL_IMG_URL},
+            },
+            {
+                "type": "video_url",
+                "video_url": {"url": video_url},
+            },
+        ],
+        repeat_count=1,
+        expected_response=expected_response,
+        temperature=0.0,
+        max_tokens=16,
+    )
+
+
 def _make_http_video_payload(url: str, expected_response: list[str]) -> ChatPayload:
     return chat_payload(
         [

--- a/tests/utils/test_multimodal.py
+++ b/tests/utils/test_multimodal.py
@@ -5,9 +5,14 @@ import base64
 
 import pytest
 
-from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
+from tests.serve.conftest import (
+    MULTIMODAL_IMG_URL,
+    MULTIMODAL_VIDEO_URL,
+    get_multimodal_test_image_bytes,
+)
 from tests.utils.multimodal import (
     UuidPassthroughChatPayload,
+    make_mixed_image_video_payload,
     make_qwen35_custom_encoder_multi_image_payload,
 )
 
@@ -82,3 +87,18 @@ def test_qwen35_multi_image_payload_is_order_sensitive() -> None:
         + base64.b64encode(get_multimodal_test_image_bytes(color)).decode()
         for color in ("green", "red")
     ]
+
+
+def test_mixed_image_video_payload_requires_video_context() -> None:
+    payload = make_mixed_image_video_payload(["triangle"], frontend_decoding=True)
+    content = payload.body["messages"][0]["content"]
+
+    assert content[1] == {
+        "type": "image_url",
+        "image_url": {"url": MULTIMODAL_IMG_URL},
+    }
+    assert content[2] == {
+        "type": "video_url",
+        "video_url": {"url": MULTIMODAL_VIDEO_URL},
+    }
+    assert payload.expected_response == ["triangle"]


### PR DESCRIPTION
## Overview

Backports #14496 to `release/1.5.0`.

## Details

Preserves mixed image and video media during the vLLM E/P/D decode handoff. When a reconstructed image placeholder is already present, the decode path now reloads and merges the remaining video/audio media instead of skipping it.

The backport also carries the focused unit coverage and the mixed-media E/P/D post-merge profile gate from the original PR.

## Where should the reviewer start?

`components/src/dynamo/vllm/multimodal_utils/request_processor.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- Verified the backport patch ID exactly matches merged commit `6909a0125` from #14496.
- Release-runtime focused tests: 3 passed, 74 deselected.
- Pre-commit passed for all five changed files.
- `git diff --check` passed.
- The original fix was E2E validated with mixed image/video E/P/D requests on both a local one-GPU topology and a Lyris GB300 multi-GPU topology.