### PR TITLE
fix: restore OpenCV to the vLLM image without a software codec

### DIFF
--- a/components/src/dynamo/common/multimodal/codec_errors.py
+++ b/components/src/dynamo/common/multimodal/codec_errors.py
@@ -66,16 +66,24 @@ def _install_hint(backend: str, package: str, module: str) -> str:
     The bundled installer is offered only where it installs this package for
     this backend; elsewhere it exits 0 having fixed nothing.
     """
-    flags = "--no-deps"
-    spec = VALIDATED_SPECS[package]
     if _carrier_present(module):
-        flags += f" --force-reinstall --only-binary {package}"
+        # Replacing a build that is already here, so pin what is installed. The
+        # validated range would be wrong twice: it can be satisfied by what is
+        # present, so pip changes nothing, and its upper bound can sit below
+        # the version the image ships. That version is whatever the backend
+        # resolved, so this is deliberately not called a validated install.
         installed = _installed_version(package)
-        if installed:
-            spec = f"{package}=={installed}"
-        # No distribution metadata: the validated spec is the only bound left,
-        # and force-reinstall still replaces what is there.
-    hint = f"install the validated decoder with `pip install {flags} '{spec}'`"
+        spec = f"{package}=={installed}" if installed else VALIDATED_SPECS[package]
+        hint = (
+            "replace the shipped build with the binary wheel of the same "
+            f"version: `pip install --no-deps --force-reinstall "
+            f"--only-binary {package} '{spec}'`"
+        )
+    else:
+        hint = (
+            "install the validated decoder with "
+            f"`pip install --no-deps '{VALIDATED_SPECS[package]}'`"
+        )
     if installer_covers(backend, package):
         hint += f" (or `{INSTALLER_CMD} {backend}`)"
     return hint

--- a/components/src/dynamo/common/multimodal/codec_errors.py
+++ b/components/src/dynamo/common/multimodal/codec_errors.py
@@ -20,6 +20,7 @@ module installs anything.
 
 from __future__ import annotations
 
+import importlib.metadata
 import importlib.util
 
 from dynamo.common.multimodal.nvdec_decoder import HW_ROUTED_CODECS, nvdec_available
@@ -37,21 +38,43 @@ class MissingMediaDecoderError(RuntimeError):
     """
 
 
+def _carrier_present(module: str) -> bool:
+    """Whether the decode carrier imports here, however it was built."""
+    return importlib.util.find_spec(module) is not None
+
+
+def _installed_version(package: str) -> str | None:
+    """The installed distribution version, or None when it has no metadata."""
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
 def _install_hint(backend: str, package: str, module: str) -> str:
     """The remedy line: a pip command that works from where the caller is.
 
-    Two things make the naive command wrong. The carrier may already be
-    importable but unusable for this input -- the vLLM images ship an OpenCV
-    built from source with no video backend, at a version that can satisfy the
-    spec below, so a plain install reports "already satisfied" and changes
-    nothing. And the bundled installer does not cover every backend/package
-    pair, so offering it where it installs nothing relevant sends the caller
-    down a command that exits 0 and fixes nothing.
+    Where the carrier is absent, install the validated spec. Where it is
+    already importable but unusable for this input -- the vLLM images ship an
+    OpenCV built from source with no video backend -- the remedy is to swap
+    that build for the binary wheel, so it pins the version already installed.
+    Reusing the validated spec there would be wrong twice over: it can be
+    satisfied by what is present, so pip changes nothing, and its upper bound
+    can be below the version the image ships, so a caller who ran it anyway
+    would be downgraded off what the backend resolved.
+
+    The bundled installer is offered only where it installs this package for
+    this backend; elsewhere it exits 0 having fixed nothing.
     """
-    spec = VALIDATED_SPECS[package]
     flags = "--no-deps"
-    if importlib.util.find_spec(module) is not None:
+    spec = VALIDATED_SPECS[package]
+    if _carrier_present(module):
         flags += f" --force-reinstall --only-binary {package}"
+        installed = _installed_version(package)
+        if installed:
+            spec = f"{package}=={installed}"
+        # No distribution metadata: the validated spec is the only bound left,
+        # and force-reinstall still replaces what is there.
     hint = f"install the validated decoder with `pip install {flags} '{spec}'`"
     if installer_covers(backend, package):
         hint += f" (or `{INSTALLER_CMD} {backend}`)"
