### PR TITLE
fix(sglang): enable memory saver before snapshot launch

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -286,6 +286,7 @@ snapshot_vllm:
   - 'deploy/operator/internal/dynamo/backend_vllm.go'
 
 snapshot_sglang:
+  - 'components/src/dynamo/sglang/args.py'
   - 'components/src/dynamo/sglang/snapshot.py'
   - 'deploy/operator/internal/dynamo/backend_sglang.go'
 

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -288,6 +288,9 @@ snapshot_vllm:
 snapshot_sglang:
   - 'components/src/dynamo/sglang/args.py'
   - 'components/src/dynamo/sglang/snapshot.py'
+  # The SGLang runtime tag controls the engine version exercised by this suite,
+  # so engine bumps must trigger it. Deliberately omit broad pyproject.toml.
+  - 'container/context.yaml'
   - 'deploy/operator/internal/dynamo/backend_sglang.go'
 
 snapshot_trtllm:

--- a/.github/scripts/test-filters.js
+++ b/.github/scripts/test-filters.js
@@ -281,6 +281,16 @@ const testCases = [
     desc: 'sglang snapshot.py gates only sglang checkpoint tests'
   },
   {
+    file: 'container/context.yaml',
+    expect: {
+      snapshot: false,
+      snapshot_vllm: false,
+      snapshot_sglang: true,
+      snapshot_trtllm: false,
+    },
+    desc: 'runtime tag changes gate the SGLang checkpoint tests'
+  },
+  {
     file: 'components/src/dynamo/trtllm/snapshot.py',
     expect: {
       trtllm: true,

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -551,6 +551,9 @@ async def parse_args(args: list[str]) -> Config:
 
     if is_snapshot_enabled():
         configure_snapshot_capture_env()
+        # SGLang's scheduler launcher reads the raw field before late
+        # resolution, so snapshot mode must enable it before ServerArgs creation.
+        parsed_args.enable_memory_saver = True
 
     # TODO: sglang downloads the model in `from_cli_args`, which means we had to
     # fetch_model (download the model) here, in `parse_args`. `parse_args` should not

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -549,11 +549,13 @@ async def parse_args(args: list[str]) -> Config:
     if should_fetch_model(parsed_args, model_path):
         await fetch_model(model_path)
 
-    if is_snapshot_enabled():
+    snapshot_enabled = is_snapshot_enabled()
+    if snapshot_enabled:
         configure_snapshot_capture_env()
-        # SGLang's scheduler launcher reads the raw field before late
-        # resolution, so snapshot mode must enable it before ServerArgs creation.
+        # SGLang reads these raw fields before late resolution, so snapshot mode
+        # must set them before ServerArgs creation.
         parsed_args.enable_memory_saver = True
+        parsed_args.enable_forward_pass_metrics = False
 
     # TODO: sglang downloads the model in `from_cli_args`, which means we had to
     # fetch_model (download the model) here, in `parse_args`. `parse_args` should not
@@ -574,7 +576,11 @@ async def parse_args(args: list[str]) -> Config:
         parsed_args.enable_memory_saver = True
 
     fpm_source = _forward_pass_metrics_source(dynamo_config)
-    if fpm_source and not getattr(parsed_args, "enable_forward_pass_metrics", False):
+    if (
+        not snapshot_enabled
+        and fpm_source
+        and not getattr(parsed_args, "enable_forward_pass_metrics", False)
+    ):
         parsed_args.enable_forward_pass_metrics = True
         logging.info("Enabled forward_pass_metrics from %s", fpm_source)
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -519,29 +519,24 @@ async def test_parse_args_applies_dynamo_defaults_before_resolution(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("snapshot_enabled", "gms_v1", "expected"),
+    ("snapshot_enabled", "expected"),
     [
-        (False, False, False),
-        (True, False, True),
-        (False, True, True),
-        (True, True, True),
+        (False, False),
+        (True, True),
     ],
 )
 async def test_parse_args_sets_raw_memory_saver_before_resolution(
-    monkeypatch, mock_sglang_cli, tmp_path, snapshot_enabled, gms_v1, expected
+    monkeypatch, mock_sglang_cli, tmp_path, snapshot_enabled, expected
 ):
     monkeypatch.setattr(
         "dynamo.sglang.args.configure_snapshot_capture_env", lambda: None
     )
+    monkeypatch.delenv("DYN_GMS_USE_V1", raising=False)
     if snapshot_enabled:
         monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
         monkeypatch.setenv("NCCL_CUMEM_ENABLE", "0")
     else:
         monkeypatch.delenv(SNAPSHOT_CONTROL_DIR_ENV, raising=False)
-    if gms_v1:
-        monkeypatch.setenv("DYN_GMS_USE_V1", "true")
-    else:
-        monkeypatch.delenv("DYN_GMS_USE_V1", raising=False)
     server_args = SimpleNamespace(
         disaggregation_mode="null",
         dllm_algorithm=None,
@@ -556,7 +551,7 @@ async def test_parse_args_sets_raw_memory_saver_before_resolution(
         return server_args
 
     monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
-    mock_sglang_cli(model="/tmp")
+    mock_sglang_cli(model=str(tmp_path))
 
     config = await parse_args(sys.argv[1:])
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -558,6 +558,36 @@ async def test_parse_args_sets_raw_memory_saver_before_resolution(
     assert config.server_args.enable_memory_saver is expected
 
 
+@pytest.mark.asyncio
+async def test_parse_args_disables_raw_fpm_for_snapshot_with_metric_port(
+    monkeypatch, mock_sglang_cli, tmp_path
+):
+    monkeypatch.setattr(
+        "dynamo.sglang.args.configure_snapshot_capture_env", lambda: None
+    )
+    monkeypatch.delenv("DYN_GMS_USE_V1", raising=False)
+    monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+    monkeypatch.setenv("DYN_FORWARDPASS_METRIC_PORT", "23456")
+    server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        dllm_algorithm=None,
+        enable_forward_pass_metrics=False,
+        kv_events_config=None,
+        get_model_config=lambda: SimpleNamespace(is_multimodal=False),
+    )
+
+    def resolve(parsed_args):
+        assert parsed_args.enable_forward_pass_metrics is False
+        return server_args
+
+    monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
+    mock_sglang_cli(model=str(tmp_path))
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.server_args.enable_forward_pass_metrics is False
+
+
 def test_compat_filters_async_generate_kwargs_for_older_engines():
     class OldEngine:
         async def async_generate(self, input_ids=None, sampling_params=None):

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -517,6 +517,52 @@ async def test_parse_args_applies_dynamo_defaults_before_resolution(
     await parse_args(sys.argv[1:])
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot_enabled", "gms_v1", "expected"),
+    [
+        (False, False, False),
+        (True, False, True),
+        (False, True, True),
+        (True, True, True),
+    ],
+)
+async def test_parse_args_sets_raw_memory_saver_before_resolution(
+    monkeypatch, mock_sglang_cli, tmp_path, snapshot_enabled, gms_v1, expected
+):
+    monkeypatch.setattr(
+        "dynamo.sglang.args.configure_snapshot_capture_env", lambda: None
+    )
+    if snapshot_enabled:
+        monkeypatch.setenv(SNAPSHOT_CONTROL_DIR_ENV, str(tmp_path))
+        monkeypatch.setenv("NCCL_CUMEM_ENABLE", "0")
+    else:
+        monkeypatch.delenv(SNAPSHOT_CONTROL_DIR_ENV, raising=False)
+    if gms_v1:
+        monkeypatch.setenv("DYN_GMS_USE_V1", "true")
+    else:
+        monkeypatch.delenv("DYN_GMS_USE_V1", raising=False)
+    server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        dllm_algorithm=None,
+        kv_events_config=None,
+        get_model_config=lambda: SimpleNamespace(is_multimodal=False),
+    )
+
+    def resolve(parsed_args):
+        # SGLang 0.5.19 copies this raw field unchanged; late resolution does
+        # not update it before the parent process launches the scheduler.
+        server_args.enable_memory_saver = parsed_args.enable_memory_saver
+        return server_args
+
+    monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
+    mock_sglang_cli(model="/tmp")
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.server_args.enable_memory_saver is expected
+
+
 def test_compat_filters_async_generate_kwargs_for_older_engines():
     class OldEngine:
         async def async_generate(self, input_ids=None, sampling_params=None):


### PR DESCRIPTION
## Summary

- enable SGLang memory saver in the raw parsed arguments before `ServerArgs` construction when Dynamo snapshot mode is active
- disable raw forward-pass metrics during snapshot startup, including when the restored pod carries `DYN_FORWARDPASS_METRIC_PORT`
- keep the existing resolved snapshot overrides so raw launcher input and resolved runtime configuration agree
- add regression coverage for normal/snapshot memory-saver startup and snapshot FPM suppression
- make both `sglang/args.py` changes and `container/context.yaml` runtime-tag bumps run the SGLang snapshot deployment suite
- add filter-harness coverage for the runtime-tag trigger

SGLang v0.5.19 keeps late-resolution overrides separate from the raw `ServerArgs` record, while parts of scheduler and restored-worker startup still read raw fields. Setting snapshot requirements before `ServerArgs.from_cli_args()` ensures scheduler subprocesses receive the memory-saver preload and restored workers do not incorrectly re-enable forward-pass metrics.

## Validation

- focused memory-saver and forward-pass-metrics tests — 15 passed
- full `test_sglang_unit.py` in the offline CI harness — 109 passed
- negative controls reproduced both failures when their production guards were removed
- non-snapshot env-, trace-, and CLI-driven FPM activation tests passed
- pre-commit passed for all four PR files
- filter harness: new `container/context.yaml` case passed; its three other failures reproduce on `main`
- YAML/JavaScript/Python syntax and `git diff --check` passed
- SGLang Snapshot Deploy Test passed on Full CI attempt 2 at head `b381afab9f`; it is being rerun for the latest filter-only head

The first exact-head deployment confirmed the memory-saver fix and exposed the raw FPM mismatch addressed by this PR. A later exact-head deployment completed the full SGLang snapshot/restore lifecycle successfully.
