### PR TITLE
feat(frontend): expose detailed finish reason

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
+++ b/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
@@ -37,7 +37,7 @@ Include `nvext` as a top-level field alongside standard OpenAI-compatible fields
 | `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When present, the frontend skips tokenization. |
 | `max_thinking_tokens` | `u32` | `None` | Backend | Maximum thinking tokens allowed (passed through to backends). |
 | `cache_salt` | `string` | `None` | Router / supported backends | Namespaces Dynamo KV routing. vLLM and TensorRT-LLM also isolate backend KV-cache reuse; see [Backend support](#backend-support). This is the recommended cache-isolation input. |
-| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`, `"prompt_token_ids"`, `"completion_token_ids"`, `"prompt_logprobs"`. |
+| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`, `"detailed_finish_reason"`, `"prompt_token_ids"`, `"completion_token_ids"`, `"prompt_logprobs"`. |
 | `metadata_upload` | object | `None` | SGLang backend | Uploads final cumulative SGLang `meta_info` out of band. The object accepts one required `url` field. Requires an RL-enabled SGLang worker. |
 | `prefill_worker_id` | `u64` | `None` | Router | Routes the request to a specific prefill worker (disaggregated serving). |
 | `decode_worker_id` | `u64` | `None` | Router | Routes the request to a specific decode worker (disaggregated serving). |
@@ -248,10 +248,55 @@ When the client requests response metadata via `extra_fields`, the response incl
 | `routed_experts` | `extra_fields: ["routed_experts"]` | Backend-specific routed expert capture payload returned by compatible vLLM and SGLang engines. |
 | `engine_data` | `extra_fields: ["engine_data"]` | Opaque backend-provided engine metadata. |
 | `stop_reason` | `extra_fields: ["stop_reason"]` | Backend-specific matched stop condition, returned under `nvext` because it is not part of the OpenAI completions schema. Dynamo currently serves this as a response-level field for single-choice requests; supporting `n > 1` will require an indexed per-choice shape. |
+| `detailed_finish_reason` | `extra_fields: ["detailed_finish_reason"]` | Dynamo's internal finish reason before OpenAI conversion. Backend-specific values are normalized first. See [Detailed Finish Reason](#detailed-finish-reason). |
 | `prompt_token_ids` | `extra_fields: ["prompt_token_ids"]` | Effective single-prompt token sequence used after preprocessing, including pre-tokenized input supplied through the request. Emitted on the final response. |
 | `completion_token_ids` | `extra_fields: ["completion_token_ids"]` | Generated token IDs. Requires a single prompt and one generated choice. |
 | `prompt_logprobs` | `extra_fields: ["prompt_logprobs"]` | Prompt log probabilities requested with the top-level `prompt_logprobs` field. Emitted on the final response. |
 | `token_ids` | Automatic (GAIE Stage 1) | Tokenized prompt for reuse in Stage 2 query-only mode. |
+
+### Detailed Finish Reason
+
+The OpenAI-compatible API uses standard values in `finish_reason`.
+Dynamo maps an external cancellation to `stop` to keep this API compatible.
+
+The `nvext.detailed_finish_reason` field contains Dynamo's internal finish reason.
+Dynamo normalizes backend-specific values before it creates this field.
+For example, SGLang's `abort` becomes `cancelled`.
+The field supports these values:
+
+- `eos`
+- `length`
+- `stop`
+- `cancelled`
+- `content_filter`
+
+Add `detailed_finish_reason` to `nvext.extra_fields`:
+
+```json
+{
+    "nvext": {
+        "extra_fields": ["detailed_finish_reason"]
+    }
+}
+```
+
+If SGLang aborts the request, Dynamo returns this response data:
+
+```json
+{
+    "choices": [
+        {
+            "finish_reason": "stop"
+        }
+    ],
+    "nvext": {
+        "detailed_finish_reason": "cancelled"
+    }
+}
+```
+
+This response field is available for `/v1/chat/completions` and `/v1/completions`.
+Dynamo supports this field for requests with one choice.
 
 ### Example response `nvext`
 

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -13,8 +13,9 @@ use crate::protocols::TokenIdType;
 use crate::protocols::agents::{
     AgentContextHeaderValues, agent_context_header_values, session_affinity_header_value,
 };
+use crate::protocols::common::FinishReason;
 use crate::protocols::common::llm_backend::PromptLogprobs;
-use crate::protocols::common::timing::TimingInfo;
+use crate::protocols::common::timing::{RequestTracker, TimingInfo};
 
 /// Request-level taint constraints carried by `nvext.routing_constraints`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -651,6 +652,13 @@ pub struct NvExtResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<serde_json::Value>,
 
+    /// Dynamo's internal finish reason before OpenAI conversion.
+    ///
+    /// Backend-specific reasons are normalized before this value is set.
+    /// For example, SGLang's `abort` becomes `cancelled`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detailed_finish_reason: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completion_token_ids: Option<Vec<TokenIdType>>,
 
@@ -707,9 +715,21 @@ pub struct NvExtResponseFieldSelection {
     pub routed_experts: bool,
     pub engine_data: bool,
     pub stop_reason: bool,
+    pub detailed_finish_reason: bool,
     pub completion_token_ids: bool,
     pub prompt_token_ids: bool,
     pub prompt_logprobs: bool,
+}
+
+/// Backend data available when building an NVExt response.
+#[derive(Debug, Default)]
+pub struct NvExtResponseInput<'a> {
+    pub tracker: Option<&'a RequestTracker>,
+    pub finish_reason: Option<&'a FinishReason>,
+    pub engine_data: Option<serde_json::Value>,
+    pub stop_reason: Option<StopReason>,
+    pub completion_token_ids: Option<&'a [TokenIdType]>,
+    pub prompt_logprobs: Option<PromptLogprobs>,
 }
 
 impl NvExtResponseFieldSelection {
@@ -727,6 +747,7 @@ impl NvExtResponseFieldSelection {
                     "routed_experts" => selection.routed_experts = true,
                     "engine_data" => selection.engine_data = true,
                     "stop_reason" => selection.stop_reason = true,
+                    "detailed_finish_reason" => selection.detailed_finish_reason = true,
                     "completion_token_ids" => selection.completion_token_ids = true,
                     "prompt_token_ids" => selection.prompt_token_ids = true,
                     "prompt_logprobs" => selection.prompt_logprobs = true,
@@ -741,30 +762,26 @@ impl NvExtResponseFieldSelection {
         selection
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_response_nvext(
-        &self,
-        tracker: Option<&std::sync::Arc<crate::protocols::common::timing::RequestTracker>>,
-        finish_reason_present: bool,
-        engine_data_from_backend: Option<serde_json::Value>,
-        stop_reason_from_backend: Option<StopReason>,
-        completion_token_ids_from_backend: Option<&[TokenIdType]>,
-        prompt_logprobs_from_backend: Option<PromptLogprobs>,
-    ) -> Option<NvExtResponse> {
+    pub fn build_response_nvext(&self, input: NvExtResponseInput<'_>) -> Option<NvExtResponse> {
+        let finish_reason_present = input.finish_reason.is_some();
+
         let worker_id = if self.worker_id {
-            tracker.and_then(|t| t.get_worker_info())
+            input.tracker.and_then(RequestTracker::get_worker_info)
         } else {
             None
         };
 
         let token_ids = if self.token_ids {
-            tracker.and_then(|t| t.query_token_ids().map(<[u32]>::to_vec))
+            input
+                .tracker
+                .and_then(|tracker| tracker.query_token_ids().map(<[u32]>::to_vec))
         } else {
             None
         };
 
         let routed_experts = if self.routed_experts {
-            engine_data_from_backend
+            input
+                .engine_data
                 .as_ref()
                 .and_then(|data| data.get("routed_experts"))
                 .cloned()
@@ -773,25 +790,33 @@ impl NvExtResponseFieldSelection {
         };
 
         let timing = if finish_reason_present && self.timing {
-            tracker.map(|t| t.get_timing_info())
+            input.tracker.map(RequestTracker::get_timing_info)
         } else {
             None
         };
 
         let engine_data = if self.engine_data {
-            engine_data_from_backend
+            input.engine_data
         } else {
             None
         };
 
         let stop_reason = if self.stop_reason {
-            stop_reason_from_backend.and_then(|reason| serde_json::to_value(reason).ok())
+            input
+                .stop_reason
+                .and_then(|reason| serde_json::to_value(reason).ok())
+        } else {
+            None
+        };
+
+        let detailed_finish_reason = if self.detailed_finish_reason {
+            input.finish_reason.map(ToString::to_string)
         } else {
             None
         };
 
         let completion_token_ids = if self.completion_token_ids {
-            completion_token_ids_from_backend.map(<[u32]>::to_vec)
+            input.completion_token_ids.map(<[u32]>::to_vec)
         } else {
             None
         };
@@ -799,13 +824,15 @@ impl NvExtResponseFieldSelection {
         // Prompt IDs can be large, so emit them only once on the terminal
         // chunk. The tracker stores them only for an explicit opt-in request.
         let prompt_token_ids = if self.prompt_token_ids && finish_reason_present {
-            tracker.and_then(|t| t.prompt_token_ids().map(<[u32]>::to_vec))
+            input
+                .tracker
+                .and_then(|tracker| tracker.prompt_token_ids().map(<[u32]>::to_vec))
         } else {
             None
         };
 
         let prompt_logprobs = if self.prompt_logprobs && finish_reason_present {
-            prompt_logprobs_from_backend
+            input.prompt_logprobs
         } else {
             None
         };
@@ -816,6 +843,7 @@ impl NvExtResponseFieldSelection {
             && timing.is_none()
             && engine_data.is_none()
             && stop_reason.is_none()
+            && detailed_finish_reason.is_none()
             && completion_token_ids.is_none()
             && prompt_token_ids.is_none()
             && prompt_logprobs.is_none()
@@ -830,6 +858,7 @@ impl NvExtResponseFieldSelection {
             routed_experts,
             engine_data,
             stop_reason,
+            detailed_finish_reason,
             completion_token_ids,
             prompt_token_ids,
             prompt_logprobs,
@@ -1604,6 +1633,7 @@ mod tests {
                 "worker_id".to_string(),
                 "routed_experts".to_string(),
                 "prompt_token_ids".to_string(),
+                "detailed_finish_reason".to_string(),
             ])
             .build()
             .unwrap();
@@ -1614,6 +1644,7 @@ mod tests {
                 worker_id: true,
                 routed_experts: true,
                 prompt_token_ids: true,
+                detailed_finish_reason: true,
                 ..Default::default()
             }
         );
@@ -1695,9 +1726,13 @@ mod tests {
 
     #[test]
     fn build_response_nvext_all_false_returns_none() {
+        let finish_reason = FinishReason::Cancelled;
         assert!(
             NvExtResponseFieldSelection::default()
-                .build_response_nvext(None, false, None, None, None, None)
+                .build_response_nvext(NvExtResponseInput {
+                    finish_reason: Some(&finish_reason),
+                    ..Default::default()
+                })
                 .is_none()
         );
     }
@@ -1711,7 +1746,10 @@ mod tests {
         let tracker = tracker_with_prefill_worker();
 
         let out = selection
-            .build_response_nvext(Some(&tracker), false, None, None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                tracker: Some(&tracker),
+                ..Default::default()
+            })
             .expect("worker_id should emit regardless of finish_reason");
 
         assert!(out.worker_id.is_some());
@@ -1729,7 +1767,10 @@ mod tests {
         let tracker = tracker_with_forwarded_worker_info();
 
         let out = selection
-            .build_response_nvext(Some(&tracker), false, None, None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                tracker: Some(&tracker),
+                ..Default::default()
+            })
             .expect("forwarded worker_id should surface in nvext");
 
         assert_eq!(
@@ -1753,12 +1794,20 @@ mod tests {
 
         assert!(
             selection
-                .build_response_nvext(Some(&tracker), false, None, None, None, None)
+                .build_response_nvext(NvExtResponseInput {
+                    tracker: Some(&tracker),
+                    ..Default::default()
+                })
                 .is_none()
         );
 
+        let finish_reason = FinishReason::Stop;
         let out = selection
-            .build_response_nvext(Some(&tracker), true, None, None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                tracker: Some(&tracker),
+                finish_reason: Some(&finish_reason),
+                ..Default::default()
+            })
             .expect("timing should emit on finish");
         assert!(out.timing.is_some());
     }
@@ -1772,7 +1821,10 @@ mod tests {
         let tracker = tracker_with_query_token_ids();
 
         let out = selection
-            .build_response_nvext(Some(&tracker), false, None, None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                tracker: Some(&tracker),
+                ..Default::default()
+            })
             .expect("token_ids should emit when present");
 
         assert_eq!(out.token_ids, Some(vec![11u32, 22, 33]));
@@ -1787,7 +1839,10 @@ mod tests {
         let engine_data = serde_json::json!({ "routed_experts": {"layer_0": [1, 3]} });
 
         let out = selection
-            .build_response_nvext(None, false, Some(engine_data), None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                engine_data: Some(engine_data),
+                ..Default::default()
+            })
             .expect("routed_experts should emit when present");
 
         assert_eq!(
@@ -1804,11 +1859,32 @@ mod tests {
         };
 
         let out = selection
-            .build_response_nvext(None, false, None, None, Some(&[101u32, 102, 103]), None)
+            .build_response_nvext(NvExtResponseInput {
+                completion_token_ids: Some(&[101u32, 102, 103]),
+                ..Default::default()
+            })
             .expect("completion_token_ids should emit when requested and present");
 
         assert_eq!(out.completion_token_ids, Some(vec![101u32, 102, 103]));
         assert!(out.prompt_logprobs.is_none());
+    }
+
+    #[test]
+    fn build_response_nvext_detailed_finish_reason_pass_through() {
+        let selection = NvExtResponseFieldSelection {
+            detailed_finish_reason: true,
+            ..Default::default()
+        };
+
+        let finish_reason = FinishReason::Cancelled;
+        let out = selection
+            .build_response_nvext(NvExtResponseInput {
+                finish_reason: Some(&finish_reason),
+                ..Default::default()
+            })
+            .expect("detailed_finish_reason should emit when requested and present");
+
+        assert_eq!(out.detailed_finish_reason.as_deref(), Some("cancelled"));
     }
 
     #[test]
@@ -1821,12 +1897,20 @@ mod tests {
 
         assert!(
             selection
-                .build_response_nvext(Some(&tracker), false, None, None, None, None)
+                .build_response_nvext(NvExtResponseInput {
+                    tracker: Some(&tracker),
+                    ..Default::default()
+                })
                 .is_none()
         );
 
+        let finish_reason = FinishReason::Stop;
         let out = selection
-            .build_response_nvext(Some(&tracker), true, None, None, None, None)
+            .build_response_nvext(NvExtResponseInput {
+                tracker: Some(&tracker),
+                finish_reason: Some(&finish_reason),
+                ..Default::default()
+            })
             .expect("prompt_token_ids should emit on the final chunk");
         assert_eq!(out.prompt_token_ids, Some(vec![101u32, 102, 103]));
     }
@@ -1850,12 +1934,20 @@ mod tests {
 
         assert!(
             selection
-                .build_response_nvext(None, false, None, None, None, Some(payload.clone()))
+                .build_response_nvext(NvExtResponseInput {
+                    prompt_logprobs: Some(payload.clone()),
+                    ..Default::default()
+                })
                 .is_none()
         );
 
+        let finish_reason = FinishReason::Stop;
         let out = selection
-            .build_response_nvext(None, true, None, None, None, Some(payload))
+            .build_response_nvext(NvExtResponseInput {
+                finish_reason: Some(&finish_reason),
+                prompt_logprobs: Some(payload),
+                ..Default::default()
+            })
             .expect("prompt_logprobs should emit on the final chunk");
         let got = out.prompt_logprobs.expect("prompt_logprobs payload");
         assert_eq!(got.len(), 2);

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -6,7 +6,11 @@ use std::{collections::HashSet, sync::Arc};
 use super::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse};
 use crate::{
     protocols::{
-        common::{self, extensions::NvExtProvider, timing::RequestTracker},
+        common::{
+            self,
+            extensions::{NvExtProvider, NvExtResponseInput},
+            timing::RequestTracker,
+        },
         openai::{
             convert_backend_top_logprobs,
             delta_common::{self, DeltaGeneratorOptions, DeltaGeneratorState},
@@ -242,7 +246,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         );
 
         // Map backend finish reasons to OpenAI's finish reasons.
-        let finish_reason = match delta.finish_reason {
+        let finish_reason = match delta.finish_reason.as_ref() {
             Some(common::FinishReason::EoS) => Some(dynamo_protocols::types::FinishReason::Stop),
             Some(common::FinishReason::Stop) => Some(dynamo_protocols::types::FinishReason::Stop),
             Some(common::FinishReason::Length) => {
@@ -255,7 +259,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
                 Some(dynamo_protocols::types::FinishReason::ContentFilter)
             }
             Some(common::FinishReason::Error(err_msg)) => {
-                return Err(anyhow::anyhow!(err_msg));
+                return Err(anyhow::anyhow!(err_msg.clone()));
             }
             None => None,
         };
@@ -278,14 +282,19 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         let prompt_logprobs_payload =
             common::llm_backend::prompt_logprobs_from_engine_data(delta.engine_data.as_ref());
         let completion_token_ids_slice: &[u32] = &delta.token_ids;
-        if let Some(nvext_response) = self.state.options().response_fields.build_response_nvext(
-            Some(self.state.tracker_ref()),
-            finish_reason.is_some(),
-            delta.engine_data,
-            stop_reason,
-            Some(completion_token_ids_slice),
-            prompt_logprobs_payload,
-        ) && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
+        if let Some(nvext_response) =
+            self.state
+                .options()
+                .response_fields
+                .build_response_nvext(NvExtResponseInput {
+                    tracker: Some(self.state.tracker_ref()),
+                    finish_reason: delta.finish_reason.as_ref(),
+                    engine_data: delta.engine_data,
+                    stop_reason,
+                    completion_token_ids: Some(completion_token_ids_slice),
+                    prompt_logprobs: prompt_logprobs_payload,
+                })
+            && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
         {
             stream_response.nvext = Some(nvext_json);
             if let Some(ref info) = nvext_response.worker_id {
@@ -753,6 +762,26 @@ mod tests {
         let response_json = serde_json::to_value(&response).expect("serialize response");
         assert!(response_json["choices"][0].get("stop_reason").is_none());
         assert_eq!(response_json["nvext"]["stop_reason"], "END");
+    }
+
+    #[test]
+    fn test_cancelled_detailed_finish_reason_preserves_openai_finish_reason() {
+        let request =
+            create_test_request_with_extra_fields(vec!["detailed_finish_reason".to_string()]);
+        let mut generator = request.response_generator("req-cancelled-nvext".to_string());
+        let mut output = final_backend_output();
+        output.finish_reason = Some(common::FinishReason::Cancelled);
+
+        let response = generator
+            .choice_from_postprocessor(output)
+            .expect("choice generation");
+        let response_json = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(response_json["choices"][0]["finish_reason"], "stop");
+        assert_eq!(
+            response_json["nvext"]["detailed_finish_reason"],
+            "cancelled"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -6,7 +6,11 @@ use std::sync::Arc;
 use super::{NvCreateCompletionRequest, NvCreateCompletionResponse};
 use crate::{
     protocols::{
-        common::{self, extensions::NvExtProvider, timing::RequestTracker},
+        common::{
+            self,
+            extensions::{NvExtProvider, NvExtResponseInput},
+            timing::RequestTracker,
+        },
         openai::{
             convert_backend_top_logprobs,
             delta_common::{self, DeltaGeneratorOptions, DeltaGeneratorState},
@@ -208,12 +212,12 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
 
         // Backend errors are response errors, not successful OpenAI stop reasons.
         // Keep completions aligned with the chat-completions delta generator.
-        let finish_reason = match delta.finish_reason {
+        let finish_reason = match delta.finish_reason.as_ref() {
             Some(common::FinishReason::Error(err_msg)) => {
                 self.state.tracker_ref().record_finish();
-                return Err(anyhow::anyhow!(err_msg));
+                return Err(anyhow::anyhow!(err_msg.clone()));
             }
-            Some(reason) => Some(reason.into()),
+            Some(reason) => Some(reason.clone().into()),
             None => None,
         };
         let stop_reason = delta.stop_reason.clone();
@@ -234,14 +238,19 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         // rules stay in one place.
         let prompt_logprobs_payload =
             common::llm_backend::prompt_logprobs_from_engine_data(delta.engine_data.as_ref());
-        if let Some(nvext_response) = self.state.options().response_fields.build_response_nvext(
-            Some(self.state.tracker_ref()),
-            finish_reason.is_some(),
-            delta.engine_data,
-            stop_reason,
-            completion_token_ids_for_nvext.as_deref(),
-            prompt_logprobs_payload,
-        ) && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
+        if let Some(nvext_response) =
+            self.state
+                .options()
+                .response_fields
+                .build_response_nvext(NvExtResponseInput {
+                    tracker: Some(self.state.tracker_ref()),
+                    finish_reason: delta.finish_reason.as_ref(),
+                    engine_data: delta.engine_data,
+                    stop_reason,
+                    completion_token_ids: completion_token_ids_for_nvext.as_deref(),
+                    prompt_logprobs: prompt_logprobs_payload,
+                })
+            && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
         {
             response.nvext = Some(nvext_json);
             if let Some(ref info) = nvext_response.worker_id {
@@ -552,6 +561,26 @@ mod tests {
         let response_json = serde_json::to_value(&response).expect("serialize response");
         assert!(response_json["choices"][0].get("stop_reason").is_none());
         assert_eq!(response_json["nvext"]["stop_reason"], "END");
+    }
+
+    #[test]
+    fn test_cancelled_detailed_finish_reason_preserves_openai_finish_reason() {
+        let request =
+            create_test_request_with_extra_fields(vec!["detailed_finish_reason".to_string()]);
+        let mut generator = request.response_generator("req-cancelled-nvext".to_string());
+        let mut output = final_backend_output();
+        output.finish_reason = Some(common::FinishReason::Cancelled);
+
+        let response = generator
+            .choice_from_postprocessor(output)
+            .expect("choice generation");
+        let response_json = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(response_json["choices"][0]["finish_reason"], "stop");
+        assert_eq!(
+            response_json["nvext"]["detailed_finish_reason"],
+            "cancelled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Expose Dynamo's canonical internal finish reason through opt-in `nvext.detailed_finish_reason`.
- Keep standard OpenAI `finish_reason` values unchanged, so cancellation remains `stop`.
- Preserve the extension through streaming and non-streaming aggregation for `/v1/chat/completions` and `/v1/completions`.
- Use a typed `NvExtResponseInput` boundary for reusable response metadata construction.
- Document the new `nvext.extra_fields` selector.

SGLang 0.5.18 defaults `pause_generation` to abort mode and emits an `abort` finish reason. Dynamo parses both `abort` and `cancelled` as `FinishReason::Cancelled`. Clients can now request `detailed_finish_reason` and receive `"cancelled"` without introducing a non-standard OpenAI finish reason.

Closes #14418

## Validation

- `cargo test -p dynamo-llm detailed_finish_reason --lib`
- `cargo test -p dynamo-llm protocols::common::extensions::tests --lib`
- `cargo test -p dynamo-llm test_multiple_deltas_merge_nvext_fields --lib`
- `cargo clippy -p dynamo-llm --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 docs/fern/scripts/docs_lint.py --scan docs` (0 errors; 8 pre-existing warnings)
- Live NVIDIA B200 test with SGLang 0.5.18 and Qwen3-0.6B:
  - `/v1/completions`: `finish_reason: "stop"`, `nvext.detailed_finish_reason: "cancelled"`
  - `/v1/chat/completions`: `finish_reason: "stop"`, `nvext.detailed_finish_reason: "cancelled"`
  - Both requests were interrupted by calling `/engine/pause_generation` without a mode, exercising SGLang's default `mode="abort"`.
