### PR TITLE
fix(tritonserver): decode/encode BYTES tensors correctly in RequestHandler

### DIFF
--- a/examples/backends/tritonserver/src/tritonworker.py
+++ b/examples/backends/tritonserver/src/tritonworker.py
@@ -49,33 +49,62 @@ class RequestHandler:
         inference_request = self.model.create_request()
         for tensor in request["tensors"]:
             logger.debug(f"Tensor: {tensor}")
-            # Convert Triton dtype string ("INT32") to NumPy dtype (np.int32) for array construction
-            np_dtype = triton_to_np_dtype(tensor["metadata"]["data_type"].upper())
-            arr = np.array(tensor["data"]["values"], dtype=np_dtype).reshape(
-                tensor["metadata"]["shape"]
-            )
-            inference_request.inputs[tensor["metadata"]["name"]] = arr
+            data_type = tensor["metadata"]["data_type"].upper()
+            values = tensor["data"]["values"]
+            shape = tensor["metadata"]["shape"]
+            if data_type == "BYTES":
+                # BYTES/string tensor values arrive as a list of byte-integer
+                # lists (one per element), not a flat numeric array. Decode
+                # each element into real bytes before handing the tensor to
+                # tritonserver, which has its own accessor for string tensors
+                # rather than the raw-buffer path numeric dtypes use.
+                elements = np.array(
+                    [bytes(value) for value in values], dtype=object
+                ).reshape(shape)
+                inference_request.inputs[tensor["metadata"]["name"]] = (
+                    tritonserver.Tensor.from_bytes_array(elements)
+                )
+            else:
+                # Convert Triton dtype string ("INT32") to NumPy dtype (np.int32) for array construction
+                np_dtype = triton_to_np_dtype(data_type)
+                arr = np.array(values, dtype=np_dtype).reshape(shape)
+                inference_request.inputs[tensor["metadata"]["name"]] = arr
 
         inference_responses = self.model.async_infer(inference_request)
         async for inference_response in inference_responses:
             response_tensors = []
             for output in self.model.metadata()["outputs"]:
-                output_data = np.from_dlpack(inference_response.outputs[output["name"]])
-                response_arr = output_data
+                out_tensor = inference_response.outputs[output["name"]]
                 # Convert Triton dtype (e.g., "INT32") to Dynamo dtype (e.g., "Int32")
                 dtype_str = TRITON_TO_DYNAMO_DTYPE.get(
                     output["datatype"], output["datatype"]
                 )
+                if output["datatype"] == "BYTES":
+                    # DLPack has no string/object dtype support, so BYTES
+                    # outputs need tritonserver's dedicated string accessor
+                    # instead of np.from_dlpack. Re-encode each string back
+                    # into a byte-integer list to match the wire format the
+                    # BYTES branch above decodes on the request side.
+                    string_arr = out_tensor.to_string_array()
+                    response_shape = list(string_arr.shape)
+                    response_values = [
+                        list(value.encode("utf-8"))
+                        for value in string_arr.flatten().tolist()
+                    ]
+                else:
+                    output_data = np.from_dlpack(out_tensor)
+                    response_shape = list(output_data.shape)
+                    response_values = output_data.flatten().tolist()
                 response_tensors.append(
                     {
                         "metadata": {
                             "name": output["name"],
-                            "shape": list(response_arr.shape),
+                            "shape": response_shape,
                             "data_type": dtype_str,
                         },
                         "data": {
                             "data_type": dtype_str,
-                            "values": response_arr.flatten().tolist(),
+                            "values": response_values,
                         },
                     }
                 )


### PR DESCRIPTION
## Summary
- `RequestHandler.generate()` in `examples/backends/tritonserver/src/tritonworker.py` only worked for numeric tensors. Any BYTES/string input or output crashed.
- Input side: BYTES tensor `values` arrive as a list of byte-integer lists (per `protocols/tensor.rs`'s `FlattenTensor::Bytes(Vec<Vec<u8>>)` wire encoding), not a flat numeric array — feeding that straight into `np.array(...).reshape(shape)` produced the wrong array rank and crashed with `cannot reshape array of size N into shape (1,)`.
- Output side: `np.from_dlpack()` has no string/object dtype support, so any BYTES output hit the same class of crash.
- Fix: for BYTES tensors, decode elements into real `bytes` and use `tritonserver.Tensor.from_bytes_array()`/`to_string_array()` (the dedicated string-tensor accessors) instead of the raw numpy buffer path numeric dtypes use. Symmetric re-encoding on the response side.

Fixes #14519

## Validation (red -> green against a live deployment)

Deployed a second Triton model (`identity_text`, TYPE_STRING in/out, `max_batch_size: 0`) alongside the existing numeric `identity` sample, registered via a second `tritonworker.py` worker process, fronted by the real KServe v2 gRPC service, and drove it with a real gRPC client (aiperf).

**RED** — pristine `origin/main` `tritonworker.py`, 5 real gRPC requests with BYTES input:
```
All 10 inference request(s) failed.
...
Traceback (most recent call last):
  File "/workspace/src/tritonworker.py", line 54, in generate
    arr = np.array(tensor["data"]["values"], dtype=np_dtype).reshape(
ValueError: cannot reshape array of size 126 into shape (1,)
```

**GREEN** — this branch's `tritonworker.py`, same 5 requests:
```
Request Error Rate (%): 0.00
Completed Requests: 5/5
```
Raw response confirms a real content round-trip (echoed text matches the sent input):
```json
{"status": 200, "responses": [{"text": "{\"outputs\":[{\"name\":\"OUTPUT0\",\"datatype\":\"BYTES\",\"shape\":[1],\"data\":[\"...\"]}], ...}"}], "error": null}
```

## Test plan
- [x] `python3 -m py_compile` on the patched file
- [x] Red/green integration test against a live Dynamo + Triton deployment (see above) — the file deployed for both runs is byte-identical to what's in this PR, not a hand-rolled equivalent
- [x] Existing numeric-tensor path unaffected (else-branch preserved verbatim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Triton backend handling for byte-based inputs and outputs.
  * Preserved existing processing for numeric inputs and outputs.
  * Byte-based results are now returned in a consistent UTF-8-compatible format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->