### PR TITLE
[TEST ONLY] Validate CI on aws-ci-prod-east runners

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -94,7 +94,7 @@ jobs:
   # aren't reproducible on plain ubuntu-latest runners.
   rust-gpu:
     needs: image
-    runs-on: prod-tester-amd-gpu-v2
+    runs-on: prod-tester-amd-gpu-v2-east-canary
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ (inputs.cuda_version != '' && !startsWith(inputs.cuda_version, '13.')) && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
@@ -169,7 +169,7 @@ jobs:
 
   mypy:
     needs: image
-    runs-on: prod-tester-amd-v2
+    runs-on: prod-tester-amd-v2-east-canary
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ (inputs.cuda_version != '' && !startsWith(inputs.cuda_version, '13.')) && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
@@ -208,7 +208,7 @@ jobs:
     with:
       test_suite_name: dynamo
       test_type: parallel
-      amd_runner: prod-tester-amd-v2
+      amd_runner: prod-tester-amd-v2-east-canary
       target_tag_plain: ${{ needs.image.outputs.target_tag_plain }}
       cuda_version: '["${{ inputs.cuda_version }}"]'
       platform: '["amd64", "arm64"]'
@@ -229,7 +229,7 @@ jobs:
     with:
       test_suite_name: dynamo
       test_type: sequential
-      amd_runner: prod-tester-amd-v2
+      amd_runner: prod-tester-amd-v2-east-canary
       target_tag_plain: ${{ needs.image.outputs.target_tag_plain }}
       cuda_version: '["${{ inputs.cuda_version }}"]'
       platform: '["amd64", "arm64"]'
@@ -250,7 +250,7 @@ jobs:
     with:
       test_suite_name: dynamo
       test_type: gpu
-      amd_runner: prod-tester-amd-gpu-v2
+      amd_runner: prod-tester-amd-gpu-v2-east-canary
       target_tag_plain: ${{ needs.image.outputs.target_tag_plain }}
       cuda_version: '["${{ inputs.cuda_version }}"]'
       platform: '["amd64"]'

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,25 +14,25 @@ permissions:
   contents: read
 
 jobs:
-  four-gpu-v2-smoke:
-    name: East four-GPU v2 capacity smoke
-    runs-on: prod-tester-amd-gpu-4-v2-east-canary
+  one-gpu-v1-smoke:
+    name: East one-GPU v1 DinD capacity smoke
+    runs-on: prod-tester-amd-gpu-v1-east-canary
     timeout-minutes: 30
-    container:
-      image: ${{ vars.ECR_REGISTRY }}/dockerhub/busybox:1.37
     steps:
-      - name: Verify GPU Kubernetes container hook
-        shell: sh
+      - name: Verify Docker and nested GPU access
+        shell: bash
         run: |
-          set -eu
+          set -euo pipefail
           echo "runner_name=${RUNNER_NAME}"
           echo "runner_os=${RUNNER_OS}"
           echo "runner_arch=${RUNNER_ARCH}"
           echo "hostname=$(hostname)"
-          ls -l /dev/nvidia*
-          set -- /dev/nvidia[0-9]*
-          test -e "$1"
-          echo "gpu_device_count=$#"
-          test "$#" -eq 4
-          test -d /scratch
-          test -d /models
+          docker info
+          gpu_output=$(docker run --rm --gpus all \
+            --entrypoint nvidia-smi \
+            210086341041.dkr.ecr.us-west-2.amazonaws.com/dynamo-ci/aws/dynamo/actions-runner/dind:gpu \
+            -L)
+          printf '%s\n' "${gpu_output}"
+          gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^GPU ')
+          echo "gpu_device_count=${gpu_count}"
+          test "${gpu_count}" -eq 1

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS CI prod east canary smoke
+
+on:
+  push:
+    branches:
+      - ci/aws-ci-prod-east-canary
+    paths:
+      - .github/workflows/east-canary-smoke.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cpu-smoke:
+    name: East CPU smoke ${{ matrix.slot }}
+    runs-on: prod-default-v2-east-canary
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        slot: [1, 2]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify runner and workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "slot=${{ matrix.slot }}"
+          echo "runner_name=${RUNNER_NAME}"
+          echo "runner_os=${RUNNER_OS}"
+          echo "runner_arch=${RUNNER_ARCH}"
+          echo "hostname=$(hostname)"
+          echo "sha=${GITHUB_SHA}"
+          test "${RUNNER_OS}" = Linux
+          test -f Cargo.toml

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 
 jobs:
