### PR TITLE
fix(kv-router): decode SGLang BlockStored metadata in positional KV events

### DIFF
--- a/lib/kv-router/src/zmq_wire/README.md
+++ b/lib/kv-router/src/zmq_wire/README.md
@@ -28,7 +28,7 @@ fixed positional prefix followed by an optional metadata tail.
 4 block_size
 5 old lora_id slot
 6 medium
-7 lora_name
+7 lora_name (vLLM string) or BlockStoredMetadata (SGLang map)
 8 extra_keys
 ```
 
@@ -73,8 +73,14 @@ vLLM's `BlockStored` tuple includes the vLLM-compatible fixed prefix before
 the metadata tail, so `group_idx` and cache metadata are parsed from tail
 positions.
 
-SGLang currently emits a shorter positional `BlockStored` shape ending at
-`lora_id`, and does not emit cache-group metadata. That parses correctly
-because the tuple terminates early. If SGLang later adds positional metadata,
-it must either include the vLLM-compatible placeholder fields before the tail
-or use map/object events with named fields.
+SGLang emits the vLLM-compatible prefix through `medium` (positions 0 to 6)
+and does not emit cache-group metadata. An unsalted event terminates at
+position 6 and parses because the tuple ends early.
+
+Since SGLang 0.5.18 (sgl-project/sglang#30827), a stored node that carries a
+`cache_salt` is emitted as `BlockStoredWithMetadata`: the same prefix plus a
+`BlockStoredMetadata` map at position 7 with the key `cache_salt`.
+sgl-project/sglang#37482 adds a `session_id` key to that map. The parser tells
+this map apart from vLLM's `lora_name` string by type, maps `cache_salt` to the
+cache namespace, and ignores keys it does not model. SGLang never emits
+`extra_keys` or the tail fields, so the map is the last element.

--- a/lib/kv-router/src/zmq_wire/deserialize.rs
+++ b/lib/kv-router/src/zmq_wire/deserialize.rs
@@ -31,6 +31,27 @@ impl<'de> Deserialize<'de> for RawKvEvent {
     }
 }
 
+/// SGLang's typed `BlockStoredMetadata` map. Since SGLang 0.5.18 a positional
+/// `BlockStored` carries this map at position 7 whenever the stored node has a
+/// `cache_salt` (sgl-project/sglang#30827); unsalted events end at position 6.
+/// sgl-project/sglang#37482 adds a `session_id` key that the raw event does not
+/// model yet, so unknown keys are ignored rather than rejected.
+#[derive(Debug, Default, Deserialize)]
+struct SglangBlockStoredMetadata {
+    #[serde(default)]
+    cache_salt: Option<String>,
+}
+
+/// Position 7 of a positional `BlockStored` is vLLM's `lora_name` string or
+/// SGLang's `BlockStoredMetadata` map. Both producers encode with `array_like`,
+/// so the slot type is the only way to tell them apart.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum LoraNameOrSglangMetadata {
+    LoraName(String),
+    SglangMetadata(SglangBlockStoredMetadata),
+}
+
 struct RawKvEventVisitor;
 
 impl<'de> Visitor<'de> for RawKvEventVisitor {
@@ -198,7 +219,16 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 // Position 5 was lora_id in older formats; consume and discard for compat.
                 let _lora_id: Option<u64> = seq.next_element()?.unwrap_or(None);
                 let medium: Option<String> = normalize_medium(seq.next_element()?.unwrap_or(None));
-                let lora_name: Option<String> = seq.next_element()?.unwrap_or(None);
+                let (lora_name, sglang_metadata) = match seq
+                    .next_element::<Option<LoraNameOrSglangMetadata>>()?
+                    .unwrap_or(None)
+                {
+                    Some(LoraNameOrSglangMetadata::LoraName(name)) => (Some(name), None),
+                    Some(LoraNameOrSglangMetadata::SglangMetadata(metadata)) => {
+                        (None, Some(metadata))
+                    }
+                    None => (None, None),
+                };
                 let extra_keys: Option<Vec<Option<Vec<ExtraKeyItem>>>> =
                     seq.next_element()?.unwrap_or(None);
                 let mut trailing = std::array::from_fn(|_| None);
@@ -215,8 +245,14 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
 
                 let parsed = parse_block_stored_trailing::<A::Error>(trailing, trailing_len)?;
 
-                let cache_namespace =
-                    extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref());
+                // SGLang's typed metadata names the salt directly, like the named-map
+                // path; legacy producers derive it from extra_keys and lora_name.
+                let cache_namespace = sglang_metadata
+                    .and_then(|metadata| metadata.cache_salt)
+                    .filter(|cache_salt| !cache_salt.is_empty())
+                    .or_else(|| {
+                        extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref())
+                    });
                 let block_mm_infos = parsed
                     .block_mm_infos
                     .or_else(|| extra_keys_to_block_mm_infos(extra_keys));

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -50,6 +51,119 @@ fn test_deserialize_bigram_block_stored_sequence() {
         }
         other => panic!("expected BlockStored, got {other:?}"),
     }
+}
+
+/// SGLang >= 0.5.18 appends its `BlockStoredMetadata` map at position 7 when the
+/// stored node carries a `cache_salt` (sgl-project/sglang#30827). vLLM puts its
+/// `lora_name` string in the same slot, so the decoder must accept both shapes.
+#[test]
+fn test_deserialize_sglang_positional_block_stored_metadata_map() {
+    let encoded = to_vec(&(
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11), BlockHashValue::Unsigned(12)],
+        Option::<BlockHashValue>::None,
+        vec![1u32, 2, 3, 4],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        BTreeMap::from([("cache_salt", "tenant-a")]),
+    ))
+    .unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    match event {
+        RawKvEvent::BlockStored {
+            block_hashes,
+            token_ids,
+            lora_name,
+            cache_namespace,
+            ..
+        } => {
+            assert_eq!(block_hashes.len(), 2);
+            assert_eq!(token_ids, vec![1, 2, 3, 4]);
+            assert_eq!(lora_name, None);
+            assert_eq!(cache_namespace.as_deref(), Some("tenant-a"));
+        }
+        other => panic!("expected BlockStored, got {other:?}"),
+    }
+}
+
+/// Keys the raw event does not model yet (sgl-project/sglang#37482 adds
+/// `session_id`) and an empty `cache_salt` must not fail the event.
+#[test]
+fn test_deserialize_sglang_positional_metadata_ignores_unknown_keys() {
+    let encoded = to_vec(&(
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![1u32, 2],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        BTreeMap::from([("cache_salt", ""), ("session_id", "session-a")]),
+    ))
+    .unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    match event {
+        RawKvEvent::BlockStored {
+            lora_name,
+            cache_namespace,
+            ..
+        } => {
+            assert_eq!(lora_name, None);
+            assert_eq!(cache_namespace, None);
+        }
+        other => panic!("expected BlockStored, got {other:?}"),
+    }
+}
+
+/// The vLLM `lora_name` string at position 7 still decodes as before.
+#[test]
+fn test_deserialize_positional_lora_name_string_still_decodes() {
+    let encoded = to_vec(&(
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![1u32, 2],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some("adapter-a"),
+    ))
+    .unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    match event {
+        RawKvEvent::BlockStored { lora_name, .. } => {
+            assert_eq!(lora_name.as_deref(), Some("adapter-a"));
+        }
+        other => panic!("expected BlockStored, got {other:?}"),
+    }
+}
+
+/// The listener decodes a whole `EventBatch` at once, so one salted SGLang event
+/// used to drop every event in its batch. The batch must decode end to end.
+#[test]
+fn test_decode_event_batch_with_sglang_metadata_event() {
+    let salted = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![1u32, 2],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        BTreeMap::from([("cache_salt", "tenant-a")]),
+    );
+    let encoded = to_vec(&(1.0f64, vec![salted], Option::<i32>::None)).unwrap();
+
+    let batch = decode_event_batch(&encoded).expect("batch with SGLang metadata must decode");
+    assert_eq!(batch.events.len(), 1);
+    assert!(matches!(
+        &batch.events[0],
+        RawKvEvent::BlockStored { cache_namespace, .. } if cache_namespace.as_deref() == Some("tenant-a")
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- SGLang >= 0.5.18 emits `BlockStoredWithMetadata` (sgl-project/sglang#30827): the vLLM-compatible positional prefix plus a `BlockStoredMetadata` map at position 7 whenever the stored node carries a `cache_salt`. sgl-project/sglang#37482 adds `session_id` to the same map.
- Dynamo's positional decoder read position 7 as vLLM's `lora_name: Option<String>`. Every such event failed with `invalid type: map, expected a string`, and `apply_live_batch` in `services/indexer/listener.rs` dropped the whole ZMQ batch. Co-batched unsalted events were lost too, so the router index silently diverged from the engine. No error reached the client.
- This change accepts either a string or a map at position 7, maps `cache_salt` to the cache namespace like the named-map path already does, and ignores keys the raw event does not model yet (`session_id`), so the event and its batch decode.
- Not triggered in shipped configurations today: neither the Rust SGLang sidecar nor the Python `dynamo.sglang` worker forwards `cache_salt`. It becomes live with sglang#37482 plus session-id forwarding (#14144), or with any `cache_salt` support for SGLang. Backport candidate for `release/1.5.0`, which has the same decoder and pins SGLang 0.5.18.
- Updates `lib/kv-router/src/zmq_wire/README.md` with the SGLang shape.

## Validation

- `cargo test -p dynamo-kv-router --lib zmq_wire`: 62 passed, including 4 new tests (metadata map decode, unknown keys plus empty salt, `lora_name` string unchanged, whole-batch decode).
- `cargo clippy -p dynamo-kv-router --tests -- -D warnings` and `cargo fmt --all -- --check`: clean.
- Reproduced the failure first with the same fixture against `main`: `invalid type: map, expected a string` for both the `cache_salt`-only map and the `session_id` map; the legacy shape decoded.
- Observed end to end on an 8xH100 SGLang + Dynamo stack (SGLang at sglang#37482, session ids forwarded through the sidecar): every session-attributed batch logged `Failed to decode KvEventBatch` and the KV index stayed empty (0 cached tokens on every turn) until this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for processing SGLang positional cache metadata, including cache salts and optional session information.
  - Continued support for vLLM adapter names in positional events.
  - Unknown metadata fields and empty cache-salt values are handled safely.

- **Documentation**
  - Updated positional-event documentation to describe vLLM and SGLang formats and producer behavior.

- **Tests**
  - Added coverage for SGLang metadata decoding, fallback behavior, and mixed event batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->