### PR TITLE
feat(vllm): add A.X-K2 runtime support

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -332,6 +332,7 @@ areas:
   - container/deps/
   - container/dev/
   - container/launch_message/
+  - container/patches/vllm/axk2/
   - container/render.py
   - container/run.sh
   - container/templates/

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -207,6 +207,7 @@ vllm:
   - 'lib/sidecar/common/**'
   - 'lib/sidecar/vllm/**'
   - 'container/templates/vllm_*'
+  - 'container/patches/vllm/**'
   - '!**/*.md'
   - '!**/*.rst'
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -962,7 +962,6 @@ jobs:
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
-      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
 
@@ -1032,7 +1031,6 @@ jobs:
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
-      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -288,6 +288,7 @@
 /container/Dockerfile.docs                                                   @ai-dynamo/dynamo-ops-codeowners
 /container/Dockerfile.test                                                   @ai-dynamo/dynamo-ops-codeowners
 /container/launch_message/                                                   @ai-dynamo/dynamo-ops-codeowners
+/container/patches/vllm/axk2/                                                @ai-dynamo/dynamo-ops-codeowners
 /container/Dockerfile.template                                               @ai-dynamo/dynamo-ops-codeowners
 
 # === docs  (@ai-dynamo/dynamo-docs-codeowners) ===