-  one-gpu-v1-smoke:
-    name: East one-GPU v1 DinD capacity smoke
-    runs-on: prod-tester-amd-gpu-v1-east-canary
+  four-gpu-v1-smoke:
+    name: East four-GPU v1 DinD capacity smoke
+    runs-on: prod-tester-amd-gpu-4-v1-east-canary
     timeout-minutes: 30
     steps:
       - name: Verify Docker and nested GPU access
@@ -36,4 +36,4 @@ jobs:
           printf '%s\n' "${gpu_output}"
           gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^/dev/nvidia[0-9]')
           echo "gpu_device_count=${gpu_count}"
-          test "${gpu_count}" -eq 1
+          test "${gpu_count}" -eq 4

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 
 jobs:
-  two-gpu-v2-smoke:
-    name: East two-GPU v2 capacity smoke
-    runs-on: prod-tester-amd-gpu-2-v2-east-canary
+  four-gpu-v2-smoke:
+    name: East four-GPU v2 capacity smoke
+    runs-on: prod-tester-amd-gpu-4-v2-east-canary
     timeout-minutes: 30
     container:
       image: ${{ vars.ECR_REGISTRY }}/dockerhub/busybox:1.37
@@ -33,6 +33,6 @@ jobs:
           set -- /dev/nvidia[0-9]*
           test -e "$1"
           echo "gpu_device_count=$#"
-          test "$#" -eq 2
+          test "$#" -eq 4
           test -d /scratch
           test -d /models

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 
 jobs:
-  one-gpu-v2-smoke:
-    name: East one-GPU v2 capacity smoke
-    runs-on: prod-tester-amd-gpu-v2-east-canary
+  two-gpu-v2-smoke:
+    name: East two-GPU v2 capacity smoke
+    runs-on: prod-tester-amd-gpu-2-v2-east-canary
     timeout-minutes: 30
     container:
       image: ${{ vars.ECR_REGISTRY }}/dockerhub/busybox:1.37
@@ -33,5 +33,6 @@ jobs:
           set -- /dev/nvidia[0-9]*
           test -e "$1"
           echo "gpu_device_count=$#"
