### PR TITLE
fix(lora): preserve endpoints while unloading adapters

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1225,19 +1225,18 @@ impl ModelManager {
     /// must stay aligned with endpoint retraction: a unit answered wrongly here either
     /// disables an endpoint that still has models or leaves one enabled with none.
     pub fn has_models_of_type(&self, model_type: ModelType) -> bool {
-        (model_type.contains(ModelType::Chat) && !self.list_chat_completions_models().is_empty())
-            || (model_type.contains(ModelType::Completions)
-                && !self.list_completions_models().is_empty())
-            || (model_type.contains(ModelType::Embedding)
-                && !self.list_embeddings_models().is_empty())
-            || (model_type.contains(ModelType::Images) && !self.list_images_models().is_empty())
-            || (model_type.contains(ModelType::Audios) && !self.list_audios_models().is_empty())
-            || (model_type.contains(ModelType::Videos) && !self.list_videos_models().is_empty())
-            || (model_type.contains(ModelType::TensorBased)
-                && !self.list_tensor_models().is_empty())
-            || (model_type.contains(ModelType::Realtime) && !self.list_realtime_models().is_empty())
-            || (model_type.contains(ModelType::Classify) && !self.list_classify_models().is_empty())
-            || (model_type.contains(ModelType::Pooling) && !self.list_pooling_models().is_empty())
+        self.catalog.load().models.values().any(|model| {
+            (model_type.contains(ModelType::Chat) && model.has_chat_engine())
+                || (model_type.contains(ModelType::Completions) && model.has_completions_engine())
+                || (model_type.contains(ModelType::Embedding) && model.has_embeddings_engine())
+                || (model_type.contains(ModelType::Images) && model.has_images_engine())
+                || (model_type.contains(ModelType::Audios) && model.has_audios_engine())
+                || (model_type.contains(ModelType::Videos) && model.has_videos_engine())
+                || (model_type.contains(ModelType::TensorBased) && model.has_tensor_engine())
+                || (model_type.contains(ModelType::Realtime) && model.has_realtime_engine())
+                || (model_type.contains(ModelType::Classify) && model.has_classify_engine())
+                || (model_type.contains(ModelType::Pooling) && model.has_pooling_engine())
+        })
     }
 
     pub fn get_embeddings_engine(

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3782,7 +3782,6 @@ mod tests {
         );
     }
 
-    /// Stand-in engine for registration-only tests; never invoked.
     struct UncalledEngine;
 
     #[async_trait::async_trait]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1802,22 +1802,25 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Pooling));
     }
 
-    /// `ALL_MODEL_TYPES` is the second hand-maintained list of the same `ModelType` units
-    /// that `ModelManager::has_models_of_type` enumerates, and it is what
-    /// `removed_model_cards` iterates. A unit missing from it is never considered for a
-    /// retraction card, so that unit's endpoint is never retracted even when its last model
-    /// is gone. `ModelType` is a `bitflags!` type, so nothing else catches the omission.
+    /// Every endpoint-backed model type must produce a retraction card once its last model is
+    /// gone.
     #[test]
-    fn all_model_types_covers_every_endpoint_backed_unit() {
+    fn endpoint_backed_model_types_emit_retraction_cards() {
+        let manager = ModelManager::new();
         for unit in ModelType::all().units() {
-            // Units that serve no HTTP endpoint need no retraction card.
             if unit.as_endpoint_types_with_anthropic(true).is_empty() {
                 continue;
             }
+
+            let mut card = ModelDeploymentCard::with_name_only("model");
+            card.model_type = unit;
+            let removed_cards = removed_model_cards(&manager, &card);
+
             assert!(
-                ALL_MODEL_TYPES.contains(&unit),
-                "{unit:?} maps onto an HTTP endpoint but is missing from ALL_MODEL_TYPES, so \
-                 removed_model_cards would never emit a retraction card for it"
+                removed_cards
+                    .iter()
+                    .any(|removed| removed.model_type == unit),
+                "{unit:?} maps onto an HTTP endpoint but does not produce a retraction card"
             );
         }
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1802,8 +1802,6 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Pooling));
     }
 
-    /// Every endpoint-backed model type must produce a retraction card once its last model is
-    /// gone.
     #[test]
     fn endpoint_backed_model_types_emit_retraction_cards() {
         let manager = ModelManager::new();

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1016,9 +1016,8 @@ impl HttpService {
         Ok(())
     }
 
-    /// Reports whether requests to `endpoint_type` are currently served. A disabled
-    /// endpoint answers `404` for every model.
-    pub fn model_endpoint_enabled(&self, endpoint_type: EndpointType) -> bool {
+    #[cfg(test)]
+    pub(crate) fn model_endpoint_enabled(&self, endpoint_type: EndpointType) -> bool {
         self.state.flags.get(&endpoint_type)
     }
 }


### PR DESCRIPTION
## Summary

- Preserve the LoRA endpoint-retraction fix from #14216.
- Exercise endpoint retraction through `removed_model_cards` for every endpoint-backed model type.
- Keep endpoint-state inspection test-scoped and avoid allocating model-name lists while checking occupancy.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p dynamo-llm --lib` was attempted but could not complete because the local filesystem ran out of space while compiling dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model-backed endpoints now remain available while compatible sibling models or adapters are still registered.
  - Endpoints are disabled only after the final model of the corresponding type is removed.
  - Model removal notifications are now generated consistently for all endpoint-backed model types.

- **Tests**
  - Added coverage for model-type tracking, adapter removal, endpoint state changes, and final-model removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->