--- a/container/deps/vllm/validate_axk2_port.py
+++ b/container/deps/vllm/validate_axk2_port.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm.model_executor.models.registry import ModelRegistry
+from vllm.transformers_utils.configs.axk2 import AXK2Config
+from vllm.transformers_utils.configs.speculators.algos import update_dspark
+from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+
+def main() -> None:
+    config = AXK2Config()
+    assert config.model_type == "axk2"
+    assert "AXK2ForCausalLM" in ModelRegistry.get_supported_archs()
+
+    registered = ModelRegistry.models["AXK2ForCausalLM"]
+    model_cls = registered.load_model_cls()
+    assert model_cls is not None
+    assert model_cls.__name__ == "AXK2ForCausalLM"
+
+    # Dynamo 1.4.1's vLLM 0.26.0 base already contains the upstream DSpark
+    # runtime. Verify the pieces needed by skt/A.X-K2-DSpark instead of
+    # overlaying SKT's older vLLM 0.23 implementation on top of them.
+    assert "Qwen3DSparkModel" in ModelRegistry.get_supported_archs()
+    dspark_cls = ModelRegistry.models["Qwen3DSparkModel"].load_model_cls()
+    assert dspark_cls is not None
+    assert dspark_cls.__name__ == "Qwen3DSparkForCausalLM"
+
+    converted: dict[str, object] = {}
+    update_dspark(
+        {
+            "aux_hidden_state_layer_ids": [2, 30, 58],
+            "draft_vocab_size": 32768,
+            "mask_token_id": 163695,
+            "markov_rank": 256,
+            "markov_head_type": "vanilla",
+            "block_size": 5,
+            "enable_confidence_head": True,
+            "confidence_head_with_markov": True,
+            "sample_from_anchor": True,
+        },
+        converted,
+    )
+    assert converted["architectures"] == ["Qwen3DSparkModel"]
+    assert converted["eagle_aux_hidden_state_layer_ids"] == [2, 30, 58]
+    assert converted["target_layer_ids"] == [1, 29, 57]
+    assert converted["draft_vocab_size"] == 32768
+    assert converted["markov_rank"] == 256
+    assert converted["dspark_bonus_anchor"] is False
+
+    # AXK2's sparse indexer, target MLA, and the DSpark SWA draft have
+    # incompatible page sizes. Verify the upstream allocation-only fallback:
+    # promote the draft cache to the target's block size without changing its
+    # sliding-window compute semantics.
+    grouping_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        speculative_config=None,
+    )
+    draft_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=16,
+        head_size=112,
+        dtype=torch.bfloat16,
+        sliding_window=128,
+    )
+    cache_specs = {
+        "target.0.attn": MLAAttentionSpec(
+            block_size=64,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+        ),
+        "target.0.indexer": MLAAttentionSpec(
+            block_size=64,
+            num_kv_heads=1,
+            head_size=132,
+            dtype=torch.uint8,
+        ),
+        "draft.0": draft_spec,
+    }
+    cache_groups = get_kv_cache_groups(grouping_config, cache_specs)
+    assert len(cache_groups) == 1
+    group_spec = cache_groups[0].kv_cache_spec
+    assert isinstance(group_spec, UniformTypeKVCacheSpecs)
+    promoted_draft = group_spec.kv_cache_specs["draft.0"]
+    assert isinstance(promoted_draft, FullAttentionSpec)
+    assert not isinstance(promoted_draft, SlidingWindowSpec)
+    assert promoted_draft.block_size == 64
+    assert promoted_draft.sliding_window == 128
+    assert cache_specs["draft.0"] is draft_spec
+
+    print("AXK2_DSPARK_PORT_WIRING_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/container/patches/vllm/axk2/0001-Model-Add-SKT-A.X-K2-axk2.patch
+++ b/container/patches/vllm/axk2/0001-Model-Add-SKT-A.X-K2-axk2.patch
@@ -1,0 +1,2799 @@
+From 7f264ad0a93302ba9f0442cde22ab78d910ccad2 Mon Sep 17 00:00:00 2001
+From: "Kim, Jin" <jinn.kim@sk.com>
+Date: Tue, 28 Jul 2026 03:07:37 +0000
+Subject: [PATCH 1/2] [Model] Add SKT A.X K2 (axk2)
+
+A.X K2 is a 688B-total / 33B-active Mixture-of-Experts decoder-only model
+(256 routed + 1 shared expert, 8 routed experts per token, 61 layers) released
+by SKT under Apache-2.0. The published checkpoint is block-scaled FP8 (E4M3).
+
+Architecturally it builds on the DeepSeek-V3 MLA layout and adds:
+
+- Sparse Gated Attention (SGA): a lightweight indexer scores key-value
+  candidates and selects top-k (k=2048) per query, combined with a
+  head-specific output gate on the attention output. The gate is fused into
+  q_b_proj at load time.
+- Gated Norm: an input-dependent low-rank gate applied after RMSNorm, which
+  suppresses massive activations and keeps the activation distribution
+  friendly to narrow low-precision formats.
+
+Adds the model implementation and config class, and registers model_type
+"axk2" so MLA is selected for it. MLA head_size is kv_lora_rank +
+qk_rope_head_dim = 512 + 64 = 576, which the FlashMLA kernels accept.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ vllm/model_executor/models/axk2.py            | 2552 +++++++++++++++++
+ vllm/model_executor/models/registry.py        |    1 +
+ vllm/transformers_utils/config.py             |    1 +
+ vllm/transformers_utils/configs/__init__.py   |    2 +
+ vllm/transformers_utils/configs/axk2.py       |  136 +
+ .../model_arch_config_convertor.py            |    2 +
+ 6 files changed, 2694 insertions(+)
+ create mode 100644 vllm/model_executor/models/axk2.py
+ create mode 100644 vllm/transformers_utils/configs/axk2.py
+
+diff --git a/vllm/model_executor/models/axk2.py b/vllm/model_executor/models/axk2.py
+new file mode 100644
+index 000000000..94beea6a8
+--- /dev/null
++++ b/vllm/model_executor/models/axk2.py
+@@ -0,0 +1,2552 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++# Adapted from
++# https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
++# Copyright 2023 The vLLM team.
++#
++# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
++# and OPT implementations in this library. It has been modified from its
++# original forms to accommodate minor architectural differences compared
++# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++"""Inference-only A.X K2 model."""
++
++import typing
++from collections.abc import Callable, Iterable
++from itertools import islice
++import functools
++
++import torch
++from torch import nn
++import torch.nn.functional as F
++
++import vllm._custom_ops as ops
++from vllm._aiter_ops import rocm_aiter_ops
++from vllm.compilation.decorators import support_torch_compile
++from vllm.config import CacheConfig, ParallelConfig, VllmConfig, get_current_vllm_config
++from vllm.distributed import (
++    get_ep_group,
++    get_pp_group,
++    get_tensor_model_parallel_rank,
++    get_tensor_model_parallel_world_size,
++    tensor_model_parallel_all_gather,
++)
++from vllm.logger import init_logger
++from vllm.model_executor.layers.activation import SiluAndMul
++from vllm.model_executor.layers.attention import Attention
++from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
++from vllm.model_executor.layers.fused_moe import (
++    FusedMoE,
++    GateLinear,
++    fused_moe_make_expert_params_mapping,
++)
++from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
++from vllm.model_executor.layers.linear import (
++    ColumnParallelLinear,
++    MergedColumnParallelLinear,
++    QKVParallelLinear,
++    ReplicatedLinear,
++    RowParallelLinear,
++)
++from vllm.model_executor.layers.logits_processor import LogitsProcessor
++from vllm.model_executor.layers.mla import (
++    MLAAttention,
++    MLAModules,
++    MultiHeadLatentAttentionWrapper,
++)
++from vllm.model_executor.layers.quantization import QuantizationConfig
++from vllm.model_executor.layers.quantization.utils.fp8_utils import (
++    per_token_group_quant_fp8,
++)
++from vllm.model_executor.layers.rotary_embedding import get_rope
++from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
++from vllm.model_executor.layers.vocab_parallel_embedding import (
++    ParallelLMHead,
++    VocabParallelEmbedding,
++)
++from vllm.model_executor.model_loader.weight_utils import (
++    default_weight_loader,
++    maybe_remap_kv_scale_name,
++)
++from vllm.model_executor.models.deepseek_v2 import (
++    DeepSeekV2FusedQkvAProjLinear,
++    DeepseekV2MLP,
++    DeepseekV32IndexerCache,
++    yarn_get_mscale,
++)
++from vllm.model_executor.models.utils import sequence_parallel_chunk
++from vllm.platforms import current_platform
++from vllm.sequence import IntermediateTensors
++from vllm.transformers_utils.configs.axk2 import AXK2Config
++from vllm.utils.torch_utils import direct_register_custom_op
++from vllm.v1.attention.backend import AttentionBackend
++from vllm.v1.attention.backends.mla.indexer import (
++    DeepseekV32IndexerBackend,
++)
++from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
++
++from .interfaces import (
++    MixtureOfExperts,
++    SupportsEagle,
++    SupportsEagle3,
++    SupportsLoRA,
++    SupportsPP,
++)
++from .utils import (
++    PPMissingLayer,
++    is_pp_missing_parameter,
++    make_empty_intermediate_tensors_factory,
++    make_layers,
++    maybe_prefix,
++)
++
++logger = init_logger(__name__)
++
++
++# DeepSeek-V3-style fixed layout that vLLM's GPU sparse MLA backends
++# (FlashMLA / FlashInfer / XPU sparse) hardcode in their precompiled CUDA
++# kernels: head_size = kv_lora_rank + qk_rope_head_dim = 512 + 64 = 576,
++# and head_dim_v = 512. AXK2-DSA configs whose native dims are smaller
++# (e.g. kv_lora=128, qk_rope=32, qk_nope=64, v_head=64) get rejected by
++# the backend with ``head_size not supported``. The padding path below
++# makes those models run by zero-extending q / kv_c / k_pe and the
++# kv_b_proj / q_b_proj weights to the DSv3 shape. Zero entries propagate
++# harmlessly through attention; we strip the attention output back to
++# the native v_head_dim before o_proj.
++_MLA_HEAD_SIZE_TARGETS = {
++    576: dict(kv_lora=512,qk_rope=64,qk_nope=None,v_head=None),
++}
++_MLA_DSA_HEAD_SIZE_TARGETS = {
++    576: dict(kv_lora=512,qk_rope=64,qk_nope=128,v_head=128),
++}
++
++
++# RMSNorm over a padded latent dimension. Kept local to this module so that
++# adding A.X K2 does not modify the in-tree AXK1 implementation.
++class PartialRMSNorm(RMSNorm):
++    """
++    RMSNorm applied only to the first `actual_size` dimensions of the
++    last axis. The remaining trailing dimensions are passed through
++    (or added to residual in the fused path) unchanged.
++
++    Args:
++        actual_size: the real learned rank (e.g. 128). `self.weight`
++            will have shape [actual_size].
++        full_size:   the padded rank exposed to downstream ops
++            (e.g. 512). Inputs must have last dim == full_size.
++        eps:         RMSNorm epsilon.
++
++    Weight loading:
++        Since `super().__init__(actual_size)` is called, `self.weight`
++        is a parameter of shape [actual_size], which matches the
++        unchanged checkpoint tensor `kv_a_layernorm.weight`.
++    """
++
++    def __init__(self, actual_size: int, full_size: int, eps: float = 1e-6):
++        assert full_size >= actual_size, (
++            f"full_size ({full_size}) must be >= actual_size ({actual_size})"
++        )
++        super().__init__(actual_size, eps=eps)
++        self.actual_size = actual_size
++        self.full_size = full_size
++        self.pad_size = full_size - actual_size
++
++    def forward(
++        self,
++        x: torch.Tensor,
++        residual: torch.Tensor | None = None,
++    ):
++        # Fast path when no padding is in effect.
++        if self.pad_size == 0:
++            if residual is None:
++                return super().forward(x)
++            return super().forward(x, residual)
++
++        assert x.shape[-1] == self.full_size, (
++            f"PartialRMSNorm expected last dim == {self.full_size}, "
++            f"got {x.shape[-1]}"
++        )
++
++        # Split along the last axis. .contiguous() ensures the head slice
++        # satisfies downstream kernels that expect contiguous memory.
++        x_head = x[..., : self.actual_size].contiguous()
++        x_tail = x[..., self.actual_size :]
++
++        if residual is None:
++            out_head = super().forward(x_head)
++            out = torch.cat([out_head, x_tail], dim=-1)
++            return out
++
++        # Fused residual path: new_residual = x + residual, out = rmsnorm(new_residual).
++        assert residual.shape[-1] == self.full_size, (
++            f"residual last dim ({residual.shape[-1]}) must match "
++            f"full_size ({self.full_size})"
++        )
++        res_head = residual[..., : self.actual_size].contiguous()
++        res_tail = residual[..., self.actual_size :]
++
++        # super().forward with residual returns (normed_output, new_residual).
++        out_head, new_res_head = super().forward(x_head, res_head)
++        new_res_tail = x_tail + res_tail
++
++        out = torch.cat([out_head, new_res_tail], dim=-1)
++        new_residual = torch.cat([new_res_head, new_res_tail], dim=-1)
++        return out, new_residual
++
++    def extra_repr(self) -> str:
++        return (
++            f"actual_size={self.actual_size}, "
++            f"full_size={self.full_size}, "
++            f"eps={self.variance_epsilon}"
++        )
++
++
++def _mla_pad_dims(
++    qk_nope_head_dim: int,
++    qk_rope_head_dim: int,
++    v_head_dim: int,
++    kv_lora_rank: int,
++    target_head_size: int = 576,
++    is_dsa: bool = False,
++) -> tuple[int, int, int, int]:
++    """Effective (qk_nope, qk_rope, v_head, kv_lora) dims, padded up to the
++    DSv3 layout when natives are smaller. No rescaling, just per-axis max."""
++    spec = _MLA_DSA_HEAD_SIZE_TARGETS[target_head_size] if is_dsa else _MLA_HEAD_SIZE_TARGETS[target_head_size]
++    return (
++        max(qk_nope_head_dim, spec["qk_nope"] or qk_nope_head_dim),
++        max(qk_rope_head_dim, spec["qk_rope"] or qk_rope_head_dim),
++        max(v_head_dim, spec["v_head"] or v_head_dim),
++        max(kv_lora_rank, spec["kv_lora"] or kv_lora_rank),
++    )
++
++
++def _pick_mla_target(config):
++    if hasattr(config, "index_topk"):
++        return 576, True
++    # All AXK2 models standardize on the DSv3 layout (kv_lora_rank=512,
++    # head_size=576); the kv_lora=256 / head_size=320 target was dropped.
++    return 576, False
++
++
++def _pad_q_b_proj_native_to_eff(
++    weight: torch.Tensor,
++    num_heads: int,
++    native_qk_nope_head_dim: int,
++    native_qk_rope_head_dim: int,
++    eff_qk_nope_head_dim: int,
++    eff_qk_rope_head_dim: int,
++) -> torch.Tensor:
++    """[num_heads * (native_qk_nope+native_qk_rope), q_lora_rank]
++    → [num_heads * (eff_qk_nope+eff_qk_rope), q_lora_rank]
++    per-head [nope | rope] layout 유지하며 zero-pad."""
++    in_dim = weight.shape[-1]
++    native_head = native_qk_nope_head_dim + native_qk_rope_head_dim
++    eff_head    = eff_qk_nope_head_dim + eff_qk_rope_head_dim
++    q3 = weight.view(num_heads, native_head, in_dim)
++    out = weight.new_zeros((num_heads, eff_head, in_dim))
++    out[:, : native_qk_nope_head_dim] = q3[:, : native_qk_nope_head_dim]
++    out[
++        :,
++        eff_qk_nope_head_dim : eff_qk_nope_head_dim + native_qk_rope_head_dim,
++    ] = q3[:, native_qk_nope_head_dim:]
++    return out.reshape(num_heads * eff_head, in_dim).contiguous()
++
++
++def _pad_fused_q_b_proj_native_to_eff(
++    weight: torch.Tensor,
++    num_heads: int,
++    native_qk_nope_head_dim: int,
++    native_qk_rope_head_dim: int,
++    eff_qk_nope_head_dim: int,
++    eff_qk_rope_head_dim: int,
++    v_head_dim: int,
++) -> torch.Tensor:
++    """Pad the FUSED q_b_proj native->eff (per-head [q | gate] interleave).
++
++    [num_heads * (native_qk_nope+native_qk_rope + v_head), 2*q_lora]
++    → [num_heads * (eff_qk_nope+eff_qk_rope + v_head), 2*q_lora]
++    Only the q sub-block (per head [nope | rope]) is zero-extended; the gate
++    sub-block (v_head) and the doubled input columns are untouched. The doubled
++    input layout (q on the post-norm half, gate on the pre-norm half) is carried
++    in the column dim and preserved as-is."""
++    in_dim = weight.shape[-1]  # 2 * q_lora_rank
++    native_qk = native_qk_nope_head_dim + native_qk_rope_head_dim
++    eff_qk = eff_qk_nope_head_dim + eff_qk_rope_head_dim
++    native_ph = native_qk + v_head_dim
++    eff_ph = eff_qk + v_head_dim
++    w = weight.view(num_heads, native_ph, in_dim)
++    out = weight.new_zeros((num_heads, eff_ph, in_dim))
++    # q nope
++    out[:, :native_qk_nope_head_dim] = w[:, :native_qk_nope_head_dim]
++    # q rope (shifted to start at eff_qk_nope)
++    out[:, eff_qk_nope_head_dim : eff_qk_nope_head_dim + native_qk_rope_head_dim] = (
++        w[:, native_qk_nope_head_dim:native_qk]
++    )
++    # gate (after the eff q block)
++    out[:, eff_qk : eff_qk + v_head_dim] = w[:, native_qk:native_ph]
++    return out.reshape(num_heads * eff_ph, in_dim).contiguous()
++
++
++def _pad_kv_b_proj_native_to_eff(
++    weight: torch.Tensor,
++    num_heads: int,
++    native_qk_nope_head_dim: int,
++    native_v_head_dim: int,
++    native_kv_lora_rank: int,
++    eff_qk_nope_head_dim: int,
++    eff_v_head_dim: int,
++    eff_kv_lora_rank: int,
++) -> torch.Tensor:
++    """[num_heads * (native_qk_nope+native_v_head), native_kv_lora]
++    → [num_heads * (eff_qk_nope+eff_v_head), eff_kv_lora]
++    per-head [k_nope | v] layout 유지하며 dim 0과 dim 1 모두 zero-pad."""
++    native_out = native_qk_nope_head_dim + native_v_head_dim
++    eff_out    = eff_qk_nope_head_dim + eff_v_head_dim
++    w3 = weight.view(num_heads, native_out, native_kv_lora_rank)
++    out = weight.new_zeros((num_heads, eff_out, eff_kv_lora_rank))
++    out[
++        :,
++        : native_qk_nope_head_dim,
++        : native_kv_lora_rank,
++    ] = w3[:, : native_qk_nope_head_dim]
++    out[
++        :,
++        eff_qk_nope_head_dim : eff_qk_nope_head_dim + native_v_head_dim,
++        : native_kv_lora_rank,
++    ] = w3[:, native_qk_nope_head_dim:]
++    return out.reshape(num_heads * eff_out, eff_kv_lora_rank).contiguous()
++
++
++_INDEXER_MIN_N_HEADS = 32
++
++def _indexer_pad_n_heads(native_n_heads: int) -> int:
++    if native_n_heads >= _INDEXER_MIN_N_HEADS:
++        return native_n_heads
++    return _INDEXER_MIN_N_HEADS
++
++
++def _pad_indexer_wq_b(
++    weight: torch.Tensor,
++    native_n_heads: int,
++    eff_n_heads: int,
++    head_dim: int,
++) -> torch.Tensor:
++    """[native_n_heads * head_dim, q_lora_rank] → [eff_n_heads * head_dim, q_lora_rank].
++
++    Head boundaries are aligned at head_dim units, so simple zero-append along
++    dim 0 is correct (no per-head reshape needed unlike q_b_proj which has
++    [nope | rope] per head)."""
++    if eff_n_heads == native_n_heads:
++        return weight
++    pad_rows = (eff_n_heads - native_n_heads) * head_dim
++    zeros = torch.zeros(pad_rows, weight.shape[1],
++                        dtype=weight.dtype, device=weight.device)
++    return torch.cat([weight, zeros], dim=0).contiguous()
++
++
++def _pad_indexer_weights_proj(
++    weight: torch.Tensor,
++    native_n_heads: int,
++    eff_n_heads: int,
++) -> torch.Tensor:
++    """[native_n_heads, hidden] → [eff_n_heads, hidden]. Zero-append on dim 0."""
++    if eff_n_heads == native_n_heads:
++        return weight
++    pad_rows = eff_n_heads - native_n_heads
++    zeros = torch.zeros(pad_rows, weight.shape[1],
++                        dtype=weight.dtype, device=weight.device)
++    return torch.cat([weight, zeros], dim=0).contiguous()
++
++
++def _make_padded_weight_loader(native_shape, pad_fn, original_loader):
++    """기존 weight_loader를 wrap. loaded_weight가 native shape이면 패딩 후 위임,
++    eff shape이면 그대로 통과. 초기 load와 verl runtime update 모두 같은 경로."""
++    native_shape = tuple(native_shape)
++
++    def padded_loader(param, loaded_weight, *args, **kwargs):
++        if tuple(loaded_weight.shape) == native_shape:
++            loaded_weight = pad_fn(loaded_weight)
++        return original_loader(param, loaded_weight, *args, **kwargs)
++
++    return padded_loader
++
++
++# ============================================================================
++# Fused Gated RMSNorm with Low-Rank Bottleneck (Triton)
++#
++# Fuses: rms_norm + (optional residual_add) + W_down GEMM + SiLU + W_up GEMM
++#        + sigmoid + element-wise multiply
++#
++# Original Python implementation:
++#     y = rms_norm(x + residual)  # also updates residual
++#     z = W_down(y)               # [M, H] @ [H, R] -> [M, R]
++#     z = silu(z)
++#     gate = W_up(z)              # [M, R] @ [R, H] -> [M, H]
++#     out = y * sigmoid(gate)
++#
++# Designed for: H=4096 (or hidden_size in this model), R=16 (low rank)
++# Layout assumption:
++#     x:         [M, H]  contiguous, bf16
++#     residual:  [M, H]  contiguous, bf16  (optional)
++#     w_norm:    [H]     bf16
++#     W_down:    [H, R]  bf16, row-major (linear weight is [out, in] in PyTorch,
++#                       so ReplicatedLinear(H, R).weight has shape [R, H];
++#                       we transpose conceptually by indexing accordingly)
++#     W_up:      [R, H]  bf16  (ReplicatedLinear(R, H).weight has shape [H, R];
++#                       again handle indexing)
++#
++# Note on Linear weight shapes in PyTorch:
++#     nn.Linear(in_features, out_features).weight is [out_features, in_features].
++#     ReplicatedLinear follows the same convention.
++#     For W_down = Linear(H, R): weight is [R, H]
++#     For W_up   = Linear(R, H): weight is [H, R]
++#     The kernel below uses these PyTorch-native shapes directly.
++# ============================================================================
++
++import triton
++import triton.language as tl
++from typing import Optional, Tuple
++
++
++@triton.jit
++def _axk2_gated_rmsnorm_kernel(
++    # Pointers
++    x_ptr,           # [M, H]
++    residual_ptr,    # [M, H]  (may be unused if not HAS_RESIDUAL)
++    out_ptr,         # [M, H]
++    w_norm_ptr,      # [H]
++    w_down_ptr,      # [R, H]  PyTorch Linear weight layout: [out, in]
++    w_up_ptr,        # [H, R]  PyTorch Linear weight layout: [out, in]
++    # Sizes
++    M,
++    stride_xm,       # stride to next row in x
++    stride_rm,       # stride to next row in residual
++    stride_om,       # stride to next row in out
++    # Constants
++    H: tl.constexpr,
++    R: tl.constexpr,
++    EPS: tl.constexpr,
++    HAS_RESIDUAL: tl.constexpr,
++    BLOCK_H: tl.constexpr,
++):
++    """
++    One program handles one row (one token).
++
++    Constraints:
++      - H must be <= BLOCK_H (kernel requires full row in registers/SRAM)
++      - R must be a power of 2 and small (e.g., 16, 32)
++    """
++    pid = tl.program_id(0)
++
++    # Pointers to this row
++    x_row_ptr = x_ptr + pid * stride_xm
++    out_row_ptr = out_ptr + pid * stride_om
++
++    # ---------- Step 1: Load x and (optionally) residual add ----------
++    offs_h = tl.arange(0, BLOCK_H)
++    mask_h = offs_h < H
++
++    x = tl.load(x_row_ptr + offs_h, mask=mask_h, other=0.0).to(tl.float32)
++
++    if HAS_RESIDUAL:
++        res_row_ptr = residual_ptr + pid * stride_rm
++        r = tl.load(res_row_ptr + offs_h, mask=mask_h, other=0.0).to(tl.float32)
++        x = x + r
++        # Update residual in-place (cast back to original dtype, bf16)
++        tl.store(res_row_ptr + offs_h, x.to(tl.bfloat16), mask=mask_h)
++
++    # ---------- Step 2: RMSNorm ----------
++    # variance = mean(x^2)
++    var = tl.sum(x * x, axis=0) / H
++    rstd = 1.0 / tl.sqrt(var + EPS)
++
++    # Load norm weight and apply
++    w_norm = tl.load(w_norm_ptr + offs_h, mask=mask_h, other=0.0).to(tl.float32)
++    y = x * rstd * w_norm  # [BLOCK_H], fp32
++
++    # ---------- Step 3: W_down GEMM: y @ W_down.T  ->  z[R] ----------
++    # W_down has PyTorch shape [R, H], stored row-major
++    # We compute z[r] = sum over h of (y[h] * W_down[r, h])
++    #
++    # Load W_down block: [R, H] -> use 2D indexing
++    # Memory layout: W_down[r, h] is at offset r * H + h
++
++    offs_r = tl.arange(0, R)
++
++    # Build [R, BLOCK_H] index matrix for W_down
++    w_down_offsets = offs_r[:, None] * H + offs_h[None, :]
++    w_down_mask = mask_h[None, :]  # only mask on H dim; R is fully valid
++    w_down_block = tl.load(
++        w_down_ptr + w_down_offsets,
++        mask=w_down_mask,
++        other=0.0,
++    ).to(tl.float32)  # [R, BLOCK_H]
++
++    # z = W_down @ y, where y is [BLOCK_H] and W_down is [R, BLOCK_H]
++    # Result is [R]
++    z = tl.sum(w_down_block * y[None, :], axis=1)  # [R]
++
++    # ---------- Step 4: SiLU ----------
++    z = z * tl.sigmoid(z)
++
++    # ---------- Step 5: W_up GEMM: z @ W_up.T  ->  gate[H] ----------
++    # W_up has PyTorch shape [H, R], stored row-major
++    # We compute gate[h] = sum over r of (z[r] * W_up[h, r])
++    #
++    # Memory layout: W_up[h, r] is at offset h * R + r
++
++    w_up_offsets = offs_h[:, None] * R + offs_r[None, :]
++    w_up_mask = mask_h[:, None]
++    w_up_block = tl.load(
++        w_up_ptr + w_up_offsets,
++        mask=w_up_mask,
++        other=0.0,
++    ).to(tl.float32)  # [BLOCK_H, R]
++
++    # gate = W_up @ z, where z is [R] and W_up is [BLOCK_H, R]
++    # Result is [BLOCK_H]
++    gate = tl.sum(w_up_block * z[None, :], axis=1)  # [BLOCK_H]
++
++    # ---------- Step 6: Sigmoid gate and apply ----------
++    out = y * tl.sigmoid(gate)  # [BLOCK_H], fp32
++
++    # ---------- Step 7: Store ----------
++    tl.store(out_row_ptr + offs_h, out.to(tl.bfloat16), mask=mask_h)
++
++
++def _next_power_of_2(n: int) -> int:
++    """Smallest power of 2 >= n."""
++    # p = 1
++    # while p < n:
++    #     p *= 2
++    # return p
++    if n <= 1:
++        return 1
++    return 1 << (n - 1).bit_length()
++
++
++def axk2_gated_rmsnorm_triton(
++    x: torch.Tensor,
++    residual: Optional[torch.Tensor],
++    w_norm: torch.Tensor,
++    w_down: torch.Tensor,
++    w_up: torch.Tensor,
++    eps: float,
++) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
++    """
++    Fused Gated RMSNorm with Low-Rank Bottleneck.
++
++    Args:
++        x:         [..., H]  any shape, last dim must be H
++        residual:  [..., H]  same shape as x, or None
++        w_norm:    [H]
++        w_down:    [R, H]    PyTorch Linear weight layout (out, in)
++        w_up:      [H, R]    PyTorch Linear weight layout (out, in)
++        eps:       float
++
++    Returns:
++        out:       [..., H]  same shape and dtype as x
++        residual:  updated residual tensor if input was not None, else None
++                   (residual is updated in-place; same tensor is returned)
++
++    Behavior matches:
++        y = rms_norm(x + residual) if residual is not None else rms_norm(x)
++        residual_out = (x + residual) in original dtype
++        z = silu(y @ w_down.T)
++        gate = z @ w_up.T
++        out = y * sigmoid(gate)
++        return out, residual_out
++    """
++    assert x.is_cuda, "axk2_gated_rmsnorm_triton requires CUDA tensors"
++    assert x.dtype == torch.bfloat16, \
++        f"Only bf16 supported currently, got {x.dtype}"
++
++    orig_shape = x.shape
++    H = orig_shape[-1]
++    M = x.numel() // H
++
++    # Flatten to 2D
++    x_2d = x.reshape(M, H)
++    if residual is not None:
++        assert residual.shape == x.shape, \
++            f"residual shape {residual.shape} != x shape {x.shape}"
++        assert residual.dtype == x.dtype
++        residual_2d = residual.reshape(M, H)
++        # Ensure contiguous for in-place write
++        assert residual_2d.is_contiguous()
++    else:
++        residual_2d = None
++
++    # Validate weight shapes
++    assert w_norm.shape == (H,), \
++        f"w_norm shape {w_norm.shape} != ({H},)"
++
++    R = w_down.shape[0]
++    assert w_down.shape == (R, H), \
++        f"w_down shape {w_down.shape} != ({R}, {H})"
++    assert w_up.shape == (H, R), \
++        f"w_up shape {w_up.shape} != ({H}, {R})"
++
++    # R must be a power of 2 for tl.arange
++    assert R > 0 and (R & (R - 1)) == 0, \
++        f"R must be a power of 2, got {R}"
++
++    # Weights must be contiguous and bf16
++    assert w_norm.is_contiguous() and w_norm.dtype == torch.bfloat16
++    assert w_down.is_contiguous() and w_down.dtype == torch.bfloat16
++    assert w_up.is_contiguous() and w_up.dtype == torch.bfloat16
++
++    # Compute BLOCK_H
++    BLOCK_H = _next_power_of_2(H)
++    # Triton has practical limits; for very large H consider tiled version
++    assert BLOCK_H <= 8192, \
++        f"H={H} too large for this kernel (BLOCK_H={BLOCK_H}); " \
++        f"use tiled implementation for H > 8192"
++
++    # Ensure x is contiguous in last dim (we use stride-aware loads)
++    assert x_2d.stride(-1) == 1, "x must have contiguous last dim"
++
++    # Allocate output
++    out_2d = torch.empty_like(x_2d)
++
++    # Compute strides (in elements, not bytes)
++    stride_xm = x_2d.stride(0)
++    stride_om = out_2d.stride(0)
++    if residual_2d is not None:
++        stride_rm = residual_2d.stride(0)
++    else:
++        stride_rm = 0  # unused
++
++    # Launch
++    grid = (M,)
++
++    # Pick num_warps based on BLOCK_H
++    # Heuristic: 4 warps for H<=2048, 8 for larger
++    if BLOCK_H <= 2048:
++        num_warps = 4
++    elif BLOCK_H <= 4096:
++        num_warps = 8
++    else:
++        num_warps = 16
++
++    _axk2_gated_rmsnorm_kernel[grid](
++        x_2d,
++        residual_2d if residual_2d is not None else x_2d,  # dummy pass when no residual
++        out_2d,
++        w_norm,
++        w_down,
++        w_up,
++        M,
++        stride_xm,
++        stride_rm,
++        stride_om,
++        H=H,
++        R=R,
++        EPS=eps,
++        HAS_RESIDUAL=residual is not None,
++        BLOCK_H=BLOCK_H,
++        num_warps=num_warps,
++    )
++
++    out = out_2d.reshape(orig_shape)
++    return out, residual  # residual is updated in-place, same tensor
++
++
++# ============================================================================
++# Register as a vLLM custom op so torch.compile / cudagraph treat it as a
++# black-box op.
++# ============================================================================
++
++def _axk2_gated_rmsnorm_impl(
++    x: torch.Tensor,
++    residual: Optional[torch.Tensor],
++    w_norm: torch.Tensor,
++    w_down: torch.Tensor,
++    w_up: torch.Tensor,
++    eps: float,
++) -> torch.Tensor:
++    """
++    Wrapper for custom op registration.
++
++    Note: We can't return a tuple from a custom op easily, and residual is
++    updated in-place anyway, so we only return `out`.
++    Callers must pass `residual` knowing it will be mutated.
++    """
++    out, _ = axk2_gated_rmsnorm_triton(x, residual, w_norm, w_down, w_up, eps)
++    return out
++
++
++def _axk2_gated_rmsnorm_fake(
++    x: torch.Tensor,
++    residual: Optional[torch.Tensor],
++    w_norm: torch.Tensor,
++    w_down: torch.Tensor,
++    w_up: torch.Tensor,
++    eps: float,
++) -> torch.Tensor:
++    """Fake (meta) implementation for torch.compile shape inference."""
++    return torch.empty_like(x)
++
++
++direct_register_custom_op(
++    op_name="axk2_gated_rmsnorm",
++    op_func=_axk2_gated_rmsnorm_impl,
++    mutates_args=["residual"],  # residual is updated in-place
++    fake_impl=_axk2_gated_rmsnorm_fake,
++)
++
++
++# ============================================================================
++# AXK2GatedRMSNorm Module (Optimized: uses fused Triton kernel)
++# ============================================================================
++
++class AXK2GatedRMSNorm2(nn.Module):
++    """
++    Gated RMSNorm with low-rank bottleneck.
++
++    Computes:
++        y = rms_norm(x + residual)  [if residual is not None]
++        z = silu(y @ W_down.T)      [low-rank projection: hidden -> rank]
++        gate = z @ W_up.T            [low-rank projection: rank -> hidden]
++        out = y * sigmoid(gate)
++
++    All fused into a single Triton kernel for performance.
++    """
++
++    def __init__(
++        self,
++        hidden_size: int,
++        eps: float = 1e-6,
++        rank: int = 16,
++        prefix: str = "",
++    ):
++        super().__init__()
++        self.hidden_size = hidden_size
++        self.rank = rank
++        self.eps = eps
++
++        # Standard RMSNorm weight (we use RMSNorm to keep weight loading
++        # compatible with existing checkpoint format; only the forward path
++        # is replaced)
++        self.norm = RMSNorm(hidden_size, eps=eps)
++
++        # Low-rank gate projections
++        # quant_config=None: keep in bf16, FP8 block quant can't handle rank=16
++        self.W_down = ReplicatedLinear(
++            hidden_size,
++            rank,
++            bias=False,
++            quant_config=None,
++            prefix=f"{prefix}.W_down",
++        )
++        self.W_up = ReplicatedLinear(
++            rank,
++            hidden_size,
++            bias=False,
++            quant_config=None,
++            prefix=f"{prefix}.W_up",
++        )
++
++    def forward(
++        self,
++        x: torch.Tensor,
++        residual: Optional[torch.Tensor] = None,
++    ):
++        """
++        Args:
++            x:         [..., hidden_size]
++            residual:  [..., hidden_size] or None
++
++        Returns:
++            If residual is None:
++                out: [..., hidden_size]
++            else:
++                (out, residual): both [..., hidden_size]; residual updated in-place
++        """
++        out = torch.ops.vllm.axk2_gated_rmsnorm(
++            x,
++            residual,
++            self.norm.weight,
++            self.W_down.weight,
++            self.W_up.weight,
++            self.eps,
++        )
++
++        if residual is None:
++            return out
++        return out, residual
++
++
++# ============================================================================
++# AXK2GatedRMSNorm Module (Original)
++# ============================================================================
++
++class AXK2GatedRMSNorm(nn.Module):
++    def __init__(
++        self,
++        hidden_size: int,
++        eps: float = 1e-6,
++        rank: int = 16,
++        prefix: str = "",
++    ):
++        super().__init__()
++        self.hidden_size = hidden_size
++        self.rank = rank
++        self.eps = eps
++
++        # RMSNorm uses vLLM's standard implementation, which internally
++        # promotes to FP32 for variance computation and casts back to the
++        # input dtype at the end (see vllm/model_executor/layers/layernorm.py).
++        # This matches DeepSeek V3.2's normalization policy.
++        self.norm = RMSNorm(hidden_size, eps=eps)
++
++        # Low-rank gate projections.
++        # quant_config=None: rank=16 is below the FP8 block quant group_size
++        # (128), so we keep these in BF16. Other small linears in the model
++        # (e.g., Indexer.weights_proj) use the same pattern.
++        self.W_down = ReplicatedLinear(
++            hidden_size,
++            rank,
++            bias=False,
++            quant_config=None,
++            prefix=f"{prefix}.W_down",
++        )
++        self.W_up = ReplicatedLinear(
++            rank,
++            hidden_size,
++            bias=False,
++            quant_config=None,
++            prefix=f"{prefix}.W_up",
++        )
++
++    def _apply_gate(self, y: torch.Tensor) -> torch.Tensor:
++        # W_down GEMM: BF16 input, BF16 weight, BF16 output
++        z, _ = self.W_down(y)
++
++        # Upcast to FP32 for silu
++        z_fp32 = z.to(torch.float32)
++        z_fp32 = F.silu(z_fp32)
++
++        # Cast back to BF16 for the next GEMM
++        z_bf16 = z_fp32.to(y.dtype)
++
++        # W_up GEMM: BF16 input, BF16 weight, BF16 output
++        gate, _ = self.W_up(z_bf16)
++
++        # Upcast both operands to FP32 for sigmoid and multiply
++        gate_fp32 = gate.to(torch.float32)
++        y_fp32 = y.to(torch.float32)
++
++        # FP32 sigmoid and elementwise multiply
++        out_fp32 = y_fp32 * torch.sigmoid(gate_fp32)
++
++        # Final cast back to BF16
++        return out_fp32.to(y.dtype)
++
++    def forward(
++        self,
++        x: torch.Tensor,
++        residual: Optional[torch.Tensor] = None,
++    ):
++        if residual is not None:
++            # RMSNorm handles residual add (in FP32 internally) and returns
++            # (normalized_output_bf16, residual_out_bf16)
++            y, residual = self.norm(x, residual)
++            return self._apply_gate(y), residual
++        else:
++            y = self.norm(x)
++            return self._apply_gate(y)
++
++
++class AXK2MoE(nn.Module):
++    def __init__(
++        self,
++        config: AXK2Config,
++        parallel_config: ParallelConfig,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++    ):
++        super().__init__()
++        self.tp_size = get_tensor_model_parallel_world_size()
++        self.tp_rank = get_tensor_model_parallel_rank()
++
++        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
++
++        self.ep_group = get_ep_group().device_group
++        self.ep_rank = get_ep_group().rank_in_group
++        self.ep_size = self.ep_group.size()
++        self.n_routed_experts: int = config.n_routed_experts
++        self.n_shared_experts: int = config.n_shared_experts
++
++        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
++
++        if config.hidden_act != "silu":
++            raise ValueError(
++                f"Unsupported activation: {config.hidden_act}. "
++                "Only silu is supported for now."
++            )
++
++        self.gate = GateLinear(
++            config.hidden_size,
++            config.n_routed_experts,
++            prefix=f"{prefix}.gate",
++        )
++        # self.gate = ReplicatedLinear(
++        #     config.hidden_size,
++        #     config.n_routed_experts,
++        #     bias=False,
++        #     quant_config=None,
++        #     prefix=f"{prefix}.gate",
++        # )
++        if getattr(config, "topk_method", None) == "noaux_tc":
++            self.gate.e_score_correction_bias = nn.Parameter(
++                torch.empty(config.n_routed_experts, dtype=torch.float32)
++            )
++        else:
++            self.gate.e_score_correction_bias = None
++
++        # Load balancing settings.
++        eplb_config = parallel_config.eplb_config
++        self.enable_eplb = parallel_config.enable_eplb
++
++        self.n_redundant_experts = eplb_config.num_redundant_experts
++        self.n_logical_experts = self.n_routed_experts
++        self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
++        self.n_local_physical_experts = self.n_physical_experts // self.ep_size
++
++        self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
++        self.physical_expert_end = (
++            self.physical_expert_start + self.n_local_physical_experts
++        )
++
++        n_group = getattr(config, "n_group", None)
++        topk_group = getattr(config, "topk_group", None)
++        if n_group is None or n_group < 1 or topk_group is None or topk_group < 1:
++            use_grouped_topk = False
++            n_group = None
++            topk_group = None
++        else:
++            use_grouped_topk = True
++
++        self.is_rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
++        self.is_fusion_moe_shared_experts_enabled = (
++            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
++        )
++        if (
++            self.is_rocm_aiter_moe_enabled
++            and self.gate.e_score_correction_bias is not None
++        ):
++            self.gate.set_out_dtype(self.gate.weight.dtype)
++
++        if config.n_shared_experts is None or self.is_fusion_moe_shared_experts_enabled:
++            self.shared_experts = None
++        else:
++            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
++
++            self.shared_experts = DeepseekV2MLP(
++                hidden_size=config.hidden_size,
++                intermediate_size=intermediate_size,
++                hidden_act=config.hidden_act,
++                quant_config=quant_config,
++                is_sequence_parallel=self.is_sequence_parallel,
++                reduce_results=False,
++                prefix=f"{prefix}.shared_experts",
++            )
++
++        self.experts = FusedMoE(
++            shared_experts=self.shared_experts,
++            gate=self.gate,
++            num_experts=config.n_routed_experts,
++            top_k=config.num_experts_per_tok,
++            hidden_size=config.hidden_size,
++            intermediate_size=config.moe_intermediate_size,
++            renormalize=config.norm_topk_prob,
++            quant_config=quant_config,
++            use_grouped_topk=use_grouped_topk,
++            num_expert_group=n_group,
++            topk_group=topk_group,
++            prefix=f"{prefix}.experts",
++            scoring_func=getattr(config, "scoring_func", "softmax"),
++            routed_scaling_factor=self.routed_scaling_factor,
++            apply_routed_scale_to_output=not self.is_rocm_aiter_moe_enabled,
++            e_score_correction_bias=self.gate.e_score_correction_bias,
++            enable_eplb=self.enable_eplb,
++            num_redundant_experts=self.n_redundant_experts,
++            is_sequence_parallel=self.is_sequence_parallel,
++            n_shared_experts=config.n_shared_experts
++            if self.is_fusion_moe_shared_experts_enabled
++            else None,
++            router_logits_dtype=self.gate.out_dtype,
++        )
++
++        if (
++            self.is_rocm_aiter_moe_enabled
++            and self.gate.e_score_correction_bias is not None
++        ):
++            self.gate.e_score_correction_bias.data = (
++                self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
++            )
++
++    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
++        num_tokens, hidden_dim = hidden_states.shape
++        hidden_states = hidden_states.view(-1, hidden_dim)
++
++        # Chunk the hidden states so they aren't replicated across TP ranks.
++        # This avoids duplicate computation in self.experts.
++        if self.is_sequence_parallel:
++            hidden_states = sequence_parallel_chunk(hidden_states)
++
++        if self.experts.is_internal_router:
++            # The gate/router runs inside the FusedMoE class.
++            final_hidden_states = self.experts(
++                hidden_states=hidden_states, router_logits=hidden_states
++            )
++        else:
++            router_logits, _ = self.gate(hidden_states)
++            final_hidden_states = self.experts(
++                hidden_states=hidden_states, router_logits=router_logits
++            )
++
++        if self.is_sequence_parallel:
++            final_hidden_states = tensor_model_parallel_all_gather(
++                final_hidden_states, 0
++            )
++            final_hidden_states = final_hidden_states[:num_tokens]
++
++        return final_hidden_states.view(num_tokens, hidden_dim)
++
++
++def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
++    import math
++
++    if scale <= 1:
++        return 1.0
++    return 0.1 * mscale * math.log(scale) + 1.0
++
++
++def _get_llama_4_scaling(
++    original_max_position_embeddings: int, scaling_beta: float, positions: torch.Tensor
++) -> torch.Tensor:
++    scaling = 1 + scaling_beta * torch.log(
++        1 + torch.floor(positions / original_max_position_embeddings)
++    )
++    # Broadcast over num_heads and head_dim
++    return scaling[..., None, None]
++
++
++class Indexer(nn.Module):
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        config,
++        hidden_size: int,
++        q_lora_rank: int,
++        quant_config: QuantizationConfig | None,
++        cache_config: CacheConfig | None,
++        topk_indices_buffer: torch.Tensor | None,
++        prefix: str = "",
++    ):
++        super().__init__()
++        self.vllm_config = vllm_config
++        self.config = config
++        # self.indexer_cfg = config.attn_module_list_cfg[0]["attn_index"]
++        self.topk_tokens = config.index_topk
++
++        # Native config 값
++        native_n_heads = config.index_n_heads
++        # DeepGEMM 호환 위해 padded value 계산
++        eff_n_heads = _indexer_pad_n_heads(native_n_heads)
++        # config.index_n_heads = eff_n_heads
++
++        self.native_n_head = native_n_heads
++        self.n_head = eff_n_heads      # 모듈은 eff로 build
++        self.indexer_pad = (eff_n_heads != native_n_heads)
++
++        if self.indexer_pad:
++            logger.info(
++                "AXK2 Indexer padding enabled at %s: n_heads %d → %d "
++                "(DeepGEMM SM100 LDTM requires {32, 64, 128})",
++                prefix, native_n_heads, eff_n_heads,
++            )
++
++        # self.n_head = config.index_n_heads  # 64
++        self.head_dim = config.index_head_dim  # 128
++        self.rope_dim = config.qk_rope_head_dim  # 64
++        self.q_lora_rank = q_lora_rank  # 1536
++        # no tensor parallel, just replicated
++        self.wq_b = ReplicatedLinear(
++            self.q_lora_rank,
++            self.head_dim * self.n_head,
++            bias=False,
++            quant_config=quant_config,
++            prefix=f"{prefix}.wq_b",
++        )
++        self.wk = ReplicatedLinear(
++            hidden_size,
++            self.head_dim,
++            bias=False,
++            quant_config=quant_config,
++            prefix=f"{prefix}.wk",
++        )
++        self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
++        self.weights_proj = ReplicatedLinear(
++            hidden_size,
++            self.n_head,
++            bias=False,
++            quant_config=None,
++            prefix=f"{prefix}.weights_proj",
++        )
++
++        if self.indexer_pad:
++            native_wq_shape = (native_n_heads * self.head_dim, self.q_lora_rank)
++            wq_pad_fn = functools.partial(
++                _pad_indexer_wq_b,
++                native_n_heads=native_n_heads,
++                eff_n_heads=eff_n_heads,
++                head_dim=self.head_dim,
++            )
++            original_loader = self.wq_b.weight.weight_loader
++            self.wq_b.weight.weight_loader = _make_padded_weight_loader(
++                native_wq_shape, wq_pad_fn, original_loader,
++            )
++
++            native_wp_shape = (native_n_heads, hidden_size)
++            wp_pad_fn = functools.partial(
++                _pad_indexer_weights_proj,
++                native_n_heads=native_n_heads,
++                eff_n_heads=eff_n_heads,
++            )
++            original_loader = self.weights_proj.weight.weight_loader
++            self.weights_proj.weight.weight_loader = _make_padded_weight_loader(
++                native_wp_shape, wp_pad_fn, original_loader,
++            )
++
++        # self.softmax_scale = self.native_n_head**-0.5
++        self.softmax_scale = self.head_dim**-0.5
++
++        self.scale_fmt = "ue8m0"
++        self.quant_block_size = 128  # TODO: get from config
++        self.topk_indices_buffer = topk_indices_buffer
++
++        # NOTE: (zyongye) we use fp8 naive cache,
++        #       where we store value in fp8 and scale in fp32
++        #       per self.quant_block_size element
++        self.k_cache = DeepseekV32IndexerCache(
++            head_dim=self.head_dim + self.head_dim // self.quant_block_size * 4,
++            dtype=torch.uint8,
++            prefix=f"{prefix}.k_cache",
++            cache_config=cache_config,
++        )
++        self.max_model_len = vllm_config.model_config.max_model_len
++        self.prefix = prefix
++        from vllm.v1.attention.backends.mla.indexer import get_max_prefill_buffer_size
++
++        self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)
++        self.indexer_op = SparseAttnIndexer(
++            self.k_cache,
++            self.quant_block_size,
++            self.scale_fmt,
++            self.topk_tokens,
++            self.head_dim,
++            self.max_model_len,
++            self.max_total_seq_len,
++            self.topk_indices_buffer,
++        )
++
++    def forward(
++        self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
++    ) -> torch.Tensor:
++        q, _ = self.wq_b(qr)
++        q = q.view(-1, self.n_head, self.head_dim)
++        q_pe, q_nope = torch.split(
++            q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
++        )
++
++        k, _ = self.wk(hidden_states)
++        k = self.k_norm(k)
++        k_pe, k_nope = torch.split(
++            k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
++        )
++
++        q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
++        # Note: RoPE (NeoX) can introduce extra leading dimensions during compilation
++        # so we need to reshape back to token-flattened shapes
++        q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
++        k_pe = k_pe.reshape(-1, 1, self.rope_dim)
++
++        # `rotary_emb` is shape-preserving; `q_pe` is already
++        # [num_tokens, n_head, rope_dim].
++        q = torch.cat([q_pe, q_nope], dim=-1)
++        # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
++        k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
++
++        # we only quant q here since k quant is fused with cache insertion
++        q = q.view(-1, self.head_dim)
++        q_fp8, q_scale = per_token_group_quant_fp8(
++            q,
++            self.quant_block_size,
++            column_major_scales=False,
++            use_ue8m0=self.scale_fmt is not None,
++        )
++        q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
++        q_scale = q_scale.view(-1, self.n_head, 1)
++
++        weights, _ = self.weights_proj(hidden_states)
++        weights = (
++            # weights.unsqueeze(-1) * q_scale * self.softmax_scale * self.native_n_head**-0.5
++            weights.unsqueeze(-1) * q_scale * self.softmax_scale * self.n_head**-0.5
++        )
++        weights = weights.squeeze(-1)
++
++        return self.indexer_op(hidden_states, q_fp8, k, weights)
++
++
++class AXK2GatedMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
++    def __init__(
++        self,
++        hidden_size: int,
++        num_heads: int,
++        scale: float,
++        qk_nope_head_dim: int,
++        qk_rope_head_dim: int,
++        v_head_dim: int,
++        q_lora_rank: int | None,
++        kv_lora_rank: int,
++        mla_modules: MLAModules,
++        cache_config: CacheConfig | None = None,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++        attn_gate_fused: bool = False,
++        # Native (model-config) dims. When these differ from the dims
++        # passed to ``super().__init__`` above, DSA padding is in effect:
++        # the underlying MLAAttention sees the DSv3 padded layout, while
++        # inputs arriving from the rest of the model use the native sizes.
++        # The forward pad/strip plumbing below handles the conversion.
++        native_qk_nope_head_dim: int | None = None,
++        native_qk_rope_head_dim: int | None = None,
++        native_v_head_dim: int | None = None,
++        native_kv_lora_rank: int | None = None,
++    ) -> None:
++        super().__init__(
++            hidden_size=hidden_size,
++            num_heads=num_heads,
++            scale=scale,
++            qk_nope_head_dim=qk_nope_head_dim,
++            qk_rope_head_dim=qk_rope_head_dim,
++            v_head_dim=v_head_dim,
++            q_lora_rank=q_lora_rank,
++            kv_lora_rank=kv_lora_rank,
++            mla_modules=mla_modules,
++            cache_config=cache_config,
++            quant_config=quant_config,
++            prefix=prefix,
++        )
++        self.attn_gate_fused = attn_gate_fused
++
++        # ``self.qk_*`` set by super are the EFFECTIVE/padded dims; the
++        # native variants are kept alongside so we can strip back at the
++        # layer boundary.
++        self.native_qk_nope_head_dim = native_qk_nope_head_dim or qk_nope_head_dim
++        self.native_qk_rope_head_dim = native_qk_rope_head_dim or qk_rope_head_dim
++        self.native_v_head_dim = native_v_head_dim or v_head_dim
++        self.native_kv_lora_rank = native_kv_lora_rank or kv_lora_rank
++        self.native_qk_head_dim = (
++            self.native_qk_nope_head_dim + self.native_qk_rope_head_dim
++        )
++        self.dsv3_pad = (
++            self.native_qk_nope_head_dim != self.qk_nope_head_dim
++            or self.native_qk_rope_head_dim != self.qk_rope_head_dim
++            or self.native_v_head_dim != self.v_head_dim
++            or self.native_kv_lora_rank != self.kv_lora_rank
++        )
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++        llama_4_scaling: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        q_c = None
++        kv_lora = None
++
++        if self.q_lora_rank is not None:
++            assert self.fused_qkv_a_proj is not None, (
++                "fused_qkv_a_proj is required when q_lora_rank is not None"
++            )
++            assert self.q_a_layernorm is not None, (
++                "q_a_layernorm is required when q_lora_rank is not None"
++            )
++            assert self.q_b_proj is not None, (
++                "q_b_proj is required when q_lora_rank is not None"
++            )
++
++            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
++            # fused_qkv_a_proj output is at NATIVE dims, so split with the
++            # native sizes regardless of padding state.
++            q_c, kv_lora = qkv_lora.split(
++                [
++                    self.q_lora_rank,
++                    self.native_kv_lora_rank + self.native_qk_rope_head_dim,
++                ],
++                dim=-1,
++            )
++
++            # Pre-norm q_c feeds the fused gate rows (matching the reference,
++            # which computes the gate from the pre-q_a_layernorm q_c); the
++            # post-norm q_c feeds the q rows. Keep both around.
++            q_c_prenorm = q_c
++            q_c = self.q_a_layernorm(q_c)
++            if self.attn_gate_fused:
++                # q_b_proj has a doubled input ([q_lora_rank post | q_lora_rank
++                # pre]) with a block-structured weight: q rows read only the
++                # post-norm half, gate rows only the pre-norm half. Feeding
++                # cat([post, pre]) yields q (post-norm) and the gate (pre-norm)
++                # in a single GEMM.
++                q_b_out = self.q_b_proj(
++                    torch.cat([q_c, q_c_prenorm], dim=-1)
++                )[0]
++                # Per-head interleaved output:
++                #   [head0_q | head0_gate | head1_q | head1_gate | ...]
++                # View as (T, num_heads, qk_head_dim + native_v_head_dim),
++                # split per-head, then reshape back. The reshape copies
++                # because split makes the head dim non-contiguous, but it
++                # leaves both q and attn_gate contiguous so downstream
++                # MLA attention has no hidden copy.
++                per_head = self.qk_head_dim + self.native_v_head_dim
++                q_gate = q_b_out.view(-1, self.num_heads, per_head)
++                q3, gate3 = q_gate.split(
++                    [self.qk_head_dim, self.native_v_head_dim], dim=-1
++                )
++                q = q3.reshape(-1, self.num_heads * self.qk_head_dim)
++                attn_gate = gate3.reshape(
++                    -1, self.num_heads * self.native_v_head_dim
++                )
++            else:
++                # q_b_proj is at the EFFECTIVE shape when DSA padding is on;
++                # padded extension columns are zero (weights are zero-loaded).
++                q = self.q_b_proj(q_c)[0]
++                attn_gate = None
++
++        # Native split of kv_lora. When DSA padding is in effect, pad kv_c
++        # native->eff *before* the norm: kv_a_layernorm is a PartialRMSNorm
++        # that normalizes only the native portion and passes the zero-padded
++        # tail through unchanged, so the variance still reflects real data and
++        # not the padding (matches AXK1). When no padding is in effect this is
++        # a plain RMSNorm over native dims.
++        kv_c, k_pe = kv_lora.split(
++            [self.native_kv_lora_rank, self.native_qk_rope_head_dim], dim=-1
++        )
++        if self.dsv3_pad:
++            kv_pad = self.kv_lora_rank - self.native_kv_lora_rank
++            if kv_pad > 0:
++                kv_c = F.pad(kv_c, (0, kv_pad))
++        kv_c_normed = self.kv_a_layernorm(kv_c)
++
++        q = q.view(-1, self.num_heads, self.qk_head_dim)
++        # Add head dim of 1 to k_pe
++        k_pe = k_pe.unsqueeze(1)
++
++        if self.rotary_emb is not None:
++            # RoPE freq table is built at the NATIVE qk_rope_head_dim so
++            # apply rotation only on the native slice of the rope slot in
++            # the (possibly padded) q. The padded extension stays zero —
++            # rotating zero pairs yields zero pairs.
++            rope_start = self.qk_nope_head_dim
++            rope_native_end = rope_start + self.native_qk_rope_head_dim
++            q_rope_native = q[..., rope_start:rope_native_end].contiguous()
++            q_rope_native, k_pe = self.rotary_emb(
++                positions, q_rope_native, k_pe
++            )
++            q[..., rope_start:rope_native_end] = q_rope_native
++
++        if self.indexer and self.is_sparse:
++            _topk_indices = self.indexer(
++                hidden_states, q_c, positions, self.indexer_rope_emb
++            )
++
++        if llama_4_scaling is not None:
++            q *= llama_4_scaling
++
++        # Pad k_pe out to the EFFECTIVE qk_rope dim that MLAAttention /
++        # FlashMLA expect. kv_c_normed is already at the effective kv_lora
++        # rank (padded before the PartialRMSNorm); ``q`` is already at the
++        # effective qk_head_dim because q_b_proj is built at the padded shape.
++        if self.dsv3_pad:
++            rope_pad = self.qk_rope_head_dim - self.native_qk_rope_head_dim
++            if rope_pad > 0:
++                k_pe = F.pad(k_pe, (0, rope_pad))
++
++        attn_out = self.mla_attn(
++            q,
++            kv_c_normed,
++            k_pe,
++            output_shape=(
++                hidden_states.shape[0],
++                self.num_heads * self.v_head_dim,
++            ),
++        )
++
++        # Strip the padded v_head extension before applying the gate /
++        # passing into o_proj (which expects native v_head_dim).
++        if self.dsv3_pad and self.v_head_dim != self.native_v_head_dim:
++            attn_out = attn_out.view(-1, self.num_heads, self.v_head_dim)[
++                ..., : self.native_v_head_dim
++            ].reshape(-1, self.num_heads * self.native_v_head_dim)
++
++        if attn_gate is not None:
++            attn_out = attn_out * torch.sigmoid(attn_gate)
++
++        return self.o_proj(attn_out)[0]
++
++
++class AXK2MLAAttention(nn.Module):
++    """
++    Main reference: DeepseekV2 paper, and FlashInfer Implementation
++    (https://arxiv.org/abs/2405.04434 and https://github.com/flashinfer-ai/flashinfer/pull/551).
++
++        For more info see MLACommonImpl in:
++        vllm/v1/attention/backends/mla/utils.py
++    """
++
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        config: AXK2Config,
++        hidden_size: int,
++        num_heads: int,
++        qk_nope_head_dim: int,
++        qk_rope_head_dim: int,
++        v_head_dim: int,
++        q_lora_rank: int | None,
++        kv_lora_rank: int,
++        max_position_embeddings: int = 8192,
++        cache_config: CacheConfig | None = None,
++        quant_config: QuantizationConfig | None = None,
++        prefix: str = "",
++        topk_indices_buffer: torch.Tensor | None = None,
++        input_size: int | None = None,
++    ) -> None:
++        super().__init__()
++        self.hidden_size = hidden_size
++        # self.qk_nope_head_dim = qk_nope_head_dim
++        # self.qk_rope_head_dim = qk_rope_head_dim
++        # self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
++        # self.v_head_dim = v_head_dim
++
++        # self.q_lora_rank = q_lora_rank
++        # self.kv_lora_rank = kv_lora_rank
++
++        # After AXK2ForCausalLM.__init__ has mutated config, the dims
++        # arriving as positional args are the EFFECTIVE values. The
++        # NATIVE values were stashed on config. Prefer stashed natives
++        # so self.* represents the real, learned dims.
++        self.qk_nope_head_dim = getattr(
++            config, "_axk2_native_qk_nope_head_dim", qk_nope_head_dim
++        )
++        self.qk_rope_head_dim = getattr(
++            config, "_axk2_native_qk_rope_head_dim", qk_rope_head_dim
++        )
++        self.v_head_dim = getattr(
++            config, "_axk2_native_v_head_dim", v_head_dim
++        )
++        self.kv_lora_rank = getattr(
++            config, "_axk2_native_kv_lora_rank", kv_lora_rank
++        )
++        self.qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
++        self.q_lora_rank = q_lora_rank
++
++        self.num_heads = num_heads
++        tp_size = get_tensor_model_parallel_world_size()
++        assert num_heads % tp_size == 0
++        self.num_local_heads = num_heads // tp_size
++
++        self.scaling = self.qk_head_dim**-0.5
++        self.max_position_embeddings = max_position_embeddings
++
++        # Use input_size for projection input dimensions if provided,
++        # otherwise default to hidden_size (used in Eagle3 Deepseek with MLA)
++        proj_input_size = input_size if input_size is not None else self.hidden_size
++
++        # AXK2 always has q_lora_rank → fused q_a + kv_a projection. The
++        # q-lora-less (separate kv_a_proj_with_mqa) path has been removed.
++        self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
++            proj_input_size,
++            [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
++            quant_config=quant_config,
++            prefix=f"{prefix}.fused_qkv_a_proj",
++        )
++
++        # vLLM's GPU sparse MLA backends only accept head_size=576
++        # (kv_lora_rank=512 + qk_rope_head_dim=64); their precompiled CUDA
++        # kernels are bound to that layout. When the native dims are
++        # smaller, transparently zero-extend everything to the DSv3 shape:
++        # q_b_proj / kv_b_proj are constructed at the padded shape and
++        # weights are zero-padded at load time. The native input/output
++        # shape is preserved at the layer boundary by the wrapper.
++        target_head_size, self.is_sparse = _pick_mla_target(config)
++        eff_qk_nope = getattr(config, "_axk2_eff_qk_nope_head_dim", None)
++        eff_qk_rope = getattr(config, "_axk2_eff_qk_rope_head_dim", None)
++        eff_v_head = getattr(config, "_axk2_eff_v_head_dim", None)
++        eff_kv_lora = getattr(config, "_axk2_eff_kv_lora_rank", None)
++        if any(v is None for v in (eff_qk_nope, eff_qk_rope, eff_v_head, eff_kv_lora)):
++            eff_qk_nope, eff_qk_rope, eff_v_head, eff_kv_lora = _mla_pad_dims(
++                self.qk_nope_head_dim,
++                self.qk_rope_head_dim,
++                self.v_head_dim,
++                self.kv_lora_rank,
++                target_head_size=target_head_size,
++                is_dsa=self.is_sparse,
++            )
++        self.dsv3_pad = (
++            (eff_qk_nope, eff_qk_rope, eff_v_head, eff_kv_lora)
++            != (
++                self.qk_nope_head_dim,
++                self.qk_rope_head_dim,
++                self.v_head_dim,
++                self.kv_lora_rank,
++            )
++        )
++        if self.dsv3_pad:
++            self.eff_qk_nope_head_dim = eff_qk_nope
++            self.eff_qk_rope_head_dim = eff_qk_rope
++            self.eff_v_head_dim = eff_v_head
++            self.eff_kv_lora_rank = eff_kv_lora
++            logger.info(
++                "AXK2 DSA padding enabled at %s: qk_nope %d→%d, qk_rope %d→%d, "
++                "v_head %d→%d, kv_lora %d→%d (target head_size=%d, is_sparse=%s)",
++                prefix,
++                self.qk_nope_head_dim, eff_qk_nope,
++                self.qk_rope_head_dim, eff_qk_rope,
++                self.v_head_dim, eff_v_head,
++                self.kv_lora_rank, eff_kv_lora,
++                target_head_size, self.is_sparse,
++            )
++        else:
++            self.eff_qk_nope_head_dim = self.qk_nope_head_dim
++            self.eff_qk_rope_head_dim = self.qk_rope_head_dim
++            self.eff_v_head_dim = self.v_head_dim
++            self.eff_kv_lora_rank = self.kv_lora_rank
++        self.eff_qk_head_dim = self.eff_qk_nope_head_dim + self.eff_qk_rope_head_dim
++
++        self.use_output_gate = getattr(config, "attention_output_gate", False)
++        # The attention output gate is ALWAYS fused into q_b_proj (Qwen3-Next
++        # style): q_b_proj is widened to a doubled input
++        # [q_lora post-norm | q_lora pre-norm] with a per-head interleaved
++        # [q | gate] output, so a single GEMM yields q (post-norm) and the gate
++        # (pre-norm, matching the reference). Checkpoints are pre-merged offline
++        # (and re-quantized for fp8). The separate-``linear_gate`` path has been
++        # removed — gating requires q_lora_rank.
++        self.attn_gate_fused = self.use_output_gate
++        if self.use_output_gate:
++            assert self.q_lora_rank is not None, (
++                "attention_output_gate requires q_lora_rank (fused gate rides "
++                "inside q_b_proj)"
++            )
++
++        # AXK2 always uses q-lora MLA; the q-lora-less (q_proj) path is removed.
++        assert self.q_lora_rank is not None, (
++            "AXK2 requires q_lora_rank; the q-lora-less MLA (q_proj) path "
++            "has been removed."
++        )
++        if self.q_lora_rank is not None:
++            self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
++            # q_b_proj is built at the EFFECTIVE shape; native checkpoint
++            # weights are zero-padded into this buffer at load time.
++            if self.attn_gate_fused:
++                # Pre-fused checkpoint: q_b_proj already absorbs the attention
++                # output gate (Qwen3-Next style), produced offline by the
++                # checkpoint merge step. Layout:
++                #   input  = 2 * q_lora_rank  -> [q_lora post-norm | q_lora pre-norm]
++                #   output = num_heads * (eff_qk_head_dim + v_head_dim),
++                #            per-head interleaved [head0(q|gate) | head1(q|gate)...]
++                # The q rows are non-zero only on the post-norm input half and
++                # the gate rows only on the pre-norm half, so feeding
++                # cat([post, pre]) reproduces the non-fused path exactly — q on
++                # post-q_a_layernorm q_c, gate on pre-q_a_layernorm q_c
++                # (matching the reference linear_gate). Checkpoints carry the
++                # merged q_b_proj at NATIVE dims; when DSA padding is on (and the
++                # weight is bf16) it is zero-padded native->eff at load below,
++                # mirroring the non-fused branch. fp8 checkpoints are native==eff
++                # (no padding) so they load directly.
++                self.q_b_proj = ColumnParallelLinear(
++                    2 * self.q_lora_rank,
++                    self.num_heads * (self.eff_qk_head_dim + self.v_head_dim),
++                    bias=False,
++                    quant_config=quant_config,
++                    prefix=f"{prefix}.q_b_proj",
++                )
++                if self.dsv3_pad:
++                    native_fused_q_b_shape = (
++                        self.num_heads
++                        * (self.qk_nope_head_dim + self.qk_rope_head_dim
++                           + self.v_head_dim),
++                        2 * self.q_lora_rank,
++                    )
++                    pad_fused_q_b = functools.partial(
++                        _pad_fused_q_b_proj_native_to_eff,
++                        num_heads=self.num_heads,
++                        native_qk_nope_head_dim=self.qk_nope_head_dim,
++                        native_qk_rope_head_dim=self.qk_rope_head_dim,
++                        eff_qk_nope_head_dim=self.eff_qk_nope_head_dim,
++                        eff_qk_rope_head_dim=self.eff_qk_rope_head_dim,
++                        v_head_dim=self.v_head_dim,
++                    )
++                    original_loader = self.q_b_proj.weight.weight_loader
++                    self.q_b_proj.weight.weight_loader = _make_padded_weight_loader(
++                        native_fused_q_b_shape, pad_fused_q_b, original_loader,
++                    )
++            else:
++                self.q_b_proj = ColumnParallelLinear(
++                    self.q_lora_rank,
++                    self.num_heads * self.eff_qk_head_dim,
++                    bias=False,
++                    quant_config=quant_config,
++                    prefix=f"{prefix}.q_b_proj",
++                )
++
++                if self.dsv3_pad:
++                    native_q_b_shape = (
++                        self.num_heads
++                        * (self.qk_nope_head_dim + self.qk_rope_head_dim),
++                        self.q_lora_rank,
++                    )
++                    pad_q_b = functools.partial(
++                        _pad_q_b_proj_native_to_eff,
++                        num_heads=self.num_heads,
++                        native_qk_nope_head_dim=self.qk_nope_head_dim,
++                        native_qk_rope_head_dim=self.qk_rope_head_dim,
++                        eff_qk_nope_head_dim=self.eff_qk_nope_head_dim,
++                        eff_qk_rope_head_dim=self.eff_qk_rope_head_dim,
++                    )
++                    original_loader = self.q_b_proj.weight.weight_loader
++                    self.q_b_proj.weight.weight_loader = _make_padded_weight_loader(
++                        native_q_b_shape, pad_q_b, original_loader,
++                    )
++        # kv_a_layernorm: weight lives at NATIVE kv_lora_rank (checkpoint
++        # shape). When DSA padding is in effect (eff > native), wrap it in
++        # PartialRMSNorm so only the first `kv_lora_rank` (native) elements of
++        # the input are normalized and the zero-padded tail is passed through
++        # unchanged. This matches the application in AXK1.py. The wrapper
++        # forward pads kv_c native->eff *before* calling this norm.
++        if self.eff_kv_lora_rank > self.kv_lora_rank:
++            self.kv_a_layernorm = PartialRMSNorm(
++                actual_size=self.kv_lora_rank,        # native
++                full_size=self.eff_kv_lora_rank,      # eff (= 512)
++                eps=config.rms_norm_eps,
++            )
++        else:
++            self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
++        self.kv_b_proj = ColumnParallelLinear(
++            self.eff_kv_lora_rank,
++            self.num_heads * (self.eff_qk_nope_head_dim + self.eff_v_head_dim),
++            bias=False,
++            quant_config=quant_config,
++            prefix=f"{prefix}.kv_b_proj",
++        )
++        if self.dsv3_pad:
++            native_kv_b_shape = (
++                self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
++                self.kv_lora_rank,
++            )
++            pad_kv_b = functools.partial(
++                _pad_kv_b_proj_native_to_eff,
++                num_heads=self.num_heads,
++                native_qk_nope_head_dim=self.qk_nope_head_dim,
++                native_v_head_dim=self.v_head_dim,
++                native_kv_lora_rank=self.kv_lora_rank,
++                eff_qk_nope_head_dim=self.eff_qk_nope_head_dim,
++                eff_v_head_dim=self.eff_v_head_dim,
++                eff_kv_lora_rank=self.eff_kv_lora_rank,
++            )
++            original_loader = self.kv_b_proj.weight.weight_loader
++            self.kv_b_proj.weight.weight_loader = _make_padded_weight_loader(
++                native_kv_b_shape, pad_kv_b, original_loader,
++            )
++
++        self.o_proj = RowParallelLinear(
++            self.num_heads * self.v_head_dim,
++            self.hidden_size,
++            bias=False,
++            quant_config=quant_config,
++            prefix=f"{prefix}.o_proj",
++        )
++
++        if config.rope_parameters["rope_type"] != "default":
++            config.rope_parameters["rope_type"] = (
++                "deepseek_yarn"
++                if config.rope_parameters.get("apply_yarn_scaling", True)
++                else "deepseek_llama_scaling"
++            )
++
++        # Build the main RoPE cos/sin cache at the NATIVE qk_rope_head_dim.
++        # The wrapper forward rotates only the native rope sub-slice of the
++        # DSv3-padded q and the native-width k_pe. The `qk_rope_head_dim` arg
++        # is the EFFECTIVE/padded value (config was mutated to the DSv3
++        # layout), so using it would size the cache at the padded width while
++        # the forward feeds a native-width slice -> a 32-vs-64 mul mismatch
++        # that only surfaces under torch.compile (cudagraph). self.qk_rope_head_dim
++        # is the native value (no-op when no DSv3 padding is in effect).
++        self.rotary_emb = get_rope(
++            self.qk_rope_head_dim,
++            max_position=max_position_embeddings,
++            rope_parameters=config.rope_parameters,
++            is_neox_style=False,
++        )
++
++        if config.rope_parameters["rope_type"] == "deepseek_yarn":
++            mscale_all_dim = config.rope_parameters.get("mscale_all_dim", False)
++            scaling_factor = config.rope_parameters["factor"]
++            mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
++            self.scaling = self.scaling * mscale * mscale
++
++        if self.is_sparse:
++            self.indexer_rope_emb = get_rope(
++                qk_rope_head_dim,
++                max_position=max_position_embeddings,
++                rope_parameters=config.rope_parameters,
++                is_neox_style=not getattr(config, "indexer_rope_interleave", False),
++            )
++            self.indexer = Indexer(
++                vllm_config,
++                config,
++                hidden_size,
++                q_lora_rank,
++                quant_config,
++                cache_config,
++                topk_indices_buffer,
++                f"{prefix}.indexer",
++            )
++        else:
++            self.indexer_rope_emb = None
++            self.indexer = None
++
++        mla_modules = MLAModules(
++            kv_a_layernorm=self.kv_a_layernorm,
++            kv_b_proj=self.kv_b_proj,
++            rotary_emb=self.rotary_emb,
++            o_proj=self.o_proj,
++            fused_qkv_a_proj=self.fused_qkv_a_proj,
++            kv_a_proj_with_mqa=None,
++            q_a_layernorm=self.q_a_layernorm,
++            q_b_proj=self.q_b_proj,
++            q_proj=None,
++            indexer=self.indexer,
++            indexer_rotary_emb=self.indexer_rope_emb,
++            is_sparse=self.is_sparse,
++            topk_indices_buffer=topk_indices_buffer,
++        )
++
++        # Pass EFFECTIVE dims to the wrapper / underlying MLAAttention so
++        # FlashMLASparse sees DSv3 layout. The wrapper retains the native
++        # dims for input pad / output strip at the layer boundary.
++        self.mla_attn = AXK2GatedMultiHeadLatentAttentionWrapper(
++            self.hidden_size,
++            self.num_local_heads,
++            self.scaling,
++            self.eff_qk_nope_head_dim,
++            self.eff_qk_rope_head_dim,
++            self.eff_v_head_dim,
++            self.q_lora_rank,
++            self.eff_kv_lora_rank,
++            mla_modules,
++            cache_config,
++            quant_config,
++            prefix,
++            attn_gate_fused=self.attn_gate_fused,
++            native_qk_nope_head_dim=self.qk_nope_head_dim,
++            native_qk_rope_head_dim=self.qk_rope_head_dim,
++            native_v_head_dim=self.v_head_dim,
++            native_kv_lora_rank=self.kv_lora_rank,
++        )
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++        llama_4_scaling: torch.Tensor | None,
++    ) -> torch.Tensor:
++        return self.mla_attn(positions, hidden_states, llama_4_scaling)
++
++
++class AXK2DecoderLayer(nn.Module):
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        prefix: str,
++        config: AXK2Config | None = None,
++        topk_indices_buffer: torch.Tensor | None = None,
++    ) -> None:
++        super().__init__()
++
++        if config is None:
++            config = vllm_config.model_config.hf_config
++        self.config = config
++        model_config = vllm_config.model_config
++        cache_config = vllm_config.cache_config
++        quant_config = vllm_config.quant_config
++        parallel_config = vllm_config.parallel_config
++
++        self.hidden_size = config.hidden_size
++        max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
++        moe_layer_freq = getattr(config, "moe_layer_freq", 1)
++        # DecoderLayers are created with `make_layers` which passes the prefix
++        # with the layer's index.
++        layer_idx = int(prefix.split(sep=".")[-1])
++        self.layer_idx = layer_idx
++
++        # verify MLA attention specific fields
++        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
++        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
++        v_head_dim = getattr(config, "v_head_dim", 0)
++        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
++
++        # AXK2 is always MLA (DeepSeek-V3.2-style latent attention + fused
++        # output gate). The non-MLA (MHA / DeepseekAttention) path has been
++        # removed.
++        assert model_config.use_mla, (
++            "AXK2 requires MLA (use_mla) for the latent-attention + fused "
++            "output-gate path; the non-MLA fallback has been removed."
++        )
++        self.self_attn = AXK2MLAAttention(
++            vllm_config=vllm_config,
++            config=config,
++            hidden_size=self.hidden_size,
++            num_heads=config.num_attention_heads,
++            qk_nope_head_dim=qk_nope_head_dim,
++            qk_rope_head_dim=qk_rope_head_dim,
++            v_head_dim=v_head_dim,
++            q_lora_rank=config.q_lora_rank if hasattr(config, "q_lora_rank") else None,
++            kv_lora_rank=kv_lora_rank,
++            max_position_embeddings=max_position_embeddings,
++            cache_config=cache_config,
++            quant_config=quant_config,
++            prefix=f"{prefix}.self_attn",
++            topk_indices_buffer=topk_indices_buffer,
++        )
++
++        self.is_layer_sparse = self._is_layer_sparse()
++        if self.is_layer_sparse:
++            self.mlp = AXK2MoE(
++                config=config,
++                parallel_config=parallel_config,
++                quant_config=quant_config,
++                prefix=f"{prefix}.mlp",
++            )
++        else:
++            self.mlp = DeepseekV2MLP(
++                hidden_size=config.hidden_size,
++                intermediate_size=config.intermediate_size,
++                hidden_act=config.hidden_act,
++                quant_config=quant_config,
++                prefix=f"{prefix}.mlp",
++            )
++
++        use_gated_norm = getattr(config, "gated_norm", False)
++        gated_rank = getattr(config, "gated_norm_rank", 16)
++        if use_gated_norm:
++            self.input_layernorm = AXK2GatedRMSNorm(
++                config.hidden_size, eps=config.rms_norm_eps, rank=gated_rank,
++                prefix=f"{prefix}.input_layernorm",
++            )
++        else:
++            self.input_layernorm = RMSNorm(
++                config.hidden_size, eps=config.rms_norm_eps
++            )
++        if use_gated_norm and self.is_layer_sparse:
++            self.post_attention_layernorm = AXK2GatedRMSNorm(
++                config.hidden_size, eps=config.rms_norm_eps, rank=gated_rank,
++                prefix=f"{prefix}.post_attention_layernorm",
++            )
++        else:
++            self.post_attention_layernorm = RMSNorm(
++                config.hidden_size, eps=config.rms_norm_eps
++            )
++        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
++
++    def _is_layer_sparse(self) -> bool:
++        return (
++            self.config.n_routed_experts is not None
++            and self.layer_idx >= self.config.first_k_dense_replace
++            and self.layer_idx % self.config.moe_layer_freq == 0
++        )
++
++    def forward(
++        self,
++        positions: torch.Tensor,
++        hidden_states: torch.Tensor,
++        residual: torch.Tensor | None,
++        llama_4_scaling: torch.Tensor | None = None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        # Self Attention
++        if residual is None:
++            residual = hidden_states.clone()
++            hidden_states = self.input_layernorm(hidden_states)
++        else:
++            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++
++        hidden_states = self.self_attn(
++            positions=positions,
++            hidden_states=hidden_states,
++            llama_4_scaling=llama_4_scaling,
++        )
++
++        if hidden_states.dtype == torch.float16:
++            # Fix FP16 overflow
++            # We scale both hidden_states and residual before
++            # rmsnorm, and rmsnorm result would not affect by scale.
++            hidden_states *= 1.0 / self.routed_scaling_factor
++            if self.layer_idx == 0:
++                # The residual is shared by all layers, we only scale it on
++                # first layer.
++                residual *= 1.0 / self.routed_scaling_factor
++
++        # Fully Connected
++        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
++        hidden_states = self.mlp(hidden_states)
++
++        if isinstance(self.mlp, DeepseekV2MLP) and hidden_states.dtype == torch.float16:
++            # Fix FP16 overflow
++            # Scaling the DeepseekV2MLP output, it is the input of
++            # input_layernorm of next decoder layer.
++            # The scaling of AXK2MOE output would be done in the forward
++            # of AXK2MOE
++            hidden_states *= 1.0 / self.routed_scaling_factor
++
++        return hidden_states, residual
++
++
++@support_torch_compile
++class AXK2Model(nn.Module):
++    fall_back_to_pt_during_load = False
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
++        super().__init__()
++
++        config = vllm_config.model_config.hf_config
++        quant_config = vllm_config.quant_config
++        self.config = config
++        self.device = current_platform.device_type
++
++        self.vocab_size = config.vocab_size
++        self.is_sparse = hasattr(config, "index_topk")
++        if self.is_sparse:
++            topk_tokens = config.index_topk
++            topk_indices_buffer = torch.empty(
++                vllm_config.scheduler_config.max_num_batched_tokens,
++                topk_tokens,
++                dtype=torch.int32,
++                device=self.device,
++            )
++        else:
++            topk_indices_buffer = None
++
++        if get_pp_group().is_first_rank:
++            self.embed_tokens = VocabParallelEmbedding(
++                config.vocab_size,
++                config.hidden_size,
++                quant_config=quant_config,
++                prefix=f"{prefix}.embed_tokens",
++            )
++        else:
++            self.embed_tokens = PPMissingLayer()
++        self.start_layer, self.end_layer, self.layers = make_layers(
++            config.num_hidden_layers,
++            lambda prefix: AXK2DecoderLayer(
++                vllm_config, prefix, topk_indices_buffer=topk_indices_buffer
++            ),
++            prefix=f"{prefix}.layers",
++        )
++
++        if get_pp_group().is_last_rank:
++            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
++        else:
++            self.norm = PPMissingLayer()
++        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
++            ["hidden_states", "residual"], config.hidden_size
++        )
++
++        self.aux_hidden_state_layers = tuple[int, ...]()
++
++    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
++        return self.embed_tokens(input_ids)
++
++    def forward(
++        self,
++        input_ids: torch.Tensor | None,
++        positions: torch.Tensor,
++        intermediate_tensors: IntermediateTensors | None,
++        inputs_embeds: torch.Tensor | None = None,
++    ) -> torch.Tensor | IntermediateTensors:
++        if get_pp_group().is_first_rank:
++            if inputs_embeds is not None:
++                hidden_states = inputs_embeds
++            else:
++                if input_ids is None:
++                    raise ValueError(
++                        "Either input_ids or inputs_embeds must be provided "
++                        "to AXK2Model.forward"
++                    )
++                hidden_states = self.embed_input_ids(input_ids)
++            residual = None
++        else:
++            assert intermediate_tensors is not None
++            hidden_states = intermediate_tensors["hidden_states"]
++            residual = intermediate_tensors["residual"]
++
++        # Compute llama 4 scaling once per forward pass if enabled
++        llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
++        llama_4_scaling: torch.Tensor | None
++        if llama_4_scaling_config is not None:
++            llama_4_scaling = _get_llama_4_scaling(
++                original_max_position_embeddings=llama_4_scaling_config[
++                    "original_max_position_embeddings"
++                ],
++                scaling_beta=llama_4_scaling_config["beta"],
++                positions=positions,
++            )
++        else:
++            llama_4_scaling = None
++
++        aux_hidden_states = []
++        for idx, layer in enumerate(
++            islice(self.layers, self.start_layer, self.end_layer),
++            start=self.start_layer,
++        ):
++            if idx in self.aux_hidden_state_layers:
++                aux_hidden_states.append(hidden_states + residual)
++            hidden_states, residual = layer(
++                positions, hidden_states, residual, llama_4_scaling
++            )
++
++        if not get_pp_group().is_last_rank:
++            return IntermediateTensors(
++                {"hidden_states": hidden_states, "residual": residual}
++            )
++
++        hidden_states, _ = self.norm(hidden_states, residual)
++        if len(aux_hidden_states) > 0:
++            return hidden_states, aux_hidden_states
++        return hidden_states
++
++
++class AXK2MixtureOfExperts(MixtureOfExperts):
++    moe_mlp_layers: list[AXK2MoE]
++    """
++    List of MoE MLP layers in the model.
++    """
++
++    def extract_moe_parameters(self, example_moe: AXK2MoE | None):
++        if example_moe is None:
++            self.num_moe_layers = 0
++            self.num_expert_groups = 0
++            self.num_logical_experts = 0
++            self.num_physical_experts = 0
++            self.num_local_physical_experts = 0
++            self.num_routed_experts = 0
++            self.num_shared_experts = 0
++            self.num_redundant_experts = 0
++            logger.warning("AXK2: No AXK2MoE layer found in model.layers.")
++        else:
++            self.num_logical_experts = example_moe.n_logical_experts
++            self.num_physical_experts = example_moe.n_physical_experts
++            self.num_local_physical_experts = example_moe.n_local_physical_experts
++            self.num_routed_experts = example_moe.n_routed_experts
++            self.num_shared_experts = example_moe.n_shared_experts
++            self.num_redundant_experts = example_moe.n_redundant_experts
++
++    def update_physical_experts_metadata(
++        self,
++        num_physical_experts: int,
++        num_local_physical_experts: int,
++    ) -> None:
++        assert self.num_local_physical_experts == num_local_physical_experts
++        self.num_physical_experts = num_physical_experts
++        self.num_local_physical_experts = num_local_physical_experts
++        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
++        for moe in self.moe_mlp_layers:
++            moe.n_local_physical_experts = num_local_physical_experts
++            moe.n_physical_experts = num_physical_experts
++            moe.n_redundant_experts = self.num_redundant_experts
++            moe.experts.update_expert_map()
++
++
++class AXK2ForCausalLM(
++    nn.Module,
++    SupportsPP,
++    AXK2MixtureOfExperts,
++    SupportsLoRA,
++    SupportsEagle,
++    SupportsEagle3,
++):
++    packed_modules_mapping = {
++        "gate_up_proj": ["gate_proj", "up_proj"],
++    }
++    model_cls = AXK2Model
++
++    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
++        super().__init__()
++        config = vllm_config.model_config.hf_config
++        quant_config = vllm_config.quant_config
++        self.config = config
++        self.quant_config = quant_config
++
++        if not getattr(config, "_axk2_native_dims_stashed", False):
++            # For support non DSA path.
++            qk_nope_native = getattr(config, "qk_nope_head_dim", 0)
++            qk_rope_native = getattr(config, "qk_rope_head_dim", 0)
++            v_head_native = getattr(config, "v_head_dim", 0)
++            kv_lora_native = getattr(config, "kv_lora_rank", 0)
++
++            if qk_nope_native > 0 or qk_rope_native > 0:
++                target_head_size, is_dsa = _pick_mla_target(config)
++                (
++                    eff_qk_nope,
++                    eff_qk_rope,
++                    eff_v_head,
++                    eff_kv_lora,
++                ) = _mla_pad_dims(
++                    qk_nope_native,
++                    qk_rope_native,
++                    v_head_native,
++                    kv_lora_native,
++                    target_head_size=target_head_size,
++                    is_dsa=is_dsa,
++                )
++
++                config._axk2_native_qk_nope_head_dim = qk_nope_native
++                config._axk2_native_qk_rope_head_dim = qk_rope_native
++                config._axk2_native_v_head_dim = v_head_native
++                config._axk2_native_kv_lora_rank = kv_lora_native
++                config._axk2_eff_qk_nope_head_dim = eff_qk_nope
++                config._axk2_eff_qk_rope_head_dim = eff_qk_rope
++                config._axk2_eff_v_head_dim = eff_v_head
++                config._axk2_eff_kv_lora_rank = eff_kv_lora
++                config._axk2_native_dims_stashed = True
++
++                if eff_kv_lora != kv_lora_native:
++                    config.kv_lora_rank = eff_kv_lora
++                    logger.info(
++                        "AXK2: patched config.kv_lora_rank %d -> %d",
++                        kv_lora_native, eff_kv_lora,
++                    )
++                if eff_qk_rope != qk_rope_native:
++                    config.qk_rope_head_dim = eff_qk_rope
++                    logger.info(
++                        "AXK2: patched config.qk_rope_head_dim %d -> %d",
++                        qk_rope_native, eff_qk_rope,
++                    )
++                if is_dsa and eff_qk_nope != qk_nope_native:
++                    config.qk_nope_head_dim = eff_qk_nope
++                    logger.info(
++                        "AXK2: patched config.qk_nope_head_dim %d -> %d (DSA)",
++                        qk_nope_native, eff_qk_nope,
++                    )
++                if is_dsa and eff_v_head != v_head_native:
++                    config.v_head_dim = eff_v_head
++                    logger.info(
++                        "AXK2: patched config.v_head_dim %d -> %d (DSA)",
++                        v_head_native, eff_v_head,
++                    )
++
++                # CRITICAL: vLLM caches head_size in ModelConfig.__init__.
++                # Force-update the cached value.
++                eff_head_size = eff_kv_lora + eff_qk_rope
++                model_arch_config = vllm_config.model_config.model_arch_config
++                cached_head_size = getattr(model_arch_config, "head_size", None)
++                if cached_head_size != eff_head_size:
++                    try:
++                        model_arch_config.head_size = eff_head_size
++                        logger.info(
++                            "AXK2: patched model_arch_config.head_size "
++                            "%s -> %d (target_head_size=%d, is_dsa=%s) so "
++                            "MLACommonBackend.supports_head_size accepts it.",
++                            cached_head_size, eff_head_size,
++                            target_head_size, is_dsa,
++                        )
++                    except Exception as e:
++                        object.__setattr__(
++                            model_arch_config, "head_size", eff_head_size
++                        )
++                        logger.info(
++                            "AXK2: force-patched model_arch_config.head_size "
++                            "%s -> %d via object.__setattr__ (reason: %s)",
++                            cached_head_size, eff_head_size, e,
++                        )
++
++        # `packed_modules_mapping` needs to be modified before
++        # initializing AXK2Model, as it is passed inplace to
++        # quantization config init and may be used to select the
++        # quant_method for relevant layers during initialization.
++        self.fuse_qkv_a_proj = (
++            hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
++        )
++        if self.fuse_qkv_a_proj:
++            self.packed_modules_mapping["fused_qkv_a_proj"] = [
++                "q_a_proj",
++                "kv_a_proj_with_mqa",
++            ]
++
++        self.model = self.model_cls(
++            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
++        )
++        if get_pp_group().is_last_rank:
++            self.lm_head = ParallelLMHead(
++                config.vocab_size,
++                config.hidden_size,
++                quant_config=quant_config,
++                prefix=maybe_prefix(prefix, "lm_head"),
++            )
++        else:
++            self.lm_head = PPMissingLayer()
++        self.logits_processor = LogitsProcessor(config.vocab_size)
++        self.make_empty_intermediate_tensors = (
++            self.model.make_empty_intermediate_tensors
++        )
++        # Set MoE hyperparameters
++        self.num_moe_layers = (
++            self.config.num_hidden_layers - self.config.first_k_dense_replace
++        )
++        self.set_moe_parameters()
++
++    def set_moe_parameters(self):
++        self.expert_weights = []
++
++        self.num_expert_groups = getattr(self.config, "n_group", 1) or 1
++
++        self.moe_layers = []
++        self.moe_mlp_layers = []
++        example_moe = None
++        for layer in self.model.layers:
++            if isinstance(layer, PPMissingLayer):
++                continue
++
++            assert isinstance(layer, AXK2DecoderLayer)
++            if isinstance(layer.mlp, AXK2MoE):
++                # Pick last one layer since the first ones may be dense layers.
++                example_moe = layer.mlp
++                self.moe_mlp_layers.append(layer.mlp)
++                self.moe_layers.append(layer.mlp.experts)
++
++        self.extract_moe_parameters(example_moe)
++
++    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
++        self.model.aux_hidden_state_layers = layers
++
++    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
++        num_layers = len(self.model.layers)
++        return (2, num_layers // 2, num_layers - 3)
++
++    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
++        return self.model.embed_input_ids(input_ids)
++
++    def forward(
++        self,
++        input_ids: torch.Tensor | None,
++        positions: torch.Tensor,
++        intermediate_tensors: IntermediateTensors | None = None,
++        inputs_embeds: torch.Tensor | None = None,
++    ) -> torch.Tensor | IntermediateTensors:
++        hidden_states = self.model(
++            input_ids, positions, intermediate_tensors, inputs_embeds
++        )
++        return hidden_states
++
++    def compute_logits(
++        self,
++        hidden_states: torch.Tensor,
++    ) -> torch.Tensor | None:
++        logits = self.logits_processor(self.lm_head, hidden_states)
++        return logits
++
++    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
++        # Params for weights, fp8 weight scales, fp8 activation scales
++        # (param_name, weight_name, expert_id, shard_id)
++        return fused_moe_make_expert_params_mapping(
++            self,
++            ckpt_gate_proj_name="gate_proj",
++            ckpt_down_proj_name="down_proj",
++            ckpt_up_proj_name="up_proj",
++            num_experts=self.config.n_routed_experts,
++            num_redundant_experts=0,
++        )
++
++    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
++        rocm_aiter_moe_shared_expert_enabled = (
++            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
++        )
++        # Apply DSA padding to checkpoint weights when the model uses
++        # sparse attention with native dims smaller than the DSv3 layout
++        # FlashMLASparse hard-codes (576/512). The live modules were built
++        # at the padded shape in ``AXK2MLAAttention.__init__``; here we
++        # zero-extend the legacy checkpoint weights into those buffers.
++        # native_qk_nope = getattr(self.config, "qk_nope_head_dim", 0)
++        # native_qk_rope = getattr(self.config, "qk_rope_head_dim", 0)
++        # native_v_head = getattr(self.config, "v_head_dim", 0)
++        # native_kv_lora = getattr(self.config, "kv_lora_rank", 0)
++        # eff_qk_nope, eff_qk_rope, eff_v_head, eff_kv_lora = _dsv3_pad_dims(
++        #     native_qk_nope, native_qk_rope, native_v_head, native_kv_lora
++        # )
++        # if hasattr(self.config, "index_topk") and (
++        #     (eff_qk_nope, eff_qk_rope, eff_v_head, eff_kv_lora)
++        #     != (native_qk_nope, native_qk_rope, native_v_head, native_kv_lora)
++        # ):
++        #     weights = self._dsv3_pad_ckpt_iter(
++        #         weights,
++        #         num_heads=self.config.num_attention_heads,
++        #         native_qk_nope_head_dim=native_qk_nope,
++        #         native_qk_rope_head_dim=native_qk_rope,
++        #         native_v_head_dim=native_v_head,
++        #         native_kv_lora_rank=native_kv_lora,
++        #         eff_qk_nope_head_dim=eff_qk_nope,
++        #         eff_qk_rope_head_dim=eff_qk_rope,
++        #         eff_v_head_dim=eff_v_head,
++        #         eff_kv_lora_rank=eff_kv_lora,
++        #     )
++        stacked_params_mapping = [
++            # (param_name, shard_name, shard_id)
++            ("gate_up_proj", "gate_proj", 0),
++            ("gate_up_proj", "up_proj", 1),
++        ]
++        mla_params_mapping = [
++            ("fused_qkv_a_proj", "q_a_proj", 0),
++            ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
++        ]
++        # ``attn_gate_fused`` checkpoints are PRE-MERGED offline: q_b_proj
++        # already carries the output gate (doubled input, per-head interleaved
++        # output) at the effective shape and, for fp8, re-quantized. So there
++        # is no runtime merge here — q_b_proj.weight (+ weight_scale_inv) loads
++        # through the ordinary path and linear_gate is absent.
++        # AXK2 is always MLA, so the MHA (qkv_proj) mapping has been removed.
++        stacked_params_mapping.extend(mla_params_mapping)
++
++        # Params for weights, fp8 weight scales, fp8 activation scales
++        # (param_name, weight_name, expert_id, shard_id)
++        expert_params_mapping = fused_moe_make_expert_params_mapping(
++            self,
++            ckpt_gate_proj_name="gate_proj",
++            ckpt_down_proj_name="down_proj",
++            ckpt_up_proj_name="up_proj",
++            num_experts=self.config.n_routed_experts
++            + (
++                self.config.n_shared_experts
++                if rocm_aiter_moe_shared_expert_enabled
++                else 0
++            ),
++            num_redundant_experts=self.num_redundant_experts,
++        )
++
++        params_dict = dict(self.named_parameters())
++        loaded_params: set[str] = set()
++        for name, loaded_weight in weights:
++            if "rotary_emb.inv_freq" in name:
++                continue
++
++            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
++            if spec_layer is not None:
++                continue  # skip spec decode layers for main model
++
++            is_fusion_moe_shared_experts_layer = (
++                rocm_aiter_moe_shared_expert_enabled and ("mlp.shared_experts" in name)
++            )
++
++            for param_name, weight_name, shard_id in stacked_params_mapping:
++                # Skip non-stacked layers and experts (experts handled below).
++                if weight_name not in name:
++                    continue
++                # We have mlp.experts[0].gate_proj in the checkpoint.
++                # Since we handle the experts below in expert_params_mapping,
++                # we need to skip here BEFORE we update the name, otherwise
++                # name will be updated to mlp.experts[0].gate_up_proj, which
++                # will then be updated below in expert_params_mapping
++                # for mlp.experts[0].gate_gate_up_proj, which breaks load.
++                if ("mlp.experts." in name) and name not in params_dict:
++                    continue
++                if is_fusion_moe_shared_experts_layer:
++                    continue
++                name_mapped = name.replace(weight_name, param_name)
++
++                # QKV fusion is optional, fall back to normal
++                # weight loading if it's not enabled
++                # if go with fusion option, then update name
++                if (
++                    param_name == "fused_qkv_a_proj"
++                ) and name_mapped not in params_dict:
++                    continue
++                else:
++                    name = name_mapped
++                # Skip loading extra bias for GPTQ models.
++                if name.endswith(".bias") and name not in params_dict:
++                    continue
++
++                if is_pp_missing_parameter(name, self):
++                    continue
++
++                param = params_dict[name]
++                weight_loader = param.weight_loader
++                weight_loader(param, loaded_weight, shard_id)
++                break
++            else:
++                is_expert_weight = False
++
++                # Special handling: when AITER fusion_shared_experts is enabled,
++                # checkpoints may provide a single widened shared_experts tensor
++                # without explicit expert indices
++                # (e.g. ...mlp.shared_experts.gate_proj.weight).
++                # For models with multiple shared experts, split that tensor
++                # evenly into per-shared-expert slices and load them into
++                # appended expert slots mlp.experts.{n_routed_experts + j}.*
++                # accordingly.
++                num_chunks = 1
++                if is_fusion_moe_shared_experts_layer:
++                    num_chunks = getattr(self.config, "n_shared_experts", 1) or 1
++                    # Determine split axis based on op type
++                    # gate/up: ColumnParallel → split along dim 0
++                    # down: RowParallel → split along dim 1
++                    split_dim = (
++                        1
++                        if ("down_proj.weight" in name and loaded_weight.ndim > 1)
++                        else 0
++                    )
++                    total = loaded_weight.shape[split_dim]
++                    assert total % num_chunks == 0, (
++                        f"Shared expert weight dim {total} "
++                        f"not divisible by num_chunks {num_chunks}"
++                    )
++                    chunk_size = total // num_chunks
++
++                for j in range(num_chunks):
++                    chunk_name = name
++                    weight_to_load = loaded_weight
++
++                    if is_fusion_moe_shared_experts_layer:
++                        chunk_slice = slice(j * chunk_size, (j + 1) * chunk_size)
++                        if loaded_weight.ndim == 1:
++                            weight_to_load = loaded_weight[chunk_slice]
++                        elif split_dim == 0:
++                            weight_to_load = loaded_weight[chunk_slice, :]
++                        else:
++                            weight_to_load = loaded_weight[:, chunk_slice]
++                        # Synthesize an expert-style name so expert mapping
++                        # can route it
++                        chunk_name = name.replace(
++                            "mlp.shared_experts",
++                            f"mlp.experts.{self.config.n_routed_experts + j}",
++                        )
++
++                    # Use expert_params_mapping to locate the destination
++                    # param and delegate to its expert-aware weight_loader
++                    # with expert_id.
++                    for mapping in expert_params_mapping:
++                        param_name, weight_name, expert_id, shard_id = mapping
++                        if weight_name not in chunk_name:
++                            continue
++
++                        # Anyway, this is an expert weight and should not be
++                        # attempted to load as other weights later
++                        is_expert_weight = True
++
++                        # Do not modify `name` since the loop may continue here
++                        # Instead, create a new variable
++                        name_mapped = chunk_name.replace(weight_name, param_name)
++
++                        if is_pp_missing_parameter(name_mapped, self):
++                            continue
++
++                        param = params_dict[name_mapped]
++                        # We should ask the weight loader to return success or
++                        # not here since otherwise we may skip experts with
++                        # other available replicas.
++                        weight_loader = typing.cast(
++                            Callable[..., bool], param.weight_loader
++                        )
++                        success = weight_loader(
++                            param,
++                            weight_to_load,
++                            name_mapped,
++                            shard_id=shard_id,
++                            expert_id=expert_id,
++                            return_success=True,
++                        )
++                        if success:
++                            if not is_fusion_moe_shared_experts_layer:
++                                name = name_mapped
++                            else:
++                                loaded_params.add(name_mapped)
++                            break
++                    else:
++                        if is_expert_weight:
++                            # We've checked that this is an expert weight
++                            # However it's not mapped locally to this rank
++                            # So we simply skip it
++                            continue
++
++                        # Skip loading extra bias for GPTQ models.
++                        if name.endswith(".bias") and name not in params_dict:
++                            continue
++
++                        # Remapping the name of FP8 kv-scale.
++                        name = maybe_remap_kv_scale_name(name, params_dict)
++                        if name is None:
++                            continue
++
++                        if is_pp_missing_parameter(name, self):
++                            continue
++
++                        # When loading a DSA checkpoint under a non-DSA config
++                        # (config has no `index_topk`), the indexer submodule
++                        # is not instantiated and its weights are absent from
++                        # params_dict. Silently skip those weights so a DSA
++                        # checkpoint can be served as a plain AXK2 model.
++                        if (
++                            ".self_attn.indexer." in name
++                            and not hasattr(self.config, "index_topk")
++                        ):
++                            continue
++
++                        param = params_dict[name]
++                        weight_loader = getattr(
++                            param, "weight_loader", default_weight_loader
++                        )
++                        weight_loader(param, loaded_weight)
++            if name is not None and not is_fusion_moe_shared_experts_layer:
++                loaded_params.add(name)
++
++        return loaded_params
++
++    # def reload_mla_absorbed_weights(self, act_dtype: torch.dtype | None = None):
++    #     if act_dtype is None:
++    #         act_dtype = torch.get_default_dtype()
++
++    #     for layer in self.model.layers:
++    #         if isinstance(layer, PPMissingLayer):
++    #             continue
++    #         if not isinstance(layer.self_attn, AXK2MLAAttention):
++    #             continue
++    #         mla_attn = layer.self_attn.mla_attn.mla_attn
++    #         mla_attn.process_weights_after_loading(act_dtype)
++
++
++def get_spec_layer_idx_from_weight_name(
++    config, weight_name: str
++) -> int | None:
++    num_nextn_predict_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
++    if num_nextn_predict_layers > 0:
++        layer_idx = config.num_hidden_layers
++        for i in range(num_nextn_predict_layers):
++            if weight_name.startswith(
++                f"model.layers.{layer_idx + i}."
++            ) or weight_name.startswith(f"layers.{layer_idx + i}."):
++                return layer_idx + i
++    return None
+diff --git a/vllm/model_executor/models/registry.py b/vllm/model_executor/models/registry.py
+index d28aac974..d6a5b41f0 100644
+--- a/vllm/model_executor/models/registry.py
++++ b/vllm/model_executor/models/registry.py
+@@ -75,6 +75,7 @@ _TEXT_GENERATION_MODELS = {
+     "ArceeForCausalLM": ("arcee", "ArceeForCausalLM"),
+     "ArcticForCausalLM": ("arctic", "ArcticForCausalLM"),
+     "AXK1ForCausalLM": ("AXK1", "AXK1ForCausalLM"),
++    "AXK2ForCausalLM": ("axk2", "AXK2ForCausalLM"),
+     "BailingMoeForCausalLM": ("bailing_moe", "BailingMoeForCausalLM"),
+     "BailingMoeV2ForCausalLM": ("bailing_moe", "BailingMoeV2ForCausalLM"),
+     "BailingMoeV2_5ForCausalLM": ("bailing_moe_linear", "BailingMoeV25ForCausalLM"),
+diff --git a/vllm/transformers_utils/config.py b/vllm/transformers_utils/config.py
+index 03103fbf5..b73d0ec60 100644
+--- a/vllm/transformers_utils/config.py
++++ b/vllm/transformers_utils/config.py
+@@ -73,6 +73,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
+     afmoe="AfmoeConfig",
+     arctic="ArcticConfig",
+     axk1="AXK1Config",
++    axk2="AXK2Config",
+     bagel="BagelConfig",
+     umm="CheersConfig",
+     chatglm="ChatGLMConfig",
+diff --git a/vllm/transformers_utils/configs/__init__.py b/vllm/transformers_utils/configs/__init__.py
+index 4bb7674dd..1cd665ca7 100644
+--- a/vllm/transformers_utils/configs/__init__.py
++++ b/vllm/transformers_utils/configs/__init__.py
+@@ -18,6 +18,7 @@ _CLASS_TO_MODULE: dict[str, str] = {
+     "AfmoeConfig": "vllm.transformers_utils.configs.afmoe",
+     "ArcticConfig": "vllm.transformers_utils.configs.arctic",
+     "AXK1Config": "vllm.transformers_utils.configs.AXK1",
++    "AXK2Config": "vllm.transformers_utils.configs.axk2",
+     "BagelConfig": "vllm.transformers_utils.configs.bagel",
+     "CheersConfig": "vllm.transformers_utils.configs.cheers",
+     "ChatGLMConfig": "vllm.transformers_utils.configs.chatglm",
+@@ -106,6 +107,7 @@ __all__ = [
+     "AfmoeConfig",
+     "ArcticConfig",
+     "AXK1Config",
++    "AXK2Config",
+     "BagelConfig",
+     "CheersConfig",
+     "ChatGLMConfig",
+diff --git a/vllm/transformers_utils/configs/axk2.py b/vllm/transformers_utils/configs/axk2.py
+new file mode 100644
+index 000000000..63c4d1688
+--- /dev/null
++++ b/vllm/transformers_utils/configs/axk2.py
+@@ -0,0 +1,136 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from typing import Any
++
++from transformers import PretrainedConfig
++
++
++class AXK2Config(PretrainedConfig):
++    r"""
++    Configuration class for the AXK2 model.
++    Extends AXK1 with gated normalization and attention output gating.
++    """
++
++    model_type = "axk2"
++    keys_to_ignore_at_inference = ["past_key_values"]
++
++    def __init__(
++        self,
++        vocab_size: int = 163840,
++        hidden_size: int = 2048,
++        intermediate_size: int = 5120,
++        moe_intermediate_size: int = 512,
++        num_hidden_layers: int = 48,
++        num_nextn_predict_layers: int | None = None,
++        num_attention_heads: int = 32,
++        num_key_value_heads: int = 32,
++        n_shared_experts: int | None = 1,
++        n_routed_experts: int | None = 128,
++        ep_size: int | None = 1,
++        routed_scaling_factor: float | None = 2.5,
++        kv_lora_rank: int | None = 128,
++        q_lora_rank: int | None = 384,
++        qk_rope_head_dim: int | None = 32,
++        v_head_dim: int | None = 64,
++        qk_nope_head_dim: int | None = 64,
++        topk_method: str | None = "noaux_tc",
++        n_group: int | None = None,
++        topk_group: int | None = None,
++        num_experts_per_tok: int | None = 8,
++        moe_layer_freq: int | None = 1,
++        first_k_dense_replace: int = 1,
++        norm_topk_prob: bool = True,
++        scoring_func: str | None = "sigmoid",
++        aux_loss_alpha: float | None = 0.0001,
++        seq_aux: float | None = True,
++        hidden_act: str | None = "silu",
++        max_position_embeddings: int | None = 4096,
++        initializer_range: float | None = 0.02,
++        rms_norm_eps: float = 1e-6,
++        use_cache: bool | None = True,
++        pad_token_id: int | None = None,
++        bos_token_id: int | None = 163691,
++        eos_token_id: int | None = 163691,
++        pretraining_tp: int | None = 1,
++        tie_word_embeddings: bool | None = False,
++        rope_theta: float | None = 1000000.0,
++        rope_scaling: dict[str, Any] | None = None,
++        rope_parameters: dict[str, Any] | None = None,
++        attention_bias: bool | None = False,
++        attention_dropout: float | None = 0.0,
++        attention_output_gate: bool = False,
++        gated_norm: bool = False,
++        gated_norm_rank: int = 16,
++        # DSA (Dynamic Sparse Attention) parameters
++        index_n_heads: int | None = None,
++        index_head_dim: int | None = None,
++        index_topk: int | None = None,
++        **kwargs,
++    ):
++        self.vocab_size = vocab_size
++        self.max_position_embeddings = max_position_embeddings
++        self.hidden_size = hidden_size
++        self.intermediate_size = intermediate_size
++        self.moe_intermediate_size = moe_intermediate_size
++        self.num_hidden_layers = num_hidden_layers
++        self.num_nextn_predict_layers = num_nextn_predict_layers
++        self.num_attention_heads = num_attention_heads
++        self.n_shared_experts = n_shared_experts
++        self.n_routed_experts = n_routed_experts
++        self.ep_size = ep_size
++        self.routed_scaling_factor = routed_scaling_factor
++        self.kv_lora_rank = kv_lora_rank
++        self.q_lora_rank = q_lora_rank
++        self.qk_rope_head_dim = qk_rope_head_dim
++        self.v_head_dim = v_head_dim
++        self.qk_nope_head_dim = qk_nope_head_dim
++        self.topk_method = topk_method
++        self.n_group = n_group
++        self.topk_group = topk_group
++        self.num_experts_per_tok = num_experts_per_tok
++        self.moe_layer_freq = moe_layer_freq
++        self.first_k_dense_replace = first_k_dense_replace
++        self.norm_topk_prob = norm_topk_prob
++        self.scoring_func = scoring_func
++        self.aux_loss_alpha = aux_loss_alpha
++        self.seq_aux = seq_aux
++        if num_key_value_heads is None:
++            num_key_value_heads = num_attention_heads
++        self.num_key_value_heads = num_key_value_heads
++        self.hidden_act = hidden_act
++        self.initializer_range = initializer_range
++        self.rms_norm_eps = rms_norm_eps
++        self.pretraining_tp = pretraining_tp
++        self.use_cache = use_cache
++        self.rope_theta = rope_theta
++        self.rope_scaling = rope_scaling
++        if rope_parameters is None and rope_scaling is not None:
++            rope_parameters = dict(rope_scaling)
++            if "type" in rope_parameters and "rope_type" not in rope_parameters:
++                rope_parameters["rope_type"] = rope_parameters.pop("type")
++            rope_parameters.setdefault("rope_theta", rope_theta)
++        self.rope_parameters = rope_parameters
++        self.attention_bias = attention_bias
++        self.attention_dropout = attention_dropout
++        self.attention_output_gate = attention_output_gate
++        self.gated_norm = gated_norm
++        self.gated_norm_rank = gated_norm_rank
++        # DSA — only attach when provided. vLLM uses `hasattr(config,
++        # "index_topk")` as the is_v32 sentinel (see deepseek_v2,
++        # glm4_moe_lite, deepseek_mtp, etc.), so unconditionally setting
++        # these to None makes the sentinel fire in non-DSA mode and crashes
++        # AXK2Model.__init__ when it tries to allocate topk_indices_buffer.
++        if index_n_heads is not None:
++            self.index_n_heads = index_n_heads
++        if index_head_dim is not None:
++            self.index_head_dim = index_head_dim
++        if index_topk is not None:
++            self.index_topk = index_topk
++
++        super().__init__(
++            pad_token_id=pad_token_id,
++            bos_token_id=bos_token_id,
++            eos_token_id=eos_token_id,
++            tie_word_embeddings=tie_word_embeddings,
++            **kwargs,
++        )
+diff --git a/vllm/transformers_utils/model_arch_config_convertor.py b/vllm/transformers_utils/model_arch_config_convertor.py
+index 70bb4caa5..fc2826ad9 100644
+--- a/vllm/transformers_utils/model_arch_config_convertor.py
++++ b/vllm/transformers_utils/model_arch_config_convertor.py
+@@ -262,6 +262,7 @@ class ModelArchConfigConvertorBase:
+             return False
+         elif self.hf_text_config.model_type in (
+             "axk1",
++            "axk2",
+             "deepseek_v2",
+             "deepseek_v3",
+             "deepseek_v32",
+@@ -291,6 +292,7 @@ class ModelArchConfigConvertorBase:
+                 self.hf_text_config.model.model_type
+                 in (
+                     "axk1",
++                    "axk2",
+                     "deepseek_v2",
+                     "deepseek_v3",
+                     "deepseek_v32",

--- a/container/patches/vllm/axk2/0002-Model-axk2-reject-non-fused-attention-gate-checkpoin.patch
+++ b/container/patches/vllm/axk2/0002-Model-axk2-reject-non-fused-attention-gate-checkpoin.patch
@@ -1,0 +1,60 @@
+From 038b5006511c286b2d7baeaa76881af6972c1c4d Mon Sep 17 00:00:00 2001
+From: "Kim, Jin" <jinn.kim@sk.com>
+Date: Tue, 28 Jul 2026 07:16:10 +0000
+Subject: [PATCH 2/2] [Model] axk2: reject non-fused attention-gate checkpoints
+ explicitly
+
+Only the fused attention-output-gate layout is implemented: q_b_proj takes a
+doubled input and produces a per-head interleaved [q | gate]. That is not just
+a packing choice. The head stride is qk_head_dim + v_head_dim = 320, which is
+not a multiple of the 128-wide fp8 scale block, so the q/gate boundary straddles
+scale blocks and the weight cannot be split losslessly -- a checkpoint storing
+the gate separately would be a different quantization, not a rearrangement.
+
+config.attn_gate_fused was never read, so such a checkpoint got as far as
+loading weights and then died on a bare shape mismatch against the doubled
+q_b_proj input. Read the flag and refuse up front with a message that says what
+is wrong and what to do about it.
+
+Defaults to True when the key is absent, so configs that predate the flag keep
+loading exactly as before.
+
+Verified on 4x B300 at TP=4: with attn_gate_fused=False the four workers raise
+this error during model construction, before any weight loading starts; with
+the released config (attn_gate_fused=True) the greedy output is byte-identical
+to a build without this change.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+---
+ vllm/model_executor/models/axk2.py | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/vllm/model_executor/models/axk2.py b/vllm/model_executor/models/axk2.py
+index 94beea6a8..fa51c7cad 100644
+--- a/vllm/model_executor/models/axk2.py
++++ b/vllm/model_executor/models/axk2.py
+@@ -1554,6 +1554,24 @@ class AXK2MLAAttention(nn.Module):
+                 "attention_output_gate requires q_lora_rank (fused gate rides "
+                 "inside q_b_proj)"
+             )
++            # A checkpoint that stores the gate separately cannot be served
++            # here: only the fused layout is implemented, and it is not merely
++            # a packing choice. The fused output is per-head interleaved
++            # [q | gate] with a head stride of qk_head_dim + v_head_dim, which
++            # is not a multiple of the 128-wide fp8 scale block, so the q/gate
++            # boundary straddles scale blocks and the weight cannot be split
++            # losslessly. Reject it up front -- otherwise the only symptom is a
++            # bare shape mismatch on q_b_proj (the fused projection takes
++            # 2 * q_lora_rank inputs) once the weights start loading.
++            if not getattr(config, "attn_gate_fused", True):
++                raise ValueError(
++                    "This checkpoint sets attn_gate_fused=False, i.e. the "
++                    "attention output gate is stored as a separate projection. "
++                    "Only the fused layout is supported: q_b_proj must already "
++                    "absorb the gate (doubled input, per-head interleaved "
++                    "output). Re-export the checkpoint with the offline merge "
++                    "step applied."
++                )
+ 
+         # AXK2 always uses q-lora MLA; the q-lora-less (q_proj) path is removed.
+         assert self.q_lora_rank is not None, (

--- a/container/patches/vllm/axk2/0003-Spec-Decode-honor-DSpark-anchor-sampling-layout.patch
+++ b/container/patches/vllm/axk2/0003-Spec-Decode-honor-DSpark-anchor-sampling-layout.patch
@@ -1,0 +1,33 @@
+From e2e40c76f172f17403a9d1138d9e1da21cb99986 Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Thu, 27 Aug 2026 04:04:25 -0700
+Subject: [PATCH] fix(spec decode): honor DSpark anchor sampling layout
+
+Signed-off-by: Codex <codex@openai.com>
+---
+ vllm/transformers_utils/configs/speculators/algos.py | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/vllm/transformers_utils/configs/speculators/algos.py b/vllm/transformers_utils/configs/speculators/algos.py
+index e034cec97..90ff5271b 100644
+--- a/vllm/transformers_utils/configs/speculators/algos.py
++++ b/vllm/transformers_utils/configs/speculators/algos.py
+@@ -148,8 +148,13 @@ def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
+         target_layer_ids (DSpark's i-1 layer semantics).
+     """
+     pre_trained_config["architectures"] = ["Qwen3DSparkModel"]
+-    # Speculators DSpark uses the 1+N fill-in block (anchor is a bonus token).
+-    pre_trained_config["dspark_bonus_anchor"] = True
++    # Preserve the block layout declared by the checkpoint. When
++    # sample_from_anchor is true, the anchor predicts the first draft token and
++    # DSpark needs N query slots. Otherwise it uses the 1+N fill-in layout where
++    # the anchor is a separate bonus token.
++    pre_trained_config["dspark_bonus_anchor"] = not config_dict.get(
++        "sample_from_anchor", False
++    )
+ 
+     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
+     pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
+-- 
+2.34.1
+

--- a/container/patches/vllm/axk2/0004-fix-kv-cache-support-sparse-MLA-targets-with-SWA-dra.patch
+++ b/container/patches/vllm/axk2/0004-fix-kv-cache-support-sparse-MLA-targets-with-SWA-dra.patch
@@ -1,0 +1,239 @@
+From 7d3ec012ad8dc75d4355a98caddb4d89cca8981b Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Thu, 27 Aug 2026 04:44:52 -0700
+Subject: [PATCH] fix(kv-cache): support sparse MLA targets with SWA drafts
+
+Backport vllm-project/vllm@e18f0037a5d54dc2ead5896af896305f2bf57496 to allow A.X-K2 sparse MLA plus the sliding-window DSpark draft to share a compatible full-allocation cache layout without changing sliding-window attention compute.
+---
+ vllm/v1/core/kv_cache_utils.py | 165 ++++++++++++++++++++++-----------
+ 1 file changed, 110 insertions(+), 55 deletions(-)
+
+diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
+index d4970d91b..742744d84 100644
+--- a/vllm/v1/core/kv_cache_utils.py
++++ b/vllm/v1/core/kv_cache_utils.py
+@@ -1426,100 +1426,150 @@ def get_kv_cache_config_from_groups(
+     )
+ 
+ 
+-def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
+-    """
+-    This function tries to convert the KV cache specs to one type if the model
+-    is a hybrid model with multiple type of KV cache. It will convert all
+-    SlidingWindowSpec to FullAttentionSpec if both types are present.
++def _promote_local_kv_cache_specs(
++    kv_cache_spec: dict[str, KVCacheSpec],
++) -> dict[str, KVCacheSpec]:
++    """Use full-attention allocation for local-attention cache specs.
+ 
+-    Args:
+-        kv_cache_spec: The kv cache spec of each attention layer in the model
++    The returned specs affect KV cache management only. Attention modules keep
++    their original sliding-window or chunked-local compute behavior.
+     """
++    promoted_specs = kv_cache_spec.copy()
+ 
+     if is_kv_cache_spec_uniform(
+-        kv_cache_spec
+-    ) or UniformTypeKVCacheSpecs.is_uniform_type(kv_cache_spec):
+-        return
+-
+-    logger.warning(
+-        "Hybrid KV cache manager is disabled for this hybrid model, "
+-        "This means we do not enable any optimizations for saving KV cache "
+-        "memory (e.g., dropping the KV cache outside the sliding window). "
+-        "The compute of layers like sliding window is still saved."
+-    )
++        promoted_specs
++    ) or UniformTypeKVCacheSpecs.is_uniform_type(promoted_specs):
++        return promoted_specs
+ 
+     has_full_attention = any(
+-        isinstance(spec, FullAttentionSpec) for spec in kv_cache_spec.values()
++        isinstance(spec, FullAttentionSpec) for spec in promoted_specs.values()
+     )
+     has_sliding_window = any(
+-        isinstance(spec, SlidingWindowSpec) for spec in kv_cache_spec.values()
++        isinstance(spec, SlidingWindowSpec) for spec in promoted_specs.values()
+     )
+     has_chunked_local_attention = any(
+-        isinstance(spec, ChunkedLocalAttentionSpec) for spec in kv_cache_spec.values()
++        isinstance(spec, ChunkedLocalAttentionSpec) for spec in promoted_specs.values()
+     )
+-    has_swa_mla = any(
+-        isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
++    full_block_sizes = {
++        spec.block_size
++        for spec in promoted_specs.values()
++        if isinstance(spec, FullAttentionSpec)
++    }
++    full_attention_block_size = (
++        next(iter(full_block_sizes)) if len(full_block_sizes) == 1 else None
+     )
+ 
+-    uniform_block_size: int | None = None
+-    if has_swa_mla:
+-        # For DeepseekV4, block sizes can be different for different KV cache groups.
+-        # E.g., Full MLA: 256; SWA MLA: 64; C4 partial states: 4, C128 states: 8.
+-        assert has_full_attention
+-        any_full_spec = next(
+-            iter(
+-                spec
+-                for spec in kv_cache_spec.values()
+-                if isinstance(spec, FullAttentionSpec)
+-            )
++    def promoted_page_size_padded(spec: AttentionSpec, block_size: int) -> int | None:
++        if spec.page_size_padded is None:
++            return None
++        unpadded_page_size = (
++            spec.unpadded_page_size_bytes * block_size // spec.block_size
+         )
+-        uniform_block_size = any_full_spec.block_size
++        return max(spec.page_size_padded, unpadded_page_size)
+ 
+     if has_full_attention and (has_sliding_window or has_chunked_local_attention):
+         for layer_name, spec in kv_cache_spec.items():
+             if isinstance(spec, SlidingWindowMLASpec):
+-                kv_cache_spec[layer_name] = MLAAttentionSpec(
+-                    block_size=uniform_block_size
+-                    if uniform_block_size is not None
+-                    else spec.block_size,
++                block_size = full_attention_block_size or spec.block_size
++                promoted_specs[layer_name] = MLAAttentionSpec(
++                    block_size=block_size,
+                     num_kv_heads=spec.num_kv_heads,
+                     head_size=spec.head_size,
+                     dtype=spec.dtype,
+-                    page_size_padded=spec.page_size_padded,
++                    page_size_padded=promoted_page_size_padded(spec, block_size),
+                     cache_dtype_str=spec.cache_dtype_str,
+                     alignment=spec.alignment,
+                     compress_ratio=spec.compress_ratio,
+                     model_version=spec.model_version,
+                 )
+             elif isinstance(spec, SlidingWindowSpec):
+-                kv_cache_spec[layer_name] = FullAttentionSpec(
+-                    block_size=spec.block_size,
++                block_size = full_attention_block_size or spec.block_size
++                promoted_specs[layer_name] = FullAttentionSpec(
++                    block_size=block_size,
+                     num_kv_heads=spec.num_kv_heads,
+                     head_size=spec.head_size,
+                     head_size_v=spec.head_size_v,
+                     dtype=spec.dtype,
+                     kv_quant_mode=spec.kv_quant_mode,
+                     sliding_window=spec.sliding_window,
+-                    page_size_padded=spec.page_size_padded,
++                    page_size_padded=promoted_page_size_padded(spec, block_size),
+                 )
+             elif isinstance(spec, ChunkedLocalAttentionSpec):
+-                kv_cache_spec[layer_name] = FullAttentionSpec(
+-                    block_size=spec.block_size,
++                block_size = full_attention_block_size or spec.block_size
++                promoted_specs[layer_name] = FullAttentionSpec(
++                    block_size=block_size,
+                     num_kv_heads=spec.num_kv_heads,
+                     head_size=spec.head_size,
+                     dtype=spec.dtype,
+                     attention_chunk_size=spec.attention_chunk_size,
+-                    page_size_padded=spec.page_size_padded,
++                    page_size_padded=promoted_page_size_padded(spec, block_size),
+                 )
+ 
+     if not (
+-        is_kv_cache_spec_uniform(kv_cache_spec)
+-        or UniformTypeKVCacheSpecs.is_uniform_type(kv_cache_spec)
++        is_kv_cache_spec_uniform(promoted_specs)
++        or UniformTypeKVCacheSpecs.is_uniform_type(promoted_specs)
+     ):
+-        raise ValueError(
+-            "Hybrid KV cache manager is disabled but failed to "
+-            "convert the KV cache specs to one unified type."
+-        )
++        raise ValueError("Failed to promote local KV cache specs to one unified type.")
++
++    return promoted_specs
++
++
++def _try_get_full_allocation_fallback_groups(
++    kv_cache_spec: dict[str, KVCacheSpec],
++) -> list[KVCacheGroupSpec] | None:
++    """Try a supported full-allocation fallback for local-attention layers."""
++    if any(isinstance(spec, HiddenStateCacheSpec) for spec in kv_cache_spec.values()):
++        return None
++    if any(
++        isinstance(spec, (SlidingWindowMLASpec, ChunkedLocalAttentionSpec))
++        for spec in kv_cache_spec.values()
++    ):
++        return None
++
++    has_mla = any(isinstance(spec, MLAAttentionSpec) for spec in kv_cache_spec.values())
++    has_regular_swa = any(
++        isinstance(spec, SlidingWindowSpec) for spec in kv_cache_spec.values()
++    )
++    if not (has_mla and has_regular_swa):
++        return None
++
++    try:
++        promoted_specs = _promote_local_kv_cache_specs(kv_cache_spec)
++    except ValueError:
++        return None
++    uniform_spec = UniformTypeKVCacheSpecs.from_specs(promoted_specs)
++    if uniform_spec is None:
++        return None
++    logger.warning(
++        "KV cache page sizes cannot be unified; treating sliding-window "
++        "layers as full attention for cache allocation. Sliding-window "
++        "attention compute is unchanged."
++    )
++    return _get_kv_cache_groups_uniform_type(uniform_spec)
++
++
++def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
++    """
++    This function tries to convert the KV cache specs to one type if the model
++    is a hybrid model with multiple type of KV cache. It will convert all
++    SlidingWindowSpec to FullAttentionSpec if both types are present.
++
++    Args:
++        kv_cache_spec: The kv cache spec of each attention layer in the model
++    """
++
++    if is_kv_cache_spec_uniform(
++        kv_cache_spec
++    ) or UniformTypeKVCacheSpecs.is_uniform_type(kv_cache_spec):
++        return
++
++    logger.warning(
++        "Hybrid KV cache manager is disabled for this hybrid model, "
++        "This means we do not enable any optimizations for saving KV cache "
++        "memory (e.g., dropping the KV cache outside the sliding window). "
++        "The compute of layers like sliding window is still saved."
++    )
++    kv_cache_spec.update(_promote_local_kv_cache_specs(kv_cache_spec))
+ 
+ 
+ def group_and_unify_kv_cache_specs(
+@@ -1776,10 +1826,15 @@ def get_kv_cache_groups(
+         if not isinstance(v, HiddenStateCacheSpec)
+     }
+ 
+-    # As KVCacheManager can only allocate memory of one size, we need to unify
+-    # the page size of the layers. For cases cannot be unified, this function
+-    # will raise an error.
+-    filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
++    # Prefer preserving each layer's cache semantics. If physical pages cannot
++    # be unified, try a supported allocation-only fallback before failing.
++    try:
++        filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
++    except NotImplementedError:
++        fallback_groups = _try_get_full_allocation_fallback_groups(kv_cache_spec)
++        if fallback_groups is None:
++            raise
++        return fallback_groups
+     groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+ 
+     # Add hidden-state layers back with page aligned to the common page.
+-- 
+2.34.1
+

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -124,6 +124,34 @@ RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')
         find "$CUBINS_DIR" -type d -exec chmod g+rwx {} + ; \
     fi
 
+{% if device == "cuda" %}
+# A.X-K2 support is not present in the upstream vLLM 0.26.0 runtime. Apply the
+# four Python-only forward-port patches directly to the installed package in the
+# standard Dynamo vLLM runtime image. vLLM 0.26.0 already includes the newer
+# upstream DSpark runtime, but needs the later upstream sparse-MLA-plus-SWA-draft
+# KV allocation fix. Validate config conversion, registry wiring, and that cache
+# grouping fallback rather than overlaying SKT's older DSpark implementation.
+COPY --chmod=644 container/patches/vllm/axk2/*.patch /tmp/axk2-vllm-patches/
+COPY --chmod=755 container/deps/vllm/validate_axk2_port.py /tmp/validate_axk2_port.py
+RUN set -eux; \
+    cd "${SITE_PACKAGES}"; \
+    for patch_file in /tmp/axk2-vllm-patches/*.patch; do \
+        patch --batch --forward -p1 < "${patch_file}"; \
+    done; \
+    python3 -m compileall -q \
+        vllm/model_executor/models/axk2.py \
+        vllm/transformers_utils/configs/axk2.py; \
+    python3 /tmp/validate_axk2_port.py; \
+    rm -rf /tmp/axk2-vllm-patches /tmp/validate_axk2_port.py
+
+# Model-specific safe defaults discovered during Dynamo 1.4.1 functional
+# bring-up. Quack FP8 fails under torch.compile for this architecture; disabling
+# only that vLLM-Omni override retains torch.compile and CUDA graph execution.
+ENV VLLM_USE_FLASHINFER_MOE_FP4=1 \
+    FLASHINFER_DISABLE_VERSION_CHECK=1 \
+    VLLM_OMNI_USE_QUACK_FP8=0
+{% endif %}
+
 {% if device != "cuda" %}
 # Copy UCX and NIXL from wheel_builder for CPU/XPU devices
 # (CUDA devices use NIXL from upstream vLLM wheels)


### PR DESCRIPTION
## Summary

Add A.X-K2 support to the standard Dynamo CUDA vLLM runtime. The stock vLLM 0.26.0 package lacks the A.X-K2 model and config registration; the runtime build now applies Python patches 0001–0004 and validates the resulting model, DSpark, and KV-cache wiring.

This PR contains only container changes. The native CUDA Patch 5 and AX-K2 deployment recipes are excluded.

## Details

- Add the A.X-K2 model/config and reject checkpoints with unsupported non-fused attention gates.
- Honor the DSpark anchor-sampling layout and backport compatible cache allocation for sparse MLA targets with sliding-window drafts.
- Run the AX-K2 structural validator during the runtime build and set the FP4/Quack runtime defaults used by this model.

## Where should the reviewer start?

Start with `container/templates/vllm_runtime.Dockerfile` for patch application and build-time validation, then `container/deps/vllm/validate_axk2_port.py` and `container/patches/vllm/axk2/`.

## Validation

- Passed all applicable pre-commit hooks for the Python validator and Dockerfile template. Patch files are excluded by the repository's pre-commit configuration.
- Rendered the vLLM runtime Dockerfile for `linux/amd64` with CUDA 13.0.
- Applied patches 0001–0004 sequentially to pristine vLLM `v0.26.0`; all eight patched Python files compile.
- Compiled the build-time validator and checked the diff for whitespace errors outside patch payloads.
- Verified that `recipes/` matches the release branch exactly and that the PR contains six container files with no Patch 5.
- Full container build and GPU inference were not rerun for this PR cleanup.

## Related Issues

- [x] Confirmed — no related issue
