### PR TITLE
fix(vllm): [cherry-pick 1.5.0] stop --enable-lora being accepted alongside --realtime and --classify-worker (#14446)

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -120,9 +120,6 @@ def parse_args(argv: list[str] | None = None) -> Config:
     # Consume the router flags before the engine parser sees the remainder.
     dynamo_config.router_advertisement, unknown = parse_worker_router_config(unknown)
 
-    # Validate arguments
-    dynamo_config.validate()
-
     vllm_args = vllm_parser.parse_args(unknown)
     # Set the model name from the command line arguments
     # model is defined in AsyncEngineArgs, but when AsyncEngineArgs.from_cli_args is called,
@@ -132,11 +129,19 @@ def parse_args(argv: list[str] | None = None) -> Config:
 
     engine_config = AsyncEngineArgs.from_cli_args(vllm_args)
 
+    # Attach engine_args before validate(): the --enable-lora exclusivity rules
+    # in DynamoVllmConfig.validate() read it, and are dead code without it.
+    dynamo_config.engine_args = engine_config
+
+    # Validate arguments
+    dynamo_config.validate()
+
+    # These run after validate() because they consume what it resolves --
+    # notably the DisaggregationMode enum and the benchmark sampling fields.
     cross_validate_config(dynamo_config, engine_config)
     update_dynamo_config_with_engine(dynamo_config, engine_config)
     update_engine_config_with_dynamo(dynamo_config, engine_config)
 
-    dynamo_config.engine_args = engine_config
     from .state_agent import validate_state_agent_worker
 
     validate_state_agent_worker(dynamo_config)

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from dynamo.vllm.args import parse_args
 from dynamo.vllm.backend_args import (
     DisaggregationMode,
     DynamoVllmArgGroup,
@@ -51,6 +52,10 @@ def create_config() -> DynamoVllmConfig:
     config.benchmark_mode = None
     config.use_vllm_tokenizer = False
     config.frontend_decoding = False
+    # parse_args attaches this before validate() runs, so mirror that shape
+    # here to keep the LoRA exclusivity rules on their real code path. The
+    # rules still tolerate its absence, matching a config built by hand.
+    config.engine_args = SimpleNamespace(enable_lora=False)
     return config
 
 
@@ -359,6 +364,17 @@ class TestRealtimeWorkerExclusivity:
         with pytest.raises(ValueError, match=option):
             config._validate_realtime_worker_exclusivity()
 
+    def test_absent_engine_args_reads_as_lora_disabled(self):
+        """Only parse_args attaches engine_args, so a config assembled in code
+        never has one. Treat that as LoRA disabled rather than failing on the
+        missing attribute."""
+        config = create_config()
+        del config.engine_args
+        config.realtime = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+
+        config._validate_realtime_worker_exclusivity()
+
 
 class TestClassifyWorkerExclusivity:
     """--classify-worker mirrors the embedding-worker constraints (both are
@@ -379,6 +395,16 @@ class TestClassifyWorkerExclusivity:
         config.disaggregation_mode = DisaggregationMode.AGGREGATED
         with pytest.raises(ValueError, match="mutually exclusive"):
             config._validate_classify_worker_exclusivity()
+
+    def test_absent_engine_args_reads_as_lora_disabled(self):
+        """Kept alongside the --realtime case: the two rules read engine_args
+        independently, so each needs its own missing-attribute check."""
+        config = create_config()
+        del config.engine_args
+        config.classify_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+
+        config._validate_classify_worker_exclusivity()
 
     @pytest.mark.parametrize(
         "mode",
@@ -439,6 +465,40 @@ class TestClassifyWorkerExclusivity:
         config.benchmark_mode = "agg"
         config.headless = True
         config._validate_classify_worker_exclusivity()
+
+
+class TestParseArgsLoraExclusivity:
+    """The --enable-lora exclusivity rules must fire on the real CLI path.
+
+    The tests above call the validators directly with engine_args already set,
+    so they pass even when parse_args never supplies engine_args before
+    validate() runs. These drive the whole command line instead, which is the
+    only place that ordering is observable.
+    """
+
+    @staticmethod
+    def _parse(extra_argv):
+        return parse_args(["--model", "Qwen/Qwen3-0.6B", *extra_argv])
+
+    def test_realtime_with_enable_lora_is_rejected(self):
+        with pytest.raises(ValueError, match="enable-lora"):
+            self._parse(["--realtime", "--enable-lora"])
+
+    def test_classify_worker_with_enable_lora_is_rejected(self):
+        """Kept separate from the --realtime case: the classify rule may be
+        removed once LoRA is supported on pooling-family workers, and the
+        --realtime rule is independent of that."""
+        with pytest.raises(ValueError, match="enable-lora"):
+            self._parse(["--classify-worker", "--enable-lora"])
+
+    def test_enable_lora_alone_is_accepted(self):
+        config = self._parse(["--enable-lora"])
+        assert config.engine_args.enable_lora is True
+
+    def test_realtime_alone_is_accepted(self):
+        config = self._parse(["--realtime"])
+        assert config.realtime is True
+        assert not config.engine_args.enable_lora
 
 
 class TestValidateCustomEncoder:

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -467,6 +467,7 @@ class TestClassifyWorkerExclusivity:
         config._validate_classify_worker_exclusivity()
 
 
+@pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator")
 class TestParseArgsLoraExclusivity:
     """The --enable-lora exclusivity rules must fire on the real CLI path.
 

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -14,7 +14,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.vllm.args import parse_args
 from dynamo.vllm.backend_args import (
     DisaggregationMode,
     DynamoVllmArgGroup,
@@ -479,6 +478,11 @@ class TestParseArgsLoraExclusivity:
 
     @staticmethod
     def _parse(extra_argv):
+        # Imported here, not at module top: dynamo.vllm.args pulls in vllm at
+        # import time and the release/1.5.0 dynamo-runtime image has no vllm,
+        # which broke collection of this module in the runtime-only CI jobs.
+        from dynamo.vllm.args import parse_args
+
         return parse_args(["--model", "Qwen/Qwen3-0.6B", *extra_argv])
 
     def test_realtime_with_enable_lora_is_rejected(self):


### PR DESCRIPTION
Cherry-pick of #14446 to release/1.5.0. Fixes DYN-4303 / NVBug 6726696.

Signed-off-by: Daniel Gil <dagil@nvidia.com>