### PR TITLE
refactor(operator): remove legacy DCD alpha admission endpoint

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
@@ -20,13 +20,10 @@ package validation
 import (
 	"context"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -34,21 +31,13 @@ import (
 
 const (
 	// DynamoComponentDeploymentWebhookName is the name of the validating webhook handler for DynamoComponentDeployment.
-	DynamoComponentDeploymentWebhookName         = "dynamocomponentdeployment-validating-webhook"
-	dynamoComponentDeploymentV1Alpha1WebhookPath = "/validate-nvidia-com-v1alpha1-dynamocomponentdeployment"
-	dynamoComponentDeploymentV1Beta1WebhookPath  = "/validate/nvidia.com/v1beta1/dynamocomponentdeployments"
+	DynamoComponentDeploymentWebhookName        = "dynamocomponentdeployment-validating-webhook"
+	dynamoComponentDeploymentV1Beta1WebhookPath = "/validate/nvidia.com/v1beta1/dynamocomponentdeployments"
 )
 
 // DynamoComponentDeploymentHandler is a handler for validating DynamoComponentDeployment resources.
 // It is a thin wrapper around DynamoComponentDeploymentValidator.
 type DynamoComponentDeploymentHandler struct{}
-
-// dynamoComponentDeploymentV1Alpha1Handler keeps the previous endpoint available
-// during the v1alpha1-to-v1beta1 admission migration. It converts the spoke
-// request to the v1beta1 hub before invoking the shared validation logic.
-type dynamoComponentDeploymentV1Alpha1Handler struct {
-	handler *DynamoComponentDeploymentHandler
-}
 
 // NewDynamoComponentDeploymentHandler creates a new handler for DynamoComponentDeployment Webhook.
 func NewDynamoComponentDeploymentHandler() *DynamoComponentDeploymentHandler {
@@ -57,29 +46,20 @@ func NewDynamoComponentDeploymentHandler() *DynamoComponentDeploymentHandler {
 
 // ValidateCreate validates a DynamoComponentDeployment create request.
 func (h *DynamoComponentDeploymentHandler) ValidateCreate(ctx context.Context, obj *nvidiacomv1beta1.DynamoComponentDeployment) (admission.Warnings, error) {
-	return h.validateCreate(ctx, obj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
-}
-
-func (h *DynamoComponentDeploymentHandler) validateCreate(
-	ctx context.Context,
-	obj runtime.Object,
-	expectedGVK schema.GroupVersionKind,
-) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1beta1.DynamoComponentDeploymentGVK); err != nil {
 		return nil, err
 	}
 
-	deployment, err := castToDynamoComponentDeployment(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Info("validate create", "name", deployment.Name, "namespace", deployment.Namespace)
+	logger.Info("validate create", "name", obj.Name, "namespace", obj.Namespace)
 
 	validator := NewDynamoComponentDeploymentValidator()
-	return validator.validate(ctx, deployment, runtimeVersionValidationSourceForRequest(ctx, expectedGVK))
+	return validator.validate(
+		ctx,
+		obj,
+		runtimeVersionValidationSourceForRequest(ctx, nvidiacomv1beta1.DynamoComponentDeploymentGVK),
+	)
 }
 
 // ValidateUpdate validates a DynamoComponentDeployment update request.
@@ -87,64 +67,38 @@ func (h *DynamoComponentDeploymentHandler) ValidateUpdate(
 	ctx context.Context,
 	oldObj, newObj *nvidiacomv1beta1.DynamoComponentDeployment,
 ) (admission.Warnings, error) {
-	return h.validateUpdate(ctx, oldObj, newObj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
-}
-
-func (h *DynamoComponentDeploymentHandler) validateUpdate(
-	ctx context.Context,
-	oldObj, newObj runtime.Object,
-	expectedGVK schema.GroupVersionKind,
-) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1beta1.DynamoComponentDeploymentGVK); err != nil {
 		return nil, err
 	}
 
-	newDeployment, err := castToDynamoComponentDeployment(newObj)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Info("validate update", "name", newDeployment.Name, "namespace", newDeployment.Namespace)
+	logger.Info("validate update", "name", newObj.Name, "namespace", newObj.Namespace)
 
 	// Skip validation if the resource is being deleted to allow finalizer removal.
-	if !newDeployment.DeletionTimestamp.IsZero() {
-		logger.Info("skipping validation for resource being deleted", "name", newDeployment.Name)
+	if !newObj.DeletionTimestamp.IsZero() {
+		logger.Info("skipping validation for resource being deleted", "name", newObj.Name)
 		return nil, nil
 	}
 
-	oldDeployment, err := castToDynamoComponentDeployment(oldObj)
-	if err != nil {
-		return nil, err
-	}
-
 	validator := NewDynamoComponentDeploymentValidator()
-	return validator.ValidateUpdate(ctx, oldDeployment, newDeployment, runtimeVersionValidationSourceForRequest(ctx, expectedGVK))
+	return validator.ValidateUpdate(
+		ctx,
+		oldObj,
+		newObj,
+		runtimeVersionValidationSourceForRequest(ctx, nvidiacomv1beta1.DynamoComponentDeploymentGVK),
+	)
 }
 
 // ValidateDelete validates a DynamoComponentDeployment delete request.
 func (h *DynamoComponentDeploymentHandler) ValidateDelete(ctx context.Context, obj *nvidiacomv1beta1.DynamoComponentDeployment) (admission.Warnings, error) {
-	return h.validateDelete(ctx, obj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
-}
-
-func (h *DynamoComponentDeploymentHandler) validateDelete(
-	ctx context.Context,
-	obj runtime.Object,
-	expectedGVK schema.GroupVersionKind,
-) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1beta1.DynamoComponentDeploymentGVK); err != nil {
 		return nil, err
 	}
 
-	deployment, err := dynamoComponentDeploymentMetadata(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Info("validate delete", "name", deployment.GetName(), "namespace", deployment.GetNamespace())
+	logger.Info("validate delete", "name", obj.Name, "namespace", obj.Namespace)
 	return nil, nil
 }
 
@@ -159,37 +113,5 @@ func (h *DynamoComponentDeploymentHandler) RegisterWithManager(mgr manager.Manag
 		consts.ResourceTypeDynamoComponentDeployment,
 		gate,
 	)
-
-	// TODO(1.5): Remove the v1alpha1 endpoint and handler after 1.3 is no longer
-	// a supported upgrade or rollback target.
-	alphaHandler := &dynamoComponentDeploymentV1Alpha1Handler{handler: h}
-	registerValidationWebhook(
-		mgr,
-		dynamoComponentDeploymentV1Alpha1WebhookPath,
-		alphaHandler,
-		consts.ResourceTypeDynamoComponentDeployment,
-		gate,
-	)
 	return nil
-}
-
-func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateCreate(
-	ctx context.Context,
-	obj *nvidiacomv1alpha1.DynamoComponentDeployment,
-) (admission.Warnings, error) {
-	return h.handler.validateCreate(ctx, obj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
-}
-
-func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateUpdate(
-	ctx context.Context,
-	oldObj, newObj *nvidiacomv1alpha1.DynamoComponentDeployment,
-) (admission.Warnings, error) {
-	return h.handler.validateUpdate(ctx, oldObj, newObj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
-}
-
-func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateDelete(
-	ctx context.Context,
-	obj *nvidiacomv1alpha1.DynamoComponentDeployment,
-) (admission.Warnings, error) {
-	return h.handler.validateDelete(ctx, obj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
@@ -21,82 +21,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
-	admissionv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-func TestDynamoComponentDeploymentV1Alpha1HandlerConvertsRequest(t *testing.T) {
-	handler := &dynamoComponentDeploymentV1Alpha1Handler{
-		handler: NewDynamoComponentDeploymentHandler(),
-	}
-	ctx := dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
-	dcd := &nvidiacomv1alpha1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "default"},
-		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
-			BackendFramework: "vllm",
-			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				ServiceName:            "worker",
-				ComponentType:          consts.ComponentTypeWorker,
-				RuntimeVersionOverride: "1.1.0",
-				ExtraPodSpec:           &nvidiacomv1alpha1.ExtraPodSpec{MainContainer: &corev1.Container{Image: "registry.example/runtime:1.1.0"}},
-			},
-		},
-	}
-
-	warnings, err := handler.ValidateCreate(ctx, dcd)
-	if err != nil {
-		t.Fatalf("ValidateCreate() error = %v", err)
-	}
-	if len(warnings) != 0 {
-		t.Fatalf("ValidateCreate() warnings = %v, want none", warnings)
-	}
-}
-
-func TestCastToDynamoComponentDeployment(t *testing.T) {
-	beta := &nvidiacomv1beta1.DynamoComponentDeployment{
-		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-			DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "worker",
-			},
-		},
-	}
-	got, err := castToDynamoComponentDeployment(beta)
-	if err != nil || got != beta {
-		t.Fatalf("castToDynamoComponentDeployment() = (%v, %v), want original DCD", got, err)
-	}
-
-	alpha := &nvidiacomv1alpha1.DynamoComponentDeployment{
-		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
-			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				ServiceName: "worker",
-			},
-		},
-	}
-	got, err = castToDynamoComponentDeployment(alpha)
-	if err != nil {
-		t.Fatalf("castToDynamoComponentDeployment() error = %v", err)
-	}
-	if got.Spec.ComponentName != alpha.Spec.ServiceName {
-		t.Fatalf("converted component name = %q, want %q", got.Spec.ComponentName, alpha.Spec.ServiceName)
-	}
-
-	if _, err := castToDynamoComponentDeployment(nil); err == nil {
-		t.Fatal("castToDynamoComponentDeployment() error = nil, want type mismatch")
-	}
-}
-
 func TestDynamoComponentDeploymentHandlerRegisterWithManager(t *testing.T) {
 	scheme := runtime.NewScheme()
-	if err := nvidiacomv1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add v1alpha1 scheme: %v", err)
-	}
 	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add v1beta1 scheme: %v", err)
 	}