@@ -93,6 +116,16 @@ def video_decoder_missing(
             f"this video ({codec_desc}) normally decodes in hardware via NVDEC, "
             "but NVDEC is unavailable in this container. Grant the 'video' "
             "driver capability (NVIDIA_DRIVER_CAPABILITIES) to enable it, or "
+        )
+    elif _carrier_present(module):
+        # Present but useless for video: the vLLM images ship an OpenCV built
+        # from source with no video backend. Saying it is "not installed"
+        # would send the reader looking for a package that is already there.
+        lead = (
+            f"this video ({codec_desc}) has no decoder in this image: shipped "
+            "images decode only H.264/H.265 (in hardware, via NVDEC), and the "
+            f"'{module}' they ship is built without a video backend. "
+            "Re-encode the input to H.264/H.265, or "
         )
     else:
         lead = (

--- a/components/src/dynamo/common/multimodal/codec_errors.py
+++ b/components/src/dynamo/common/multimodal/codec_errors.py
@@ -20,8 +20,10 @@ module installs anything.
 
 from __future__ import annotations
 
+import importlib.util
+
 from dynamo.common.multimodal.nvdec_decoder import HW_ROUTED_CODECS, nvdec_available
-from dynamo.common.utils.install_media_decoders import VALIDATED_SPECS
+from dynamo.common.utils.install_media_decoders import VALIDATED_SPECS, installer_covers
 
 INSTALLER_CMD = "python -m dynamo.common.utils.install_media_decoders"
 
@@ -35,12 +37,25 @@ class MissingMediaDecoderError(RuntimeError):
     """
 
 
-def _install_hint(backend: str, package: str) -> str:
+def _install_hint(backend: str, package: str, module: str) -> str:
+    """The remedy line: a pip command that works from where the caller is.
+
+    Two things make the naive command wrong. The carrier may already be
+    importable but unusable for this input -- the vLLM images ship an OpenCV
+    built from source with no video backend, at a version that can satisfy the
+    spec below, so a plain install reports "already satisfied" and changes
+    nothing. And the bundled installer does not cover every backend/package
+    pair, so offering it where it installs nothing relevant sends the caller
+    down a command that exits 0 and fixes nothing.
+    """
     spec = VALIDATED_SPECS[package]
-    return (
-        f"install the validated decoder with `pip install --no-deps '{spec}'` "
-        f"(or `{INSTALLER_CMD} {backend}`)"
-    )
+    flags = "--no-deps"
+    if importlib.util.find_spec(module) is not None:
+        flags += f" --force-reinstall --only-binary {package}"
+    hint = f"install the validated decoder with `pip install {flags} '{spec}'`"
+    if installer_covers(backend, package):
+        hint += f" (or `{INSTALLER_CMD} {backend}`)"
+    return hint
 
 
 def _with_cause(message: str, cause: str | None) -> str:
@@ -88,7 +103,10 @@ def video_decoder_missing(
         )
     return MissingMediaDecoderError(
         _with_cause(
-            "Cannot decode video: " + lead + _install_hint(backend, package) + ".",
+            "Cannot decode video: "
+            + lead
+            + _install_hint(backend, package, module)
+            + ".",
             cause,
         )
     )
@@ -106,7 +124,7 @@ def audio_decoder_missing(
         _with_cause(
             "Cannot decode audio: this input needs the PyAV decoder ('av'), which "
             "this image deliberately does not ship, and NVDEC does not decode "
-            "audio. To enable audio input, " + _install_hint(backend, "av") + ".",
+            "audio. To enable audio input, " + _install_hint(backend, "av", "av") + ".",
             cause,
         )
     )

--- a/components/src/dynamo/common/multimodal/video_loader.py
+++ b/components/src/dynamo/common/multimodal/video_loader.py
@@ -198,7 +198,8 @@ class VideoLoader:
         surfaces either a bare ``No module named 'cv2'`` or a ``SystemError``
         from ``VideoCapture``, neither carrying a codec or a remedy -- both
         become the actionable unsupported-codec error, which can name the codec
-        because the probe already ran here.
+        because the probe already ran here. Both are translated on failure
+        rather than pre-empted, so a configured non-OpenCV backend still runs.
 
         The NVDEC path honors the two ``media_io_kwargs`` that decide *which*
         frames come back -- ``num_frames`` and ``fps`` -- because it samples
@@ -222,19 +223,25 @@ class VideoLoader:
                     codec,
                     exc,
                 )
-        if _cv2_lacks_video_backend():
+        try:
+            return await asyncio.to_thread(media_io.load_bytes, content)
+        except ImportError as exc:
+            raise video_decoder_missing(
+                "vllm", "opencv-python-headless", "cv2", codec, cause=str(exc)
+            ) from exc
+        except SystemError as exc:
+            # A cv2 with no video backend fails inside VideoCapture rather than
+            # on import. Translate only when that is actually the case: the
+            # decode may be running a different backend entirely, and an
+            # unrelated SystemError must keep its own message.
+            if not _cv2_lacks_video_backend():
+                raise
             raise video_decoder_missing(
                 "vllm",
                 "opencv-python-headless",
                 "cv2",
                 codec,
                 cause="the image's OpenCV is built without a video backend",
-            )
-        try:
-            return await asyncio.to_thread(media_io.load_bytes, content)
-        except ImportError as exc:
-            raise video_decoder_missing(
-                "vllm", "opencv-python-headless", "cv2", codec, cause=str(exc)
             ) from exc
 
     def _extract_nvdec_args(self, media_io: Any) -> dict[str, Any]:

--- a/components/src/dynamo/common/multimodal/video_loader.py
+++ b/components/src/dynamo/common/multimodal/video_loader.py
@@ -51,14 +51,9 @@ logger = logging.getLogger(__name__)
 def _cv2_lacks_video_backend() -> bool:
     """Whether the installed OpenCV imports but can open no video.
 
-    The runtime images rebuild OpenCV from source with every video backend off,
-    so the image carries no software codec. ``cv2.resize`` still works, which is
-    what mistral_common needs to tokenize a still image, but ``VideoCapture``
-    opens nothing and vLLM surfaces that as ``SystemError`` -- not the
-    ``ImportError`` the decode path converts into an actionable error.
-
-    A cv2 that is absent entirely answers False: the ImportError path names that
-    case more precisely than this one can.
+    Such a build fails through ``SystemError`` from ``VideoCapture`` rather
+    than the ``ImportError`` the decode path converts. An absent cv2 answers
+    False: the ImportError path names that case more precisely.
     """
     try:
         import cv2

--- a/components/src/dynamo/common/multimodal/video_loader.py
+++ b/components/src/dynamo/common/multimodal/video_loader.py
@@ -47,6 +47,18 @@ from dynamo.common.utils.runtime import run_async
 logger = logging.getLogger(__name__)
 
 
+def _attributable_to_cv2(exc: BaseException) -> bool:
+    """Whether this decode failure is OpenCV's.
+
+    vLLM picks among several video backends. A media_io configured for PyAV or
+    DeepStream raises its own ImportError, and reinstalling OpenCV would not
+    repair it, so only errors that name cv2 earn the OpenCV remedy.
+    ``ModuleNotFoundError`` carries the module in ``name``; the SystemError a
+    backendless build raises names the class in its text.
+    """
+    return getattr(exc, "name", None) == "cv2" or "cv2" in str(exc)
+
+
 @functools.lru_cache(maxsize=1)
 def _cv2_lacks_video_backend() -> bool:
     """Whether the installed OpenCV imports but can open no video.
@@ -221,6 +233,8 @@ class VideoLoader:
         try:
             return await asyncio.to_thread(media_io.load_bytes, content)
         except ImportError as exc:
+            if not _attributable_to_cv2(exc):
+                raise
             raise video_decoder_missing(
                 "vllm", "opencv-python-headless", "cv2", codec, cause=str(exc)
             ) from exc
@@ -232,7 +246,7 @@ class VideoLoader:
             # decoder this media_io actually ran, so a configured non-OpenCV
             # backend raising SystemError would otherwise be hidden behind a
             # recommendation to reinstall OpenCV.
-            if "cv2" not in str(exc) or not _cv2_lacks_video_backend():
+            if not _attributable_to_cv2(exc) or not _cv2_lacks_video_backend():
                 raise
             raise video_decoder_missing(
                 "vllm",

--- a/components/src/dynamo/common/multimodal/video_loader.py
+++ b/components/src/dynamo/common/multimodal/video_loader.py
@@ -66,7 +66,7 @@ def _cv2_lacks_video_backend() -> bool:
         return False
     build_info = cv2.getBuildInformation()
     return not any(
-        re.search(rf"^\s*{backend}:\s*YES", build_info, re.M)
+        re.search(rf"^\s*{backend}:\s*YES", build_info, re.MULTILINE)
         for backend in ("FFMPEG", "GSTREAMER")
     )
 
@@ -231,10 +231,13 @@ class VideoLoader:
             ) from exc
         except SystemError as exc:
             # A cv2 with no video backend fails inside VideoCapture rather than
-            # on import. Translate only when that is actually the case: the
-            # decode may be running a different backend entirely, and an
-            # unrelated SystemError must keep its own message.
-            if not _cv2_lacks_video_backend():
+            # on import, as "<class 'cv2.VideoCapture'> returned a result with
+            # an exception set". Require the error to name cv2 as well as the
+            # build to lack a backend: the build says nothing about which
+            # decoder this media_io actually ran, so a configured non-OpenCV
+            # backend raising SystemError would otherwise be hidden behind a
+            # recommendation to reinstall OpenCV.
+            if "cv2" not in str(exc) or not _cv2_lacks_video_backend():
                 raise
             raise video_decoder_missing(
                 "vllm",

--- a/components/src/dynamo/common/multimodal/video_loader.py
+++ b/components/src/dynamo/common/multimodal/video_loader.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 import asyncio
+import functools
 import logging
 import os
+import re
 from typing import Any, Awaitable, Dict, Final, List
 from urllib.parse import urlparse
 
@@ -43,6 +45,30 @@ from dynamo.common.multimodal.nvdec_decoder import (
 from dynamo.common.utils.runtime import run_async
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _cv2_lacks_video_backend() -> bool:
+    """Whether the installed OpenCV imports but can open no video.
+
+    The runtime images rebuild OpenCV from source with every video backend off,
+    so the image carries no software codec. ``cv2.resize`` still works, which is
+    what mistral_common needs to tokenize a still image, but ``VideoCapture``
+    opens nothing and vLLM surfaces that as ``SystemError`` -- not the
+    ``ImportError`` the decode path converts into an actionable error.
+
+    A cv2 that is absent entirely answers False: the ImportError path names that
+    case more precisely than this one can.
+    """
+    try:
+        import cv2
+    except ImportError:
+        return False
+    build_info = cv2.getBuildInformation()
+    return not any(
+        re.search(rf"^\s*{backend}:\s*YES", build_info, re.M)
+        for backend in ("FFMPEG", "GSTREAMER")
+    )
 
 
 URL_VARIANT_KEY: Final = "Url"
@@ -165,13 +191,14 @@ class VideoLoader:
     ) -> tuple[np.ndarray, Dict[str, Any]]:
         """Decode video bytes: H.264/H.265 on NVDEC, all else software.
 
-        The runtime images purge the software decode wheels (opencv/av/decord/
-        torchcodec) for codec compliance, so the software fallback only
-        resolves where a decoder was installed separately. When it is absent,
-        vLLM's lazy import surfaces a bare ``No module named 'cv2'`` with no
-        codec and no remedy -- convert that into the actionable
-        unsupported-codec error, which can name the codec because the probe
-        already ran here.
+        The runtime images carry no software video decoder: av, decord and
+        torchcodec are purged, and OpenCV is rebuilt without a video backend so
+        mistral_common can resize still images. The software fallback therefore
+        only resolves where a decoder was installed separately. Absent one, vLLM
+        surfaces either a bare ``No module named 'cv2'`` or a ``SystemError``
+        from ``VideoCapture``, neither carrying a codec or a remedy -- both
+        become the actionable unsupported-codec error, which can name the codec
+        because the probe already ran here.
 
         The NVDEC path honors the two ``media_io_kwargs`` that decide *which*
         frames come back -- ``num_frames`` and ``fps`` -- because it samples
@@ -195,6 +222,14 @@ class VideoLoader:
                     codec,
                     exc,
                 )
+        if _cv2_lacks_video_backend():
+            raise video_decoder_missing(
+                "vllm",
+                "opencv-python-headless",
+                "cv2",
+                codec,
+                cause="the image's OpenCV is built without a video backend",
+            )
         try:
             return await asyncio.to_thread(media_io.load_bytes, content)
         except ImportError as exc:

--- a/components/src/dynamo/common/tests/multimodal/test_audio_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_audio_loader.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import dynamo.common.multimodal.audio_loader as audio_loader_module
+import dynamo.common.multimodal.codec_errors as codec_errors
 from dynamo.common.http import HttpStatusError
 from dynamo.common.http.url_validator import UrlValidationError, UrlValidationPolicy
 from dynamo.common.multimodal.audio_loader import AudioLoader
@@ -187,11 +188,14 @@ async def test_load_audio_batch_reads_decoded_variant(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_load_audio_missing_decoder_is_actionable():
+async def test_load_audio_missing_decoder_is_actionable(monkeypatch):
     """vLLM's own hint here is `pip install vllm[audio]`, which drags in an
     unpinned stack; the wrap must point at the validated bounded install and
     say there is no hardware alternative for audio."""
     loader = AudioLoader()
+    # 'av' genuinely absent, independent of what the test machine has
+    # installed: _install_hint asks the running interpreter.
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: None)
     loader._load_audio_with_vllm = AsyncMock(  # type: ignore[method-assign]
         side_effect=ImportError("Please install vllm[audio] for audio support")
     )

--- a/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
+++ b/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
@@ -16,7 +16,7 @@ from dynamo.common.utils.install_media_decoders import VALIDATED_SPECS
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
 
-def test_video_message_names_codec_spec_and_installer(monkeypatch):
+def test_video_message_names_codec_and_spec(monkeypatch):
     monkeypatch.setattr(codec_errors, "nvdec_available", lambda: True)
     err = video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9")
 
@@ -27,9 +27,34 @@ def test_video_message_names_codec_spec_and_installer(monkeypatch):
     # The bounded spec comes verbatim from the installer's constants, so the
     # message and the documented install can never drift apart.
     assert VALIDATED_SPECS["opencv-python-headless"] in msg
-    assert "install_media_decoders vllm" in msg
+    # The installer does not install OpenCV for vLLM, so offering it here would
+    # send the reader to a command that exits 0 and decodes nothing.
+    assert "install_media_decoders vllm" not in msg
     # Non-hardware codec: the hardware alternative is re-encoding.
     assert "H.264/H.265" in msg
+
+
+def test_audio_message_still_offers_the_installer():
+    """PyAV is in the vLLM set, so the installer remains a real remedy there."""
+    err = codec_errors.audio_decoder_missing("vllm")
+    assert "install_media_decoders vllm" in str(err)
+
+
+def test_present_but_unusable_carrier_forces_a_binary_reinstall(monkeypatch):
+    """A carrier already on the path needs more than a plain install.
+
+    The vLLM images ship an OpenCV built from source with no video backend, at
+    a version that satisfies the spec, so `pip install` alone reports the
+    requirement as satisfied and leaves it in place.
+    """
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: object())
+    msg = str(video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9"))
+    assert "--force-reinstall" in msg
+    assert "--only-binary opencv-python-headless" in msg
+
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: None)
+    msg = str(video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9"))
+    assert "--force-reinstall" not in msg
 
 
 def test_hw_codec_without_nvdec_points_at_driver_capability(monkeypatch):

--- a/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
+++ b/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
@@ -46,12 +46,6 @@ def test_video_message_names_codec_and_spec(monkeypatch):
     assert "H.264/H.265" in msg
 
 
-def test_audio_message_still_offers_the_installer():
-    """PyAV is in the vLLM set, so the installer remains a real remedy there."""
-    err = codec_errors.audio_decoder_missing("vllm")
-    assert "install_media_decoders vllm" in str(err)
-
-
 def test_present_but_unusable_carrier_pins_the_installed_version(monkeypatch):
     """A carrier already on the path needs more than a plain install.
 

--- a/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
+++ b/components/src/dynamo/common/tests/multimodal/test_codec_errors.py
@@ -16,6 +16,18 @@ from dynamo.common.utils.install_media_decoders import VALIDATED_SPECS
 pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
 
+@pytest.fixture(autouse=True)
+def _carrier_absent(monkeypatch):
+    """Pin the hint's view of the interpreter to "carrier not installed".
+
+    ``_install_hint`` asks whether the carrier is already importable, so
+    without this the expected message would depend on whether the machine
+    running the tests happens to have cv2 or av installed. Tests covering the
+    present-but-unusable case override it.
+    """
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: None)
+
+
 def test_video_message_names_codec_and_spec(monkeypatch):
     monkeypatch.setattr(codec_errors, "nvdec_available", lambda: True)
     err = video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9")
@@ -40,21 +52,37 @@ def test_audio_message_still_offers_the_installer():
     assert "install_media_decoders vllm" in str(err)
 
 
-def test_present_but_unusable_carrier_forces_a_binary_reinstall(monkeypatch):
+def test_present_but_unusable_carrier_pins_the_installed_version(monkeypatch):
     """A carrier already on the path needs more than a plain install.
 
-    The vLLM images ship an OpenCV built from source with no video backend, at
-    a version that satisfies the spec, so `pip install` alone reports the
-    requirement as satisfied and leaves it in place.
+    The vLLM images ship an OpenCV built from source with no video backend, so
+    the remedy is to swap that build for the wheel of the SAME version. The
+    validated range would be wrong here twice: what is installed can satisfy
+    it, so pip would change nothing, and its upper bound is below the 5.x those
+    images ship, so following it would downgrade off what vLLM resolved.
     """
     monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(
+        codec_errors.importlib.metadata, "version", lambda p: "5.0.0.93"
+    )
     msg = str(video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9"))
     assert "--force-reinstall" in msg
     assert "--only-binary opencv-python-headless" in msg
+    assert "opencv-python-headless==5.0.0.93" in msg
+    assert VALIDATED_SPECS["opencv-python-headless"] not in msg
 
-    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: None)
+
+def test_present_carrier_without_metadata_falls_back_to_the_spec(monkeypatch):
+    """Importable but with no distribution metadata: the spec is all we have."""
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: object())
+
+    def _missing(_package):
+        raise codec_errors.importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(codec_errors.importlib.metadata, "version", _missing)
     msg = str(video_decoder_missing("vllm", "opencv-python-headless", "cv2", "vp9"))
