### PR TITLE
perf(runtime): clone only the selected instance during dispatch

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -577,6 +577,15 @@ impl Client {
         self.instance_source.borrow().clone()
     }
 
+    /// Clone only the selected instance from the current discovery snapshot.
+    pub(crate) fn instance_by_id(&self, instance_id: u64) -> Option<Instance> {
+        self.instance_source
+            .borrow()
+            .iter()
+            .find(|instance| instance.id() == instance_id)
+            .cloned()
+    }
+
     pub fn instance_ids(&self) -> Vec<u64> {
         self.instances().into_iter().map(|ep| ep.id()).collect()
     }
@@ -977,6 +986,55 @@ impl Client {
 mod tests {
     use super::*;
     use crate::{DistributedRuntime, Runtime, distributed::DistributedConfig};
+
+    #[tokio::test]
+    async fn test_instance_by_id_returns_owned_current_instance() {
+        use crate::component::TransportType;
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_instance_lookup".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let mut client = endpoint.client().await.unwrap();
+        let instances: Vec<_> = (1..=2)
+            .map(|instance_id| Instance {
+                namespace: "test_instance_lookup".to_string(),
+                component: "test_component".to_string(),
+                endpoint: "test_endpoint".to_string(),
+                instance_id,
+                transport: TransportType::Tcp(format!("127.0.0.1:{}", 9000 + instance_id)),
+                device_type: None,
+                request_plane_codec: None,
+            })
+            .collect();
+        let (tx, rx) = tokio::sync::watch::channel(instances.clone());
+        client.instance_source = Arc::new(rx);
+
+        assert_eq!(client.instance_by_id(1), Some(instances[0].clone()));
+        let selected = client.instance_by_id(2).unwrap();
+        assert_eq!(selected, instances[1]);
+        assert!(client.instance_by_id(3).is_none());
+
+        let mut updated = selected.clone();
+        updated.transport = TransportType::Nats("updated.subject".to_string());
+        tx.send(vec![instances[0].clone(), updated.clone()])
+            .unwrap();
+        assert_eq!(client.instance_by_id(2), Some(updated));
+        assert_eq!(selected, instances[1]);
+
+        tx.send(vec![instances[0].clone()]).unwrap();
+        assert!(client.instance_by_id(2).is_none());
+        assert_eq!(client.instance_by_id(1), Some(instances[0].clone()));
+        assert_eq!(selected, instances[1]);
+
+        rt.shutdown();
+    }
 
     async fn wait_for_discovery_event(
         receiver: &mut DiscoveryEventReceiver,

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -577,7 +577,6 @@ impl Client {
         self.instance_source.borrow().clone()
     }
 
-    /// Clone only the selected instance from the current discovery snapshot.
     pub(crate) fn instance_by_id(&self, instance_id: u64) -> Option<Instance> {
         self.instance_source
             .borrow()
@@ -1026,12 +1025,10 @@ mod tests {
         tx.send(vec![instances[0].clone(), updated.clone()])
             .unwrap();
         assert_eq!(client.instance_by_id(2), Some(updated));
-        assert_eq!(selected, instances[1]);
 
         tx.send(vec![instances[0].clone()]).unwrap();
         assert!(client.instance_by_id(2).is_none());
         assert_eq!(client.instance_by_id(1), Some(instances[0].clone()));
-        assert_eq!(selected, instances[1]);
 
         rt.shutdown();
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1840,19 +1840,15 @@ where
         use crate::component::TransportType;
 
         let lookup = |id: u64| {
-            self.client
-                .instances()
-                .iter()
-                .find(|i| i.instance_id == id)
-                .map(|instance| {
-                    let (addr, kind) = match &instance.transport {
-                        TransportType::Tcp(tcp_endpoint) => {
-                            (tcp_endpoint.clone(), "transport.tcp.request")
-                        }
-                        TransportType::Nats(subject) => (subject.clone(), "transport.nats.request"),
-                    };
-                    (addr, kind, instance.clone())
-                })
+            self.client.instance_by_id(id).map(|instance| {
+                let (addr, kind) = match &instance.transport {
+                    TransportType::Tcp(tcp_endpoint) => {
+                        (tcp_endpoint.clone(), "transport.tcp.request")
+                    }
+                    TransportType::Nats(subject) => (subject.clone(), "transport.nats.request"),
+                };
+                (addr, kind, instance)
+            })
         };
 
         if let Some((addr, kind, inst)) = lookup(instance_id) {


### PR DESCRIPTION
## Overview:

### Summary

Avoid cloning the complete discovered-instance list when resolving a worker's request transport. Clone only the selected instance.

## Details:

- Add a crate-private `Client::instance_by_id` helper that searches the current discovery snapshot and returns an owned instance.
- Use it for primary and fallback transport lookups. Release the discovery read guard before dispatch and retain the required address copy.
- Preserve the public `instances()` API, fallback policy, transport metadata, and error behavior. Each lookup still reads a fresh snapshot.
- Keep the linear search; add no index, cache, lock, or shared state. A successful lookup clones one instance instead of the complete list plus the selected instance. A missing lookup clones none.

## Where should the reviewer start?

`Client::instance_by_id` in `lib/runtime/src/component/client.rs`, then its use in `PushRouter::resolve_transport` in `lib/runtime/src/pipeline/network/egress/push_router.rs`.

## Validation

Initial validation on `fa68d17ced`:

- Client test module: 22 passed, including the lookup test for successful/missing IDs, updated metadata, removal, and retained instances.
- Push-router test module: 39 passed, including fallback restrictions and missing-worker cases.
- `cargo check --locked -p dynamo-runtime` passed.
- `cargo clippy --locked -p dynamo-runtime --lib -- -D warnings` passed.
- Formatting checks for both changed files and `git diff --check` passed.

Review cleanup on `37bf2ae47f`: the focused lookup test, changed-file formatting check, and `git diff --check` passed. The follow-up removes only two redundant assertions and one doc comment; production logic is unchanged.

No new benchmark or profile was run; this PR makes no measured throughput claim.

## Related Issues

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance lookup during network routing.
  * Preserved existing transport address, type, and fallback behavior when resolving destinations.
  * Ensured routing reflects current instance discovery updates and removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->