@@ -108,14 +40,20 @@ func TestDynamoComponentDeploymentHandlerRegisterWithManager(t *testing.T) {
 		t.Fatalf("RegisterWithManager() error = %v", err)
 	}
 
-	for _, path := range []string{
-		dynamoComponentDeploymentV1Alpha1WebhookPath,
-		dynamoComponentDeploymentV1Beta1WebhookPath,
+	for _, tc := range []struct {
+		path        string
+		wantPattern string
+	}{
+		{
+			path:        dynamoComponentDeploymentV1Beta1WebhookPath,
+			wantPattern: dynamoComponentDeploymentV1Beta1WebhookPath,
+		},
+		{path: "/validate-nvidia-com-v1alpha1-dynamocomponentdeployment"},
 	} {
-		request := httptest.NewRequest("POST", path, nil)
+		request := httptest.NewRequest("POST", tc.path, nil)
 		_, pattern := server.WebhookMux().Handler(request)
-		if pattern != path {
-			t.Fatalf("registered pattern = %q, want %q", pattern, path)
+		if pattern != tc.wantPattern {
+			t.Fatalf("registered pattern for %q = %q, want %q", tc.path, pattern, tc.wantPattern)
 		}
 	}
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
@@ -27,12 +27,16 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// TestDynamoComponentDeploymentHandlerRegisterWithManager verifies that the beta
+// endpoint is registered and the legacy alpha endpoint is absent.
 func TestDynamoComponentDeploymentHandlerRegisterWithManager(t *testing.T) {
+	t.Log("Set up the v1beta1 scheme")
 	scheme := runtime.NewScheme()
 	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add v1beta1 scheme: %v", err)
 	}
 
+	t.Log("Register the DCD validation webhook")
 	server := ctrlwebhook.NewServer(ctrlwebhook.Options{})
 	mgr := &fakeManager{scheme: scheme, webhookServer: server}
 	handler := NewDynamoComponentDeploymentHandler()
@@ -40,6 +44,7 @@ func TestDynamoComponentDeploymentHandlerRegisterWithManager(t *testing.T) {
 		t.Fatalf("RegisterWithManager() error = %v", err)
 	}
 
+	t.Log("Verify the beta endpoint is registered and the alpha endpoint is absent")
 	for _, tc := range []struct {
 		path        string
 		wantPattern string

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_helpers.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_helpers.go
@@ -23,8 +23,6 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -69,32 +67,4 @@ func hasDynamoComponentDeploymentV1alpha1CompatibilityFields(
 		spec.EPPConfig != nil ||
 		spec.FrontendSidecar != nil ||
 		spec.Failover != nil
-}
-
-// castToDynamoComponentDeployment converts the v1alpha1 spoke to the v1beta1
-// hub used by the DCD validator, or returns a v1beta1 object unchanged.
-func castToDynamoComponentDeployment(obj runtime.Object) (*nvidiacomv1beta1.DynamoComponentDeployment, error) {
-	switch deployment := obj.(type) {
-	case *nvidiacomv1beta1.DynamoComponentDeployment:
-		return deployment, nil
-	case *nvidiacomv1alpha1.DynamoComponentDeployment:
-		converted := &nvidiacomv1beta1.DynamoComponentDeployment{}
-		if err := deployment.ConvertTo(converted); err != nil {
-			return nil, fmt.Errorf("convert v1alpha1 DynamoComponentDeployment to v1beta1: %w", err)
-		}
-		return converted, nil
-	default:
-		return nil, fmt.Errorf("expected v1alpha1 or v1beta1 DynamoComponentDeployment but got %T", obj)
-	}
-}
-
-func dynamoComponentDeploymentMetadata(obj runtime.Object) (metav1.Object, error) {
-	switch deployment := obj.(type) {
-	case *nvidiacomv1beta1.DynamoComponentDeployment:
-		return deployment, nil
-	case *nvidiacomv1alpha1.DynamoComponentDeployment:
-		return deployment, nil
-	default:
-		return nil, fmt.Errorf("expected DynamoComponentDeployment but got %T", obj)
-	}
 }


### PR DESCRIPTION
## Overview:
Post-1.5 cleanup following #11177.

## Summary
Remove the dedicated DCD v1alpha1 admission endpoint.

## Details:
Keep beta admission, alpha APIs, conversion, and compatibility validation.
Main only; do not backport to 1.5, which retains the endpoint for rollback compatibility.

## Where should the reviewer start?
`deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go`
and its registration test.

## Related Issues
**This PR is linked to an issue:**
- Closes #13173

## Validation
- Webhook/API tests, race tests, lint/build, pre-commit, and Helm checks passed.
- 17 live Kind test groups passed, including 1.5 upgrade/rollback.
- 131 focused tests/subtests passed; zero skips.

Recreate availability gaps were observed. Historical alpha storage migration was not tested.