-    assert "--force-reinstall" not in msg
+    assert VALIDATED_SPECS["opencv-python-headless"] in msg
+    assert "--force-reinstall" in msg
 
 
 def test_hw_codec_without_nvdec_points_at_driver_capability(monkeypatch):

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -305,8 +305,17 @@ async def test_decode_video_bytes_missing_decoder_is_actionable(monkeypatch):
     msg = str(exc_info.value)
     assert "'vp9'" in msg  # names the codec
     assert VALIDATED_SPECS["opencv-python-headless"] in msg  # bounded spec
-    assert "install_media_decoders vllm" in msg  # installer command
+    assert "pip install" in msg  # a remedy the reader can run
     assert "cv2" in msg
+
+
+class _SystemErrorMediaIO:
+    """What a cv2 with no video backend does: fail inside VideoCapture."""
+
+    def load_bytes(self, content: bytes):
+        raise SystemError(
+            "<class 'cv2.VideoCapture'> returned a result with an exception set"
+        )
 
 
 @pytest.mark.asyncio
@@ -316,22 +325,58 @@ async def test_decode_video_bytes_backendless_cv2_is_actionable(monkeypatch):
     The runtime images rebuild OpenCV from source with WITH_FFMPEG=OFF, so cv2
     imports and resizes but opens no video. vLLM raises SystemError from
     VideoCapture rather than ImportError, which would otherwise escape the
