### PR TITLE
fix(discovery): [cherry-pick 1.5.0] stop a rolling upgrade from hiding the model on /v1/models (#14451)

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1281,7 +1281,13 @@ fn materialization_fingerprint(
     card: &ModelDeploymentCard,
     default_router_config: &RouterConfig,
 ) -> anyhow::Result<String> {
-    let effective_router = card.router_config.as_ref().unwrap_or(default_router_config);
+    // Hash what the frontend serves with: `prepare` overlays the frontend-owned fields
+    // via `effective_router_config`, so those fields must not split a cohort.
+    let mut effective_router =
+        effective_router_config(card.router_config.as_ref(), default_router_config);
+    // Compatibility with pre-v1.4 workers advertising `enforce_disagg` during v1.5
+    // rolling upgrades. TODO(v1.6): Remove when v1.3 leaves the N-2 compatibility window.
+    effective_router.to_mut().enforce_disagg = false;
     let mut value = serde_json::to_value(card)?;
     let object = value
         .as_object_mut()
@@ -1294,7 +1300,7 @@ fn materialization_fingerprint(
     let normalized: ModelDeploymentCard = serde_json::from_value(value)?;
 
     let mut bytes = normalized.mdcsum().as_bytes().to_vec();
-    let mut router_value = serde_json::to_value(effective_router)?;
+    let mut router_value = serde_json::to_value(effective_router.as_ref())?;
     canonicalize_json(&mut router_value);
     bytes.extend(serde_json::to_vec(&router_value)?);
     Ok(blake3::hash(&bytes).to_string())
@@ -2133,6 +2139,67 @@ mod tests {
         );
         assert!(worker.kv_router_config.router_prefill_policy.is_none());
         assert!(worker.kv_router_config.router_decode_policy.is_none());
+    }
+
+    #[test]
+    fn materialization_fingerprint_joins_router_config_across_generations() {
+        use crate::session_affinity::SessionAffinityMode;
+
+        // The older generation predates `session_affinity_mode`; serde fills the absent
+        // key with `Hard`, encoding the same logical config two different ways.
+        let mut legacy_wire = serde_json::to_value(RouterConfig::default()).unwrap();
+        let legacy_object = legacy_wire.as_object_mut().unwrap();
+        legacy_object.remove("session_affinity_mode");
+        legacy_object.insert("enforce_disagg".to_string(), serde_json::json!(true));
+        let legacy_router: RouterConfig = serde_json::from_value(legacy_wire).unwrap();
+        assert_eq!(
+            legacy_router.session_affinity_mode,
+            SessionAffinityMode::Hard
+        );
+        assert!(legacy_router.enforce_disagg);
+
+        let current_router = RouterConfig {
+            session_affinity_mode: SessionAffinityMode::Soft,
+            ..RouterConfig::default()
+        };
+
+        let mut legacy = ModelDeploymentCard::with_name_only("model");
+        legacy.router_config = Some(legacy_router);
+        let mut current = ModelDeploymentCard::with_name_only("model");
+        current.router_config = Some(current_router);
+
+        // The frontend overlays its own `session_affinity_mode` and nothing reads
+        // `enforce_disagg`, so both workers serve identically and share one cohort.
+        let frontend = RouterConfig {
+            session_affinity_mode: SessionAffinityMode::Soft,
+            ..RouterConfig::default()
+        };
+        assert_eq!(
+            materialization_fingerprint(&legacy, &frontend).unwrap(),
+            materialization_fingerprint(&current, &frontend).unwrap()
+        );
+    }
+
+    #[test]
+    fn materialization_fingerprint_still_splits_on_serving_relevant_differences() {
+        let frontend = RouterConfig::default();
+
+        // `router_mode` changes how requests are placed, so two workers advertising
+        // different modes are not interchangeable.
+        let mut round_robin = ModelDeploymentCard::with_name_only("model");
+        round_robin.router_config = Some(RouterConfig {
+            router_mode: RouterMode::RoundRobin,
+            ..RouterConfig::default()
+        });
+        let mut kv = ModelDeploymentCard::with_name_only("model");
+        kv.router_config = Some(RouterConfig {
+            router_mode: RouterMode::KV,
+            ..RouterConfig::default()
+        });
+        assert_ne!(
+            materialization_fingerprint(&round_robin, &frontend).unwrap(),
+            materialization_fingerprint(&kv, &frontend).unwrap()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Cherry-pick of #14451 to release/1.5.0. Fixes DYN-4319 / NVBug 6734232.

Signed-off-by: Daniel Gil <dagil@nvidia.com>