+          test "$#" -eq 2
           test -d /scratch
           test -d /models

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -9,95 +9,29 @@ on:
       - ci/aws-ci-prod-east-canary
     paths:
       - .github/workflows/east-canary-smoke.yml
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  cpu-smoke:
-    name: East CPU smoke ${{ matrix.slot }}
-    runs-on: prod-default-v2-east-canary
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        slot: [1, 2]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Verify runner and workspace
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "slot=${{ matrix.slot }}"
-          echo "runner_name=${RUNNER_NAME}"
-          echo "runner_os=${RUNNER_OS}"
-          echo "runner_arch=${RUNNER_ARCH}"
-          echo "hostname=$(hostname)"
-          echo "sha=${GITHUB_SHA}"
-          test "${RUNNER_OS}" = Linux
-          test -f Cargo.toml
-
-  cpu-runner-family-smoke:
-    name: East CPU pool ${{ matrix.runner }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - prod-default-v1-east-canary
-          - prod-default-small-v2-east-canary
-          - prod-builder-amd-v1-east-canary
-          - prod-builder-arm-v1-east-canary
-          - prod-builder-v3-east-canary
-          - prod-deploy-tester-v1-east-canary
-          - prod-skopeo-v1-east-canary
-          - prod-tester-amd-v1-east-canary
-          - prod-tester-arm-v1-east-canary
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Verify runner and workspace
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "requested_pool=${{ matrix.runner }}"
-          echo "runner_name=${RUNNER_NAME}"
-          echo "runner_os=${RUNNER_OS}"
-          echo "runner_arch=${RUNNER_ARCH}"
-          echo "hostname=$(hostname)"
-          test "${RUNNER_OS}" = Linux
-          test -f Cargo.toml
-
-  v2-cpu-container-smoke:
-    name: East v2 CPU container ${{ matrix.runner }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - prod-tester-amd-v2-east-canary
-          - prod-tester-arm-v2-east-canary
+  one-gpu-v2-smoke:
+    name: East one-GPU v2 capacity smoke
+    runs-on: prod-tester-amd-gpu-v2-east-canary
+    timeout-minutes: 30
     container:
       image: ${{ vars.ECR_REGISTRY }}/dockerhub/busybox:1.37
     steps:
-      - name: Verify Kubernetes container hook
+      - name: Verify GPU Kubernetes container hook
         shell: sh
         run: |
           set -eu
-          echo "requested_pool=${{ matrix.runner }}"
           echo "runner_name=${RUNNER_NAME}"
           echo "runner_os=${RUNNER_OS}"
           echo "runner_arch=${RUNNER_ARCH}"
           echo "hostname=$(hostname)"
-          test "${RUNNER_OS}" = Linux
-          test -d "${GITHUB_WORKSPACE}"
+          ls -l /dev/nvidia*
+          set -- /dev/nvidia[0-9]*
+          test -e "$1"
+          echo "gpu_device_count=$#"
+          test -d /scratch
+          test -d /models

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -28,11 +28,12 @@ jobs:
           echo "runner_arch=${RUNNER_ARCH}"
           echo "hostname=$(hostname)"
           docker info
-          gpu_output=$(docker run --rm --gpus all \
-            --entrypoint nvidia-smi \
-            210086341041.dkr.ecr.us-west-2.amazonaws.com/dynamo-ci/aws/dynamo/actions-runner/dind:gpu \
-            -L)
+          gpu_output=$(docker run --rm --gpus all busybox:1.37 sh -c '
+            for device in /dev/nvidia[0-9]*; do
+              [ -e "${device}" ] && printf "%s\n" "${device}"
+            done
+          ')
           printf '%s\n' "${gpu_output}"
-          gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^GPU ')
+          gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^/dev/nvidia[0-9]')
           echo "gpu_device_count=${gpu_count}"
           test "${gpu_count}" -eq 1

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 
 jobs:
-  four-gpu-v1-smoke:
-    name: East four-GPU v1 DinD capacity smoke
-    runs-on: prod-tester-amd-gpu-4-v1-east-canary
+  gpu-builder-v1-smoke:
+    name: East GPU builder v1 DinD capacity smoke
+    runs-on: prod-builder-amd-gpu-v1-east-canary
     timeout-minutes: 30
     steps:
       - name: Verify Docker and nested GPU access
@@ -36,4 +36,4 @@ jobs:
           printf '%s\n' "${gpu_output}"
           gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^/dev/nvidia[0-9]')
           echo "gpu_device_count=${gpu_count}"
-          test "${gpu_count}" -eq 4
+          test "${gpu_count}" -eq 1

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -41,3 +41,63 @@ jobs:
           echo "sha=${GITHUB_SHA}"
           test "${RUNNER_OS}" = Linux
           test -f Cargo.toml
+
+  cpu-runner-family-smoke:
+    name: East CPU pool ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - prod-default-v1-east-canary
+          - prod-default-small-v2-east-canary
+          - prod-builder-amd-v1-east-canary
+          - prod-builder-arm-v1-east-canary
+          - prod-builder-v3-east-canary
+          - prod-deploy-tester-v1-east-canary
+          - prod-skopeo-v1-east-canary
+          - prod-tester-amd-v1-east-canary
+          - prod-tester-arm-v1-east-canary
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify runner and workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "requested_pool=${{ matrix.runner }}"
+          echo "runner_name=${RUNNER_NAME}"
+          echo "runner_os=${RUNNER_OS}"
+          echo "runner_arch=${RUNNER_ARCH}"
+          echo "hostname=$(hostname)"
+          test "${RUNNER_OS}" = Linux
+          test -f Cargo.toml
+
+  v2-cpu-container-smoke:
+    name: East v2 CPU container ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - prod-tester-amd-v2-east-canary
+          - prod-tester-arm-v2-east-canary
+    container:
+      image: ${{ vars.ECR_REGISTRY }}/dockerhub/busybox:1.37
+    steps:
+      - name: Verify Kubernetes container hook
+        shell: sh
+        run: |
+          set -eu
+          echo "requested_pool=${{ matrix.runner }}"
+          echo "runner_name=${RUNNER_NAME}"
+          echo "runner_os=${RUNNER_OS}"
+          echo "runner_arch=${RUNNER_ARCH}"
+          echo "hostname=$(hostname)"
+          test "${RUNNER_OS}" = Linux
+          test -d "${GITHUB_WORKSPACE}"

--- a/.github/workflows/east-canary-smoke.yml
+++ b/.github/workflows/east-canary-smoke.yml
@@ -14,26 +14,30 @@ permissions:
   contents: read
 
 jobs:
-  gpu-builder-v1-smoke:
-    name: East GPU builder v1 DinD capacity smoke
-    runs-on: prod-builder-amd-gpu-v1-east-canary
-    timeout-minutes: 30
+  cpu-burst:
+    name: East CPU burst slot ${{ matrix.slot }}
+    runs-on: prod-default-v2-east-canary
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        slot: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
-      - name: Verify Docker and nested GPU access
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify runner and hold burst
         shell: bash
         run: |
           set -euo pipefail
+          echo "slot=${{ matrix.slot }}"
           echo "runner_name=${RUNNER_NAME}"
           echo "runner_os=${RUNNER_OS}"
           echo "runner_arch=${RUNNER_ARCH}"
           echo "hostname=$(hostname)"
-          docker info
-          gpu_output=$(docker run --rm --gpus all busybox:1.37 sh -c '
-            for device in /dev/nvidia[0-9]*; do
-              [ -e "${device}" ] && printf "%s\n" "${device}"
-            done
-          ')
-          printf '%s\n' "${gpu_output}"
-          gpu_count=$(printf '%s\n' "${gpu_output}" | grep -c '^/dev/nvidia[0-9]')
-          echo "gpu_device_count=${gpu_count}"
-          test "${gpu_count}" -eq 1
+          test "${RUNNER_OS}" = Linux
+          test -f Cargo.toml
+          sleep 45

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -21,6 +21,10 @@ on:
         type: choice
         options: [all, vllm, sglang, trtllm]
         default: all
+      run_deploy_tests:
+        description: 'Run deploy tests (disabled for east runner validation)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -86,7 +90,7 @@ jobs:
   # ============================================================================
   operator:
     name: Operator
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       operator_default_tag: ${{ steps.build.outputs.image_tag }}
     steps:
@@ -122,7 +126,7 @@ jobs:
   power-agent:
     name: Power Agent
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -446,7 +450,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -469,7 +473,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -486,7 +490,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm
       test_type: 4-GPU Test
-      amd_runner: prod-tester-amd-gpu-4-v2
+      amd_runner: prod-tester-amd-gpu-4-v2-east-canary
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -503,7 +507,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: vllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
+      amd_runner: prod-tester-amd-v2-east-canary # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.vllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]'
@@ -544,7 +548,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: sglang
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -567,7 +571,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: sglang
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -584,7 +588,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: trtllm
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -607,7 +611,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: trtllm
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -624,7 +628,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: trtllm-efa
       test_type: CPU Test
-      amd_runner: prod-tester-amd-v2 # EFA image validation runs gpu_0 tests only
+      amd_runner: prod-tester-amd-v2-east-canary # EFA image validation runs gpu_0 tests only
       target_tag_plain: ${{ needs.trtllm-efa-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]'
@@ -641,7 +645,7 @@ jobs:
       dd_env: post-merge
       test_suite_name: planner
       test_type: CPU Test
-      amd_runner: prod-tester-amd-v2
+      amd_runner: prod-tester-amd-v2-east-canary
       target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
       cuda_version: '[""]'
       platform: '["amd64", "arm64"]'
@@ -709,7 +713,7 @@ jobs:
     name: vLLM Snapshot Placeholder
     needs: [vllm-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-vllm-placeholder', needs.vllm-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -760,7 +764,7 @@ jobs:
     name: SGLang Snapshot Placeholder
     needs: [sglang-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-sglang-placeholder', needs.sglang-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -814,7 +818,7 @@ jobs:
     name: TRTLLM Snapshot Placeholder
     needs: [trtllm-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-trtllm-placeholder', needs.trtllm-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -893,7 +897,8 @@ jobs:
 
   deploy-operator:
     needs: [operator]
-    runs-on: prod-deploy-tester-v1
+    if: github.event_name != 'workflow_dispatch' || inputs.run_deploy_tests
+    runs-on: prod-deploy-tester-v1-east-canary
     outputs:
       namespace: ${{ steps.setup.outputs.namespace }}
       vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
@@ -975,7 +980,7 @@ jobs:
     name: vLLM DynamoCheckpoint Operator Setup
     needs: [operator]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1005,7 +1010,7 @@ jobs:
     name: SGLang DynamoCheckpoint Operator Setup
     needs: [operator]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1035,7 +1040,7 @@ jobs:
     name: TRTLLM DynamoCheckpoint Operator Setup
     needs: [operator]
     if: github.event_name != 'workflow_dispatch'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1067,7 +1072,7 @@ jobs:
     if: |
       github.event_name != 'workflow_dispatch' &&
       needs.deploy-operator-checkpoint-vllm.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1113,7 +1118,7 @@ jobs:
     if: |
       github.event_name != 'workflow_dispatch' &&
       needs.deploy-operator-checkpoint-sglang.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1159,7 +1164,7 @@ jobs:
     if: |
       github.event_name != 'workflow_dispatch' &&
       needs.deploy-operator-checkpoint-trtllm.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1207,7 +1212,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-vllm.result == 'success' &&
       needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1271,7 +1276,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-sglang.result == 'success' &&
       needs.snapshot-placeholder-sglang.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1335,7 +1340,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-trtllm.result == 'success' &&
       needs.snapshot-placeholder-trtllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1392,9 +1397,9 @@ jobs:
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ needs.frontend-copy-to-acr.outputs.image_tag }}
 
   deploy-cleanup:
-    if: always()
+    if: always() && (github.event_name != 'workflow_dispatch' || inputs.run_deploy_tests)
     needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-dgdr, deploy-test-gaie]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
@@ -1410,7 +1415,7 @@ jobs:
     name: vLLM DynamoCheckpoint Cleanup
     if: always() && github.event_name != 'workflow_dispatch'
     needs: [deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
@@ -1423,7 +1428,7 @@ jobs:
     name: SGLang DynamoCheckpoint Cleanup
     if: always() && github.event_name != 'workflow_dispatch'
     needs: [deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
@@ -1436,7 +1441,7 @@ jobs:
     name: TRTLLM DynamoCheckpoint Cleanup
     if: always() && github.event_name != 'workflow_dispatch'
     needs: [deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
@@ -1450,7 +1455,7 @@ jobs:
   # ============================================================================
   deploy-test-gaie:
     name: GAIE Deploy Test
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     needs: [deploy-operator, frontend-copy-to-acr, vllm-copy-to-acr]
     timeout-minutes: 30
     permissions:
@@ -1546,7 +1551,7 @@ jobs:
 
   clean-k8s-builder:
     name: Clean K8s builder if exists
-    runs-on: prod-default-small-v2
+    runs-on: prod-default-small-v2-east-canary
     if: always()
     needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-placeholder-vllm, snapshot-placeholder-sglang, snapshot-placeholder-trtllm, power-agent, sidecar-build, frontend-build, planner-build]
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,10 @@ jobs:
       - name: Validate deploy test configuration
         id: deploy-test-configuration
         env:
-          RUN_DEPLOY_TESTS: ${{ vars.RUN_DEPLOY_TESTS }}
+          # The east deploy runner cannot initialize until Teleport trusts the
+          # production-east EKS issuer. Keep this temporary validation branch
+          # focused on runner-backed build and test jobs.
+          RUN_DEPLOY_TESTS: "false"
         run: |
           case "$RUN_DEPLOY_TESTS" in
             true)
@@ -227,7 +230,7 @@ jobs:
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true'
     name: Operator
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     # actions: read lets the compliance step download a prior run's baseline
     # operator compliance artifact to diff the OSRB CSV against. Missing -> the
     # diff soft-degrades, build stays green.
@@ -292,7 +295,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.power_agent == 'true'
     name: Power Agent
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -706,7 +709,7 @@ jobs:
       needs.changed-files.outputs.operator == 'true' &&
       needs.planner-build.result == 'success' &&
       needs.operator.result == 'success'
-    runs-on: prod-builder-amd-v1
+    runs-on: prod-builder-amd-v1-east-canary
     permissions:
       contents: read
     env:
@@ -782,7 +785,7 @@ jobs:
     with:
       test_suite_name: vllm
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -808,7 +811,7 @@ jobs:
     with:
       test_suite_name: vllm
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -825,7 +828,7 @@ jobs:
     with:
       test_suite_name: sglang
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -851,7 +854,7 @@ jobs:
     with:
       test_suite_name: sglang
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -868,7 +871,7 @@ jobs:
     with:
       test_suite_name: trtllm
       test_type: Test
-      amd_runner: prod-tester-amd-gpu-v2 # This runner is overridden for ARM platform
+      amd_runner: prod-tester-amd-gpu-v2-east-canary # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
@@ -894,7 +897,7 @@ jobs:
     with:
       test_suite_name: trtllm
       test_type: 2-GPU Test
-      amd_runner: prod-tester-amd-gpu-2-v2
+      amd_runner: prod-tester-amd-gpu-2-v2-east-canary
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
@@ -911,7 +914,7 @@ jobs:
     with:
       test_suite_name: planner
       test_type: CPU Test
-      amd_runner: prod-tester-amd-v2
+      amd_runner: prod-tester-amd-v2-east-canary
       target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
       cuda_version: '[""]'
       platform: '["amd64", "arm64"]'
@@ -942,7 +945,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [amd64, arm64]
-    runs-on: ${{ matrix.platform == 'amd64' && 'prod-tester-amd-v2' || 'prod-tester-arm-v2' }}
+    runs-on: ${{ matrix.platform == 'amd64' && 'prod-tester-amd-v2-east-canary' || 'prod-tester-arm-v2-east-canary' }}
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}-${{ needs.frontend-build.outputs.target_tag_plain }}
       env:
@@ -1155,7 +1158,7 @@ jobs:
       always() && !cancelled() &&
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_vllm == 'true')
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-vllm-placeholder', needs.vllm-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -1207,7 +1210,7 @@ jobs:
       always() && !cancelled() &&
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_sglang == 'true')
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-sglang-placeholder', needs.sglang-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -1260,7 +1263,7 @@ jobs:
       always() && !cancelled() &&
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_trtllm == 'true')
-    runs-on: prod-default-v2
+    runs-on: prod-default-v2-east-canary
     outputs:
       image_tag: ${{ format('{0}-ci-{1}-trtllm-placeholder', needs.trtllm-copy-to-acr.outputs.runtime_version, github.sha) }}
     steps:
@@ -1302,7 +1305,7 @@ jobs:
        needs.changed-files.outputs.dgdr == 'true') &&
       needs.operator.result == 'success'
     needs: [changed-files, operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1415,7 +1418,7 @@ jobs:
        needs.changed-files.outputs.snapshot_vllm == 'true') &&
       needs.operator.result == 'success'
     needs: [changed-files, operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1453,7 +1456,7 @@ jobs:
        needs.changed-files.outputs.snapshot_sglang == 'true') &&
       needs.operator.result == 'success'
     needs: [changed-files, operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1491,7 +1494,7 @@ jobs:
        needs.changed-files.outputs.snapshot_trtllm == 'true') &&
       needs.operator.result == 'success'
     needs: [changed-files, operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     permissions:
       contents: read
     outputs:
@@ -1529,7 +1532,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_vllm == 'true') &&
       needs.deploy-operator-checkpoint-vllm.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1581,7 +1584,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_sglang == 'true') &&
       needs.deploy-operator-checkpoint-sglang.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1633,7 +1636,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_trtllm == 'true') &&
       needs.deploy-operator-checkpoint-trtllm.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1687,7 +1690,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-vllm.result == 'success' &&
       needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1760,7 +1763,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-sglang.result == 'success' &&
       needs.snapshot-placeholder-sglang.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1833,7 +1836,7 @@ jobs:
       needs.deploy-snapshot-agent-checkpoint-trtllm.result == 'success' &&
       needs.snapshot-placeholder-trtllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1900,7 +1903,7 @@ jobs:
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       always()
     needs: [changed-files, deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-dgdr]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -1920,7 +1923,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_vllm == 'true')
     needs: [changed-files, deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
@@ -1937,7 +1940,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_sglang == 'true')
     needs: [changed-files, deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
@@ -1954,7 +1957,7 @@ jobs:
       (needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.snapshot_trtllm == 'true')
     needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
@@ -1965,7 +1968,7 @@ jobs:
 
   clean-k8s-builder:
     name: Clean K8s builder if exists
-    runs-on: prod-default-small-v2
+    runs-on: prod-default-small-v2-east-canary
     if: always()
     needs:
       - changed-files

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -200,7 +200,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
-    runs-on: prod-builder-v3
+    runs-on: prod-builder-v3-east-canary
     # cuda_version not empty -- name: cuda12, linux/amd64
     # cuda_version empty -- name: cpu, linux/amd64
     name: Build multi-arch ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}