-    handler below and reach the client with no codec and no remedy.
+    handler and reach the client with no codec and no remedy.
     """
     loader = VideoLoader()
     monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
     monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
     monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: True)
 
-    media_io = AsyncMock()
     with pytest.raises(MissingMediaDecoderError) as exc_info:
-        await loader._decode_video_bytes(b"vp9-bytes", media_io)
+        await loader._decode_video_bytes(b"vp9-bytes", _SystemErrorMediaIO())
 
     msg = str(exc_info.value)
     assert "'vp9'" in msg
     assert VALIDATED_SPECS["opencv-python-headless"] in msg
     assert "video backend" in msg
-    media_io.load_bytes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_backendless_cv2_does_not_pre_empt_a_working_decode(monkeypatch):
+    """The check must not short-circuit a decoder that would have succeeded.
+
+    On the shipped image the predicate is always true, so gating the call on it
+    would reject every VideoMediaIO -- including a configured non-OpenCV
+    video_backend, and the stubbed load_bytes the worker tests rely on.
+    """
+    loader = VideoLoader()
+    monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
+    monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+    monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: True)
+
+    frames = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+
+    class _WorkingMediaIO:
+        def load_bytes(self, content: bytes):
+            return frames, {"frames_indices": [0, 1]}
+
+    decoded, metadata = await loader._decode_video_bytes(
+        b"vp9-bytes", _WorkingMediaIO()
+    )
+    assert decoded is frames
+    assert metadata == {"frames_indices": [0, 1]}
+
+
+@pytest.mark.asyncio
+async def test_unrelated_system_error_keeps_its_own_message(monkeypatch):
+    """A SystemError from anywhere else must not be blamed on the codec."""
+    loader = VideoLoader()
+    monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
+    monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+    monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: False)
+
+    with pytest.raises(SystemError, match="VideoCapture"):
+        await loader._decode_video_bytes(b"vp9-bytes", _SystemErrorMediaIO())
 
 
 def test_cv2_lacks_video_backend_is_false_when_cv2_absent(monkeypatch):

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -308,7 +308,7 @@ async def test_decode_video_bytes_missing_decoder_is_actionable(monkeypatch):
     msg = str(exc_info.value)
     assert "'vp9'" in msg  # names the codec
     assert VALIDATED_SPECS["opencv-python-headless"] in msg  # bounded spec
-    assert "pip install" in msg  # a remedy the reader can run
+    assert "pip install" in msg
     assert "cv2" in msg
 
 
@@ -345,7 +345,6 @@ async def test_decode_video_bytes_backendless_cv2_is_actionable(monkeypatch):
 
     msg = str(exc_info.value)
     assert "'vp9'" in msg
-    # The remedy swaps the source build for the wheel of the same version.
     assert "opencv-python-headless==5.0.0.93" in msg
     assert "--force-reinstall" in msg
     assert "video backend" in msg

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -378,6 +378,28 @@ async def test_backendless_cv2_does_not_pre_empt_a_working_decode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_other_backend_system_error_is_not_blamed_on_opencv(monkeypatch):
+    """A different decoder's SystemError must survive on a backendless image.
+
+    _cv2_lacks_video_backend() describes the installed cv2 build; it does not
+    prove this media_io ran OpenCV. On the shipped image it is always true, so
+    keying only on it would relabel every backend's SystemError as a missing
+    OpenCV and bury the real failure.
+    """
+    loader = VideoLoader()
+    monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
+    monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+    monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: True)
+
+    class _OtherBackendMediaIO:
+        def load_bytes(self, content: bytes):
+            raise SystemError("torchcodec decoder failed to initialise")
+
+    with pytest.raises(SystemError, match="torchcodec"):
+        await loader._decode_video_bytes(b"vp9-bytes", _OtherBackendMediaIO())
+
+
+@pytest.mark.asyncio
 async def test_unrelated_system_error_keeps_its_own_message(monkeypatch):
     """A SystemError from anywhere else must not be blamed on the codec."""
     loader = VideoLoader()

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import numpy as np
 import pytest
 
+import dynamo.common.multimodal.codec_errors as codec_errors
 import dynamo.common.multimodal.video_loader as video_loader_module
 from dynamo.common.http import HttpStatusError
 from dynamo.common.http.url_validator import UrlValidationError, UrlValidationPolicy
@@ -298,6 +299,8 @@ async def test_decode_video_bytes_missing_decoder_is_actionable(monkeypatch):
     loader = VideoLoader()
     monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
     monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+    # cv2 genuinely absent, independent of what the test machine has installed.
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: None)
 
     with pytest.raises(MissingMediaDecoderError) as exc_info:
         await loader._decode_video_bytes(b"vp9-bytes", _ImportErrorMediaIO())
@@ -332,12 +335,19 @@ async def test_decode_video_bytes_backendless_cv2_is_actionable(monkeypatch):
     monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
     monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: True)
 
+    monkeypatch.setattr(codec_errors.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(
+        codec_errors.importlib.metadata, "version", lambda p: "5.0.0.93"
+    )
+
     with pytest.raises(MissingMediaDecoderError) as exc_info:
         await loader._decode_video_bytes(b"vp9-bytes", _SystemErrorMediaIO())
 
     msg = str(exc_info.value)
     assert "'vp9'" in msg
-    assert VALIDATED_SPECS["opencv-python-headless"] in msg
+    # The remedy swaps the source build for the wheel of the same version.
+    assert "opencv-python-headless==5.0.0.93" in msg
+    assert "--force-reinstall" in msg
     assert "video backend" in msg
 
 

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from unittest.mock import AsyncMock
 
 import numpy as np
@@ -306,6 +307,41 @@ async def test_decode_video_bytes_missing_decoder_is_actionable(monkeypatch):
     assert VALIDATED_SPECS["opencv-python-headless"] in msg  # bounded spec
     assert "install_media_decoders vllm" in msg  # installer command
     assert "cv2" in msg
+
+
+@pytest.mark.asyncio
+async def test_decode_video_bytes_backendless_cv2_is_actionable(monkeypatch):
+    """A cv2 built without a video backend must reach the same error.
+
+    The runtime images rebuild OpenCV from source with WITH_FFMPEG=OFF, so cv2
+    imports and resizes but opens no video. vLLM raises SystemError from
+    VideoCapture rather than ImportError, which would otherwise escape the
+    handler below and reach the client with no codec and no remedy.
+    """
+    loader = VideoLoader()
+    monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
+    monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+    monkeypatch.setattr(video_loader_module, "_cv2_lacks_video_backend", lambda: True)
+
+    media_io = AsyncMock()
+    with pytest.raises(MissingMediaDecoderError) as exc_info:
+        await loader._decode_video_bytes(b"vp9-bytes", media_io)
+
+    msg = str(exc_info.value)
+    assert "'vp9'" in msg
+    assert VALIDATED_SPECS["opencv-python-headless"] in msg
+    assert "video backend" in msg
+    media_io.load_bytes.assert_not_called()
+
+
+def test_cv2_lacks_video_backend_is_false_when_cv2_absent(monkeypatch):
+    """An absent cv2 is not this case: the ImportError path names it better."""
+    video_loader_module._cv2_lacks_video_backend.cache_clear()
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    try:
+        assert video_loader_module._cv2_lacks_video_backend() is False
+    finally:
+        video_loader_module._cv2_lacks_video_backend.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/common/tests/multimodal/test_video_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_video_loader.py
@@ -377,6 +377,27 @@ async def test_backendless_cv2_does_not_pre_empt_a_working_decode(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_other_backend_import_error_is_not_blamed_on_opencv(monkeypatch):
+    """A media_io configured for another backend keeps its own ImportError.
+
+    vLLM selects among several video backends and PyAV is absent from the
+    shipped images too, so its ImportError would otherwise be rewritten into
+    advice to reinstall OpenCV -- which cannot repair a VideoMediaIO still
+    configured for PyAV.
+    """
+    loader = VideoLoader()
+    monkeypatch.setattr(video_loader_module, "probe_video_codec", lambda b: "vp9")
+    monkeypatch.setattr(video_loader_module, "should_use_nvdec", lambda c: False)
+
+    class _PyAvMediaIO:
+        def load_bytes(self, content: bytes):
+            raise ModuleNotFoundError("No module named 'av'", name="av")
+
+    with pytest.raises(ModuleNotFoundError, match="'av'"):
+        await loader._decode_video_bytes(b"vp9-bytes", _PyAvMediaIO())
+
+
+@pytest.mark.asyncio
 async def test_other_backend_system_error_is_not_blamed_on_opencv(monkeypatch):
     """A different decoder's SystemError must survive on a backendless image.
 