--- a/.github/workflows/shared-build-sidecar.yml
+++ b/.github/workflows/shared-build-sidecar.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build:
     name: Build multi-arch cpu
-    runs-on: prod-builder-v3
+    runs-on: prod-builder-v3-east-canary
     timeout-minutes: ${{ inputs.build_timeout_minutes }}
     permissions:
       actions: read

--- a/.github/workflows/shared-compliance-audit.yml
+++ b/.github/workflows/shared-compliance-audit.yml
@@ -50,7 +50,7 @@ jobs:
     # prod-tester-amd-v2 RUNS these images for tests, so it has the memory the
     # builder lacked. Non-GPU tester (syft needs no GPU); registry scan is
     # daemon-independent.
-    runs-on: prod-tester-amd-v2
+    runs-on: prod-tester-amd-v2-east-canary
     # Run inside the shipped image itself (same runner combo as shared-test.yml,
     # proven on this pool): satisfies the runner's job-container requirement and
     # provides python3 for the audit. syft then scans the container's OWN

--- a/.github/workflows/shared-compliance.yml
+++ b/.github/workflows/shared-compliance.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         platform: ${{ fromJson(inputs.platform) }}
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
-    runs-on: prod-builder-v3
+    runs-on: prod-builder-v3-east-canary
     # cuda_version not empty -- name: cuda12, linux/amd64
     # cuda_version empty -- name: cpu, linux/amd64
     name: Compliance ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}, ${{ matrix.platform }}

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
     name: Copy to ACR cuda${{ matrix.cuda_version }}${{ inputs.override_arch != '' && format(', {0}', inputs.override_arch) || '' }}