--- a/components/src/dynamo/common/tests/test_install_media_decoders.py
+++ b/components/src/dynamo/common/tests/test_install_media_decoders.py
@@ -172,26 +172,6 @@ def test_trtllm_installs_opencv_only(sandboxed):
     assert install_media_decoders.VALIDATED_SPECS["av"] not in cmd
 
 
-def test_installs_only_missing_modules(sandboxed):
-    """Only carriers a fresh interpreter cannot import are installed.
-
-    Runs against a synthetic two-carrier backend: every shipped backend declares
-    a single carrier, so a real one leaves the subsetting branch unexercised.
-    """
-    sandboxed.setitem(
-        install_media_decoders._BACKEND_DECODERS,
-        "twocarrier",
-        (install_media_decoders._OPENCV, install_media_decoders._PYAV),
-    )
-    present = {"cv2"}  # video carrier present, audio missing
-    _set_available(sandboxed, present)
-    calls = _record_pip_and_mark(sandboxed, present, "av")
-    installed = install_media_decoders.install_media_decoders("twocarrier")
-    assert installed == [install_media_decoders.VALIDATED_SPECS["av"]]
-    (cmd,) = calls
-    assert install_media_decoders.VALIDATED_SPECS["opencv-python-headless"] not in cmd
-
-
 def test_every_install_uses_no_deps(sandboxed):
     """--no-deps is unconditional now that custom specs are out of scope --
     the installer must never be able to shift the image's pinned stack."""
@@ -261,36 +241,24 @@ def test_dry_run_reports_without_installing(sandboxed):
     assert calls == []
 
 
-def test_pending_subset_installs_only_still_missing(sandboxed):
-    """A racing process may install part of the set while we wait on the lock.
+def test_racing_install_between_probe_and_lock_runs_no_pip(sandboxed):
+    """A racing process may install the carrier while we wait on the lock.
 
-    Probe round 1 (pre-check) sees both carriers missing; round 2 (post-lock
-    re-check) sees cv2 already installed by the racing process, so only the
-    audio carrier installs; round 3 (post-verify) sees everything. Uses a
-    synthetic two-carrier backend for the reason given in
-    test_installs_only_missing_modules.
+    Probe round 1 (pre-check) sees the vLLM audio carrier missing; round 2
+    (post-lock re-check) sees the racing process already installed it, so pip
+    must not run at all.
     """
     rounds = {"n": 0}
 
     def probe(mods):
         rounds["n"] += 1
-        if rounds["n"] == 1:
-            return list(mods)
-        if rounds["n"] == 2:
-            return [m for m in mods if m != "cv2"]
-        return []
+        return list(mods) if rounds["n"] == 1 else []
 
-    sandboxed.setitem(
-        install_media_decoders._BACKEND_DECODERS,
-        "twocarrier",
-        (install_media_decoders._OPENCV, install_media_decoders._PYAV),
-    )
     sandboxed.setattr(install_media_decoders, "_modules_missing_fresh", probe)
     calls = _record_pip(sandboxed)
-    installed = install_media_decoders.install_media_decoders("twocarrier")
-    assert installed == [install_media_decoders.VALIDATED_SPECS["av"]]
-    (cmd,) = calls
-    assert install_media_decoders.VALIDATED_SPECS["opencv-python-headless"] not in cmd
+
+    assert install_media_decoders.install_media_decoders("vllm") == []
+    assert calls == []
 
 
 def test_modules_missing_fresh_real_probe():

--- a/components/src/dynamo/common/tests/test_install_media_decoders.py
+++ b/components/src/dynamo/common/tests/test_install_media_decoders.py
@@ -133,22 +133,20 @@ def test_already_present_installs_nothing(sandboxed):
     assert calls == []
 
 
-def test_vllm_installs_bounded_video_and_audio_specs(sandboxed):
+def test_vllm_installs_bounded_audio_spec(sandboxed):
     present: set[str] = set()
     _set_available(sandboxed, present)
-    calls = _record_pip_and_mark(sandboxed, present, "cv2", "av")
+    calls = _record_pip_and_mark(sandboxed, present, "av")
     installed = install_media_decoders.install_media_decoders("vllm")
-    assert installed == [
-        install_media_decoders.VALIDATED_SPECS["opencv-python-headless"],
-        install_media_decoders.VALIDATED_SPECS["av"],
-    ]
+    assert installed == [install_media_decoders.VALIDATED_SPECS["av"]]
     (cmd,) = calls
     assert "--break-system-packages" in cmd
     for spec in installed:
         assert spec in cmd
-    # Never installed: pynvvideocodec because the image already ships it as the
-    # NVDEC path, and the rest because no vLLM decode path imports them.
-    for banned in ("torchcodec", "pynvvideocodec", "decord2", "libx264"):
+    # Never installed: pynvvideocodec and opencv because the images already ship
+    # both -- NVDEC, and a source-built cv2 with no video backend -- and the
+    # rest because no vLLM decode path imports them.
+    for banned in ("torchcodec", "pynvvideocodec", "decord2", "libx264", "opencv"):
         assert not any(banned in part for part in cmd)
 
 
@@ -175,10 +173,20 @@ def test_trtllm_installs_opencv_only(sandboxed):
 
 
 def test_installs_only_missing_modules(sandboxed):
+    """Only carriers a fresh interpreter cannot import are installed.
+
+    Runs against a synthetic two-carrier backend: every shipped backend declares
+    a single carrier, so a real one leaves the subsetting branch unexercised.
+    """
+    sandboxed.setitem(
+        install_media_decoders._BACKEND_DECODERS,
+        "twocarrier",
+        (install_media_decoders._OPENCV, install_media_decoders._PYAV),
+    )
     present = {"cv2"}  # video carrier present, audio missing
     _set_available(sandboxed, present)
     calls = _record_pip_and_mark(sandboxed, present, "av")
-    installed = install_media_decoders.install_media_decoders("vllm")
+    installed = install_media_decoders.install_media_decoders("twocarrier")
     assert installed == [install_media_decoders.VALIDATED_SPECS["av"]]
     (cmd,) = calls
     assert install_media_decoders.VALIDATED_SPECS["opencv-python-headless"] not in cmd
@@ -249,19 +257,18 @@ def test_dry_run_reports_without_installing(sandboxed):
     calls = _record_pip(sandboxed)
     _set_available(sandboxed, set())
     specs = install_media_decoders.install_media_decoders("vllm", dry_run=True)
-    assert specs == [
-        install_media_decoders.VALIDATED_SPECS["opencv-python-headless"],
-        install_media_decoders.VALIDATED_SPECS["av"],
-    ]
+    assert specs == [install_media_decoders.VALIDATED_SPECS["av"]]
     assert calls == []
 
 
 def test_pending_subset_installs_only_still_missing(sandboxed):
     """A racing process may install part of the set while we wait on the lock.
 