-    runs-on: prod-default-small-v2
+    runs-on: prod-default-small-v2-east-canary
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   deploy-test:
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/shared-dgdr-deploy-test.yml
+++ b/.github/workflows/shared-dgdr-deploy-test.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   ensure-vcluster:
     name: Ensure vCluster
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 30
     permissions:
       contents: read
@@ -68,7 +68,7 @@ jobs:
   dgdr-deploy-test:
     name: CPU / ${{ matrix.suite }}
     needs: ensure-vcluster
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-deploy-tester-v1-east-canary
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -137,7 +137,7 @@ jobs:
         platform: ${{ fromJson(inputs.platform) }}
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
     name: ${{ inputs.test_type }} ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}, ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform == 'amd64' && inputs.amd_runner || 'prod-tester-arm-v2' }}
+    runs-on: ${{ matrix.platform == 'amd64' && inputs.amd_runner || 'prod-tester-arm-v2-east-canary' }}
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ inputs.target_tag_plain }}${{ (matrix.cuda_version != '' && !startsWith(matrix.cuda_version, '13.')) && format('-cuda{0}', startsWith(matrix.cuda_version, '12.') && '12' || matrix.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:


### PR DESCRIPTION
Temporary draft PR for the aws-ci-prod-east canary validation.\n\nThis branch routes AWS ARC-backed pre-merge and post-merge jobs to the east-only runner scale-set names. It does not change production runner labels or repository variables. Deploy tests are disabled on this branch while the east Teleport issuer trust is pending.\n\nKnown blocker: east BuildKit cannot currently resolve artifactory.nvidia.com because the us-east-1 Artifactory PrivateLink endpoint and private hosted zone are not provisioned. This PR is for routing evidence only and must not be merged.