-    Probe round 1 (pre-check) sees both vLLM carriers missing; round 2
-    (post-lock re-check) sees cv2 already installed by the racing process, so
-    only the audio carrier installs; round 3 (post-verify) sees everything.
+    Probe round 1 (pre-check) sees both carriers missing; round 2 (post-lock
+    re-check) sees cv2 already installed by the racing process, so only the
+    audio carrier installs; round 3 (post-verify) sees everything. Uses a
+    synthetic two-carrier backend for the reason given in
+    test_installs_only_missing_modules.
     """
     rounds = {"n": 0}
 
@@ -273,9 +280,14 @@ def test_pending_subset_installs_only_still_missing(sandboxed):
             return [m for m in mods if m != "cv2"]
         return []
 
+    sandboxed.setitem(
+        install_media_decoders._BACKEND_DECODERS,
+        "twocarrier",
+        (install_media_decoders._OPENCV, install_media_decoders._PYAV),
+    )
     sandboxed.setattr(install_media_decoders, "_modules_missing_fresh", probe)
     calls = _record_pip(sandboxed)
-    installed = install_media_decoders.install_media_decoders("vllm")
+    installed = install_media_decoders.install_media_decoders("twocarrier")
     assert installed == [install_media_decoders.VALIDATED_SPECS["av"]]
     (cmd,) = calls
     assert install_media_decoders.VALIDATED_SPECS["opencv-python-headless"] not in cmd

--- a/components/src/dynamo/common/utils/install_media_decoders.py
+++ b/components/src/dynamo/common/utils/install_media_decoders.py
@@ -22,7 +22,6 @@ Each backend decodes such input through a specific Python package whose wheel
 bundles its own FFmpeg, so the support can be added by a plain ``pip install``
 -- no image rebuild:
 
-* vLLM video input    -> OpenCV (``cv2``),    package ``opencv-python-headless``
 * vLLM audio input    -> PyAV (``av``),       package ``av``
 * SGLang video input  -> decord (``decord``), package ``decord2``
 * TRT-LLM video input -> OpenCV (``cv2``),    package ``opencv-python-headless``
@@ -126,8 +125,14 @@ VALIDATED_SPECS: dict[str, str] = {d.package: d.spec for d in (_OPENCV, _PYAV, _
 #     reinstall what is already present.
 #   * torchcodec, PyAV-on-SGLang, opencv-on-SGLang -- no Dynamo decode path
 #     imports them, so installing them would add a carrier nothing calls.
+#   * OpenCV-on-vLLM -- those images already ship a source-built cv2 with no
+#     video backend, for mistral_common's still-image resize. It is importable,
+#     so the skip-if-present check would make listing it a silent no-op that
+#     promises a video decoder this installer cannot deliver. Giving vLLM
+#     software video decode means installing the PyPI wheel directly, which
+#     puts a full FFmpeg back in the image -- see the docs.
 _BACKEND_DECODERS: dict[str, tuple[_Decoder, ...]] = {
-    "vllm": (_OPENCV, _PYAV),
+    "vllm": (_PYAV,),
     "sglang": (_DECORD,),
     # TRT-LLM decodes video_url input via tensorrt_llm.inputs -> _load_video_by_cv2
     # (OpenCV). It has no audio-input decode path today.

--- a/components/src/dynamo/common/utils/install_media_decoders.py
+++ b/components/src/dynamo/common/utils/install_media_decoders.py
@@ -145,6 +145,17 @@ _BACKEND_DECODERS: dict[str, tuple[_Decoder, ...]] = {
 }
 
 
+def installer_covers(backend: str, package: str) -> bool:
+    """Whether ``install_media_decoders <backend>`` installs ``package``.
+
+    The error builders ask before offering this installer as a remedy. A
+    backend whose set omits the package -- vLLM and OpenCV, since those images
+    already ship a source-built cv2 -- would otherwise be told to run a command
+    that exits successfully having installed nothing that helps.
+    """
+    return any(d.package == package for d in _BACKEND_DECODERS.get(backend, ()))
+
+
 def _modules_missing_fresh(modules: Sequence[str]) -> list[str]:
     """Return the subset of `modules` a FRESH interpreter cannot IMPORT.
 

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -432,13 +432,21 @@ RUN rm -rf /workspace/vllm
 # Remove the codec-bearing video-DECODE wheels inherited from the vllm-openai
 # base. Each bundles its own full ffmpeg carrying software H.264/H.265/AAC;
 # PyAV and decord additionally ship GPL libx264/libx265. Dynamo's vLLM component
-# imports none of the removed wheels, so they are unused decode-side dead weight.
+# imports none of av/decord/torchcodec, so those are unused decode-side dead
+# weight. OpenCV is the exception and is rebuilt from source at the end of this
+# RUN: mistral_common resizes every still image with cv2.resize, and vLLM
+# requires it directly and through mistral_common[image]. WITH_FFMPEG=OFF leaves
+# no libav* in its DT_NEEDED, so the rebuilt cv2 opens no video at all -- the
+# same codec surface as removing it. The version is read off the base image so
+# it cannot drift from the one vLLM resolved.
 # (PyNvVideoCodec is KEPT for NVDEC hardware decode -- see the note below.) The in-tree
 # LGPL ffmpeg + imageio-ffmpeg installed above are intentionally KEPT for the
 # omni video-encode path, which uses the royalty-free VP9 (libvpx_vp9) encoder —
 # no H.264 is built. Direct rm makes the removal robust regardless of how the
 # base image's pip is configured; the guards fail the build if any of them survive.
 RUN set -eux; \
+    OPENCV_VERSION="$(python3 -m pip show opencv-python-headless | awk '/^Version:/{print $2}')"; \
+    test -n "${OPENCV_VERSION}"; \
     python3 -m pip uninstall --yes \
         av decord decord2 opencv-python opencv-python-headless torchcodec \
         || true; \
@@ -456,7 +464,14 @@ RUN set -eux; \
     ! python3 -c "import cv2" 2>/dev/null; \
     ! python3 -c "import av" 2>/dev/null; \
     ! python3 -c "import decord" 2>/dev/null; \
-    ! python3 -c "import torchcodec" 2>/dev/null
+    ! python3 -c "import torchcodec" 2>/dev/null; \
+    ENABLE_HEADLESS=1 ENABLE_CONTRIB=0 MAKEFLAGS="-j$(nproc)" \
+    CMAKE_ARGS="-DWITH_FFMPEG=OFF -DWITH_GSTREAMER=OFF -DVIDEOIO_ENABLE_PLUGINS=OFF -DWITH_1394=OFF -DWITH_V4L=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_opencv_apps=OFF -DENABLE_CCACHE=OFF" \
+    python3 -m pip install --no-binary opencv-python-headless "opencv-python-headless==${OPENCV_VERSION}"; \
+    rm -rf /root/.cache/pip; \
+    python3 -c "import cv2; cv2.resize"; \
+    ! ls -d "${SITE_PACKAGES}"/opencv_python*.libs 2>/dev/null; \
+    python3 -c "import cv2,re,sys; m=re.search(r'^\s*FFMPEG:\s*(\S+)', cv2.getBuildInformation(), re.M); sys.exit('cv2 was built WITH FFmpeg' if m and m.group(1).upper()=='YES' else 0)"
 
 # PyNvVideoCodec is KEPT (removed from the purge above) but UPGRADED to >=2.2.0 by
 # the requirements install: the base image's 2.0.4 bundles a full FFmpeg (incl.

--- a/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
@@ -26,7 +26,6 @@ Each backend decodes such input through a specific Python package whose wheel bu
 
 | Backend | Input | Package (validated version bounds) | Import |
 |---------|-------|------------------------------------|--------|
-| vLLM | video | `opencv-python-headless>=4.13.0.92,<5` | `cv2` |
 | vLLM | audio | `av>=18.0.0,<19` | `av` |
 | SGLang | video | `decord2>=3.4.0,<4` | `decord` |
 | TensorRT-LLM | video | `opencv-python-headless>=4.13.0.92,<5` | `cv2` |
@@ -38,8 +37,8 @@ The lower bound of each spec is the version validated against Dynamo's multimoda
 The table above is the contract; these commands are its direct translation, and work with the installer of your choice (`pip`, `uv pip`, ...):
 
 ```bash
-# vLLM: video + audio input
-pip install --no-deps 'opencv-python-headless>=4.13.0.92,<5' 'av>=18.0.0,<19'
+# vLLM: audio input
+pip install --no-deps 'av>=18.0.0,<19'
 
 # SGLang: video input
 pip install --no-deps 'decord2>=3.4.0,<4'
@@ -98,4 +97,5 @@ The default pip timeout is 600 seconds (`--timeout-s` overrides it; `0` disables
 - For H.264 and H.265, prefer NVDEC. Granting the container the `video` driver capability decodes those formats on the GPU with no extra package. Install a software decoder when that is not an option, or when the input is audio.
 - Installing a decoder package brings in that wheel's bundled media libraries. The runtime images are scanned for media components at build time; a package installed afterwards is not covered by that scan. Review what your deployment ships — a baked image layer keeps the change visible and reviewable.
 - On TensorRT-LLM, the install puts back `opencv-python-headless`, which those images deliberately do not ship. H.264 and H.265 already decode there through NVDEC, so install it only for a host where NVDEC is unavailable.
+- The vLLM images ship OpenCV already, rebuilt from source with every video backend disabled. It covers still images — which multimodal Mistral models need, because `mistral_common` resizes every image through `cv2` — and decodes no video at all. Video input on vLLM goes through NVDEC. To decode video in software instead, install the PyPI wheel over it with `pip install --no-deps 'opencv-python-headless>=4.13.0.92,<5'`, which restores the bundled FFmpeg and its codecs; the bundled installer will not do this for you.
 - The optional Rust frontend decoder (`--frontend-decoding`) links FFmpeg's compiled-in decoders and always decodes VP8/VP9 regardless of installed Python packages; backend decoding is what an install extends. Re-encoding an input to VP9 (`ffmpeg -i input.mp4 -c:v libvpx-vp9 -an output.webm`) is an alternative that needs no additional packages.

--- a/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
@@ -97,12 +97,13 @@ The default pip timeout is 600 seconds (`--timeout-s` overrides it; `0` disables
 - For H.264 and H.265, prefer NVDEC. Granting the container the `video` driver capability decodes those formats on the GPU with no extra package. Install a software decoder when that is not an option, or when the input is audio.
 - Installing a decoder package brings in that wheel's bundled media libraries. The runtime images are scanned for media components at build time; a package installed afterwards is not covered by that scan. Review what your deployment ships — a baked image layer keeps the change visible and reviewable.
 - On TensorRT-LLM, the install puts back `opencv-python-headless`, which those images deliberately do not ship. H.264 and H.265 already decode there through NVDEC, so install it only for a host where NVDEC is unavailable.
-- The vLLM images ship OpenCV already, rebuilt from source with every video backend disabled. It covers still images — which multimodal Mistral models need, because `mistral_common` resizes every image through `cv2` — and decodes no video at all. Video input on vLLM goes through NVDEC. To decode video in software instead, replace it with the PyPI wheel:
+- The vLLM images ship OpenCV already, rebuilt from source with every video backend disabled. It covers still images — which multimodal Mistral models need, because `mistral_common` resizes every image through `cv2` — and decodes no video at all. Video input on vLLM goes through NVDEC. To decode video in software instead, swap that build for the PyPI wheel of the same version:
 
 ```bash
+VERSION=$(pip show opencv-python-headless | awk '/^Version:/{print $2}')
 pip install --no-deps --force-reinstall --only-binary opencv-python-headless \
-  'opencv-python-headless>=4.13.0.92,<5'
+  "opencv-python-headless==${VERSION}"
 ```
 
-`--force-reinstall` and `--only-binary` are both required: the source build already registers as `opencv-python-headless` at a version that can satisfy the spec, so a plain install reports the requirement as already satisfied and leaves the backendless build in place. The wheel restores the bundled FFmpeg and its codecs. The bundled installer does not cover this — it installs only PyAV for vLLM.
+Every part of that command is load-bearing. `--force-reinstall` and `--only-binary` are both needed because the source build already registers as `opencv-python-headless`, so a plain install reports the requirement as satisfied and leaves it in place. Pinning the installed version keeps the swap to source-build-for-wheel — a version range would risk moving you off the release the backend resolved. The wheel restores the bundled FFmpeg and its codecs, which is exactly the codec surface the image is built to exclude, so review it against your distribution policy. The bundled installer does not do this: it installs only PyAV for vLLM.
 - The optional Rust frontend decoder (`--frontend-decoding`) links FFmpeg's compiled-in decoders and always decodes VP8/VP9 regardless of installed Python packages; backend decoding is what an install extends. Re-encoding an input to VP9 (`ffmpeg -i input.mp4 -c:v libvpx-vp9 -an output.webm`) is an alternative that needs no additional packages.

--- a/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
@@ -97,5 +97,12 @@ The default pip timeout is 600 seconds (`--timeout-s` overrides it; `0` disables
 - For H.264 and H.265, prefer NVDEC. Granting the container the `video` driver capability decodes those formats on the GPU with no extra package. Install a software decoder when that is not an option, or when the input is audio.
 - Installing a decoder package brings in that wheel's bundled media libraries. The runtime images are scanned for media components at build time; a package installed afterwards is not covered by that scan. Review what your deployment ships — a baked image layer keeps the change visible and reviewable.
 - On TensorRT-LLM, the install puts back `opencv-python-headless`, which those images deliberately do not ship. H.264 and H.265 already decode there through NVDEC, so install it only for a host where NVDEC is unavailable.
-- The vLLM images ship OpenCV already, rebuilt from source with every video backend disabled. It covers still images — which multimodal Mistral models need, because `mistral_common` resizes every image through `cv2` — and decodes no video at all. Video input on vLLM goes through NVDEC. To decode video in software instead, install the PyPI wheel over it with `pip install --no-deps 'opencv-python-headless>=4.13.0.92,<5'`, which restores the bundled FFmpeg and its codecs; the bundled installer will not do this for you.
+- The vLLM images ship OpenCV already, rebuilt from source with every video backend disabled. It covers still images — which multimodal Mistral models need, because `mistral_common` resizes every image through `cv2` — and decodes no video at all. Video input on vLLM goes through NVDEC. To decode video in software instead, replace it with the PyPI wheel:
+
+```bash
+pip install --no-deps --force-reinstall --only-binary opencv-python-headless \
+  'opencv-python-headless>=4.13.0.92,<5'
+```
+
+`--force-reinstall` and `--only-binary` are both required: the source build already registers as `opencv-python-headless` at a version that can satisfy the spec, so a plain install reports the requirement as already satisfied and leaves the backendless build in place. The wheel restores the bundled FFmpeg and its codecs. The bundled installer does not cover this — it installs only PyAV for vLLM.
 - The optional Rust frontend decoder (`--frontend-decoding`) links FFmpeg's compiled-in decoders and always decodes VP8/VP9 regardless of installed Python packages; backend decoding is what an install extends. Re-encoding an input to VP9 (`ffmpeg -i input.mp4 -c:v libvpx-vp9 -an output.webm`) is an alternative that needs no additional packages.

--- a/docs/fern/pages/use-cases/multimodal-serving/video-decode-gpu-requirements.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/video-decode-gpu-requirements.md
@@ -12,8 +12,9 @@ Other formats — VP8, VP9 and AV1 — have **no video-input decoder** in the sh
 The in-tree VP8/VP9 FFmpeg serves the video *output* (generation) path; it is not wired to
 video input, and the Rust `media-ffmpeg` decoder is not built into these images. Video
 input decodes through Python carriers (OpenCV, PyAV, decord) that the images deliberately
-omit, so a VP8/VP9/AV1 clip fails with an unsupported-codec error unless one of those
-packages is installed alongside.
+omit — the vLLM images do ship OpenCV, but built without any video backend, for still-image
+work only — so a VP8/VP9/AV1 clip fails with an unsupported-codec error unless a carrier
+that decodes video is installed alongside.
 
 This page covers which GPUs provide NVDEC, what the container must expose, and how
 Dynamo behaves when hardware decode is unavailable.
@@ -133,8 +134,9 @@ to the software decode path where one exists.
 > [!IMPORTANT]
 > In the shipped images there is no software decode path for video input, for any format.
 > The Python carriers that decode video input (OpenCV, PyAV, decord) are deliberately not
-> installed, and the in-tree VP8/VP9 FFmpeg serves the video *output* path rather than
-> input. So if NVDEC is unavailable, H.264 and H.265 fail with an unsupported-codec error
+> installed — the vLLM images ship OpenCV built without a video backend, which resizes
+> still images and opens no video — and the in-tree VP8/VP9 FFmpeg serves the video
+> *output* path rather than input. So if NVDEC is unavailable, H.264 and H.265 fail with an unsupported-codec error
 > — and VP8, VP9 and AV1 fail the same way whether NVDEC is available or not, since NVDEC
 > does not decode them either.
 >
@@ -148,8 +150,8 @@ To decode a format NVDEC does not cover — or H.264/H.265 on a host with no NVD
 explicitly install the backend's decode package at the validated version bounds:
 
 ```bash
-# vLLM: video + audio input
-pip install --no-deps 'opencv-python-headless>=4.13.0.92,<5' 'av>=18.0.0,<19'
+# vLLM: audio input
+pip install --no-deps 'av>=18.0.0,<19'
 
 # SGLang: video input
 pip install --no-deps 'decord2>=3.4.0,<4'
@@ -158,9 +160,20 @@ pip install --no-deps 'decord2>=3.4.0,<4'
 pip install --no-deps 'opencv-python-headless>=4.13.0.92,<5'
 ```
 
+vLLM **video** input is the exception, because those images already ship OpenCV built
+without a video backend. Adding video decode there means replacing that build with the
+binary wheel of the same version, not installing a range:
+
+```bash
+VERSION=$(pip show opencv-python-headless | awk '/^Version:/{print $2}')
+pip install --no-deps --force-reinstall --only-binary opencv-python-headless \
+  "opencv-python-headless==${VERSION}"
+```
+
 Nothing installs automatically — this is a deliberate operator step. The images also ship
 an installer with the same bounds plus idempotency and air-gap support
-(`python -m dynamo.common.utils.install_media_decoders <backend>`); see
+(`python -m dynamo.common.utils.install_media_decoders <backend>`). It does not cover the
+vLLM OpenCV case above: that package is already importable, so the installer skips it. See
 [Additional Media Decoders](additional-media-decoders.md) for the full workflow,
 including baking the install into an image layer for Kubernetes.
 

--- a/tests/dependencies/test_no_software_video_codecs.py
+++ b/tests/dependencies/test_no_software_video_codecs.py
@@ -125,19 +125,59 @@ def _assert_no_software_codecs(surfaces: dict[str, str]) -> None:
         )
 
 
-def _assert_python_carriers_absent() -> None:
+def _assert_python_carriers_absent(ships_cv2: bool) -> None:
     """The Python decode carriers are absent from an unmodified image.
 
     They are installable at runtime behind an opt-in switch, and tests that do so
     are marked ``installs_extra_dependencies``. An unmodified image must not have
     them, or a green multimodal run says nothing about what customers receive.
+
+    ``ships_cv2`` covers the one image that carries a decode carrier on purpose:
+    the vLLM runtime rebuilds OpenCV from source without any video backend,
+    because mistral_common cannot tokenize a still image without ``cv2.resize``.
+    Presence is not what this file polices -- codecs are -- so that build is
+    checked by :func:`_assert_cv2_carries_no_codec` instead of by absence.
     """
-    for module, package in (("cv2", "opencv-python"), ("av", "PyAV")):
+    carriers = [("av", "PyAV")]
+    if not ships_cv2:
+        carriers.append(("cv2", "opencv-python"))
+    for module, package in carriers:
         spec = importlib.util.find_spec(module)
         assert spec is None, (
             f"{package} is installed ({module} at {spec.origin}); an unmodified "
             "runtime image is expected to ship without it"
         )
+
+
+def _assert_cv2_carries_no_codec() -> None:
+    """A shipped OpenCV must be the in-tree build with every video backend off.
+
+    The PyPI wheel vendors a full ffmpeg under ``opencv_python_headless.libs/``
+    and names it in the extension's DT_NEEDED, so installing it would put a
+    software H.264/H.265/AAC decoder back on disk. Ask the library what it was
+    built with rather than trusting the version, and check the vendored payload
+    is absent -- a wheel swapped in later would satisfy neither.
+    """
+    import cv2
+
+    build_info = cv2.getBuildInformation()
+    for backend in ("FFMPEG", "GSTREAMER"):
+        match = re.search(rf"^\s*{backend}:\s*(\S+)", build_info, re.M)
+        assert not (match and match.group(1).upper() == "YES"), (
+            f"the shipped cv2 was built with {backend}; it must be built with "
+            f"-DWITH_{backend}=OFF so the image carries no software video codec"
+        )
+
+    vendored = [
+        os.path.join(root, name)
+        for root in {p for p in sys.path if p and os.path.isdir(p)}
+        for name in os.listdir(root)
+        if name.startswith("opencv_python") and name.endswith(".libs")
+    ]
+    assert not vendored, (
+        f"cv2 ships vendored media libraries ({', '.join(vendored)}); the image "
+        "is expected to carry the source build, which vendors none"
+    )
 
 
 def _bundled_libavcodecs() -> list[str]:
@@ -228,11 +268,13 @@ def _assert_bundled_libavcodecs_carry_no_software_codecs() -> None:
         )
 
 
-def _check_image() -> None:
+def _check_image(ships_cv2: bool = False) -> None:
     surfaces = _surfaces()
     _assert_required_codecs_present(surfaces)
     _assert_no_software_codecs(surfaces)
-    _assert_python_carriers_absent()
+    _assert_python_carriers_absent(ships_cv2)
+    if ships_cv2:
+        _assert_cv2_carries_no_codec()
     _assert_bundled_libavcodecs_carry_no_software_codecs()
 
 
@@ -244,7 +286,7 @@ def _check_image() -> None:
 
 @pytest.mark.vllm
 def test_vllm_image_ships_no_software_video_codecs() -> None:
-    _check_image()
+    _check_image(ships_cv2=True)
 
 
 @pytest.mark.sglang

--- a/tests/dependencies/test_no_software_video_codecs.py
+++ b/tests/dependencies/test_no_software_video_codecs.py
@@ -57,7 +57,9 @@ pytestmark = [
 # H.264/H.265 via NVDEC; audio has no hardware path and is opt-in only.
 # Mirrors the build-time guard's pattern in wheel_builder.Dockerfile: `aac` is
 # anchored to a word start so it cannot match inside an unrelated identifier.
-_DISALLOWED_RE = re.compile(r"h\.?264|h\.?265|hevc|(?:^|\s)aac|nvenc|cuvid|nvdec", re.I)
+_DISALLOWED_RE = re.compile(
+    r"h\.?264|h\.?265|hevc|(?:^|\s)aac|nvenc|cuvid|nvdec", re.IGNORECASE
+)
 # Present by construction, so a broken FFmpeg cannot masquerade as a pass.
 _REQUIRED = ("vp9",)
 
@@ -162,7 +164,7 @@ def _assert_cv2_carries_no_codec() -> None:
 
     build_info = cv2.getBuildInformation()
     for backend in ("FFMPEG", "GSTREAMER"):
-        match = re.search(rf"^\s*{backend}:\s*(\S+)", build_info, re.M)
+        match = re.search(rf"^\s*{backend}:\s*(\S+)", build_info, re.MULTILINE)
         assert not (match and match.group(1).upper() == "YES"), (
             f"the shipped cv2 was built with {backend}; it must be built with "
             f"-DWITH_{backend}=OFF so the image carries no software video codec"


### PR DESCRIPTION
Multimodal Mistral models cannot load on the vLLM runtime image. vLLM's profiling run builds dummy images, mistral_common resizes each one with cv2.resize, and the image purges OpenCV entirely for codec compliance. vLLM 0.28.0 requires OpenCV directly and again through mistral_common[image], so the purge breaks a declared dependency.

Rebuild it from source rather than shipping the PyPI wheel, which vendors a full FFmpeg. WITH_FFMPEG=OFF leaves no libav* in the extension's DT_NEEDED, so the shipped cv2 resizes images and opens no video at all -- the same codec surface as removing it. The version is read off the base image so it cannot drift from the one vLLM resolved.

A present-but-backendless cv2 makes vLLM's VideoCapture raise SystemError rather than ImportError, so the video path detects it up front and still raises the actionable unsupported-codec error. The installer drops OpenCV from its vLLM set: it is now always importable, so listing it would be a silent no-op promising a video decoder it cannot deliver.

closes: DYN-4286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video-decoder error messages with actionable installation guidance tailored to the selected backend.
  * Added detection for OpenCV builds without video-decoding support and clearer recovery instructions.

* **Bug Fixes**
  * Prevented unsupported decoder installation commands from being suggested.
  * Preserved unrelated video errors while allowing supported backends to continue working.

* **Documentation**
  * Updated media-decoder guidance: vLLM uses PyAV for audio, while video decoding requires a compatible OpenCV replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->