### PR TITLE
ci(recipes): collect the recipe scaffold tests only in recipe check

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -123,7 +123,16 @@ jobs:
     - name: Check generated recipe manifests
       run: python3 scripts/kustomize-matrix.py check
     - name: Test recipe generators and docs artifacts
-      run: python3 -m pytest --noconftest tests/test_kustomize_matrix.py tests/test_generate_kustomize_openapi.py docs/tests/
+      # docs/tests is excluded from default collection in pyproject.toml so the
+      # runtime container jobs do not collect it. The shell glob expands to the
+      # test files that exist, and explicit file arguments bypass ignore-glob
+      # (a directory argument does not), so new modules are picked up without
+      # editing this list.
+      run: |
+        python3 -m pytest --noconftest \
+          tests/test_kustomize_matrix.py \
+          tests/test_generate_kustomize_openapi.py \
+          docs/tests/test_*.py
 
   api-docs:
     name: Generated API References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,12 @@ addopts = [
     "--ignore-glob=*_inc.py",
     "--ignore-glob=*/llm/tensorrtllm*",
     "--ignore-glob=docs/fern/*",
+    # docs/tests holds the recipe scaffold and validator tests. They are not
+    # Dynamo runtime tests and need Kustomize v5.8.1, so the marker-driven
+    # container jobs must not collect them; the pre-merge Recipe Check job opts
+    # back in by listing the test files explicitly (explicit file arguments
+    # bypass ignore-glob, directory arguments do not).
+    "--ignore-glob=docs/tests/*",
     # power-agent ships a standalone suite run in-image (deploy/power-agent
     # Dockerfile `test` stage + its own pytest.ini); its tests/ package name
     # collides with the repo-root tests/ package during repo-wide collection.

--- a/recipes/templates/kustomize/README.md
+++ b/recipes/templates/kustomize/README.md
@@ -356,6 +356,16 @@ python3 scripts/validate-recipe-kustomization.py \
   --kustomize-bin /explicit/path/to/kustomize
 ```
 
+The scaffold's regression tests live in `docs/tests/`. They are excluded from
+the repository's default pytest collection because they are recipe tooling
+tests, not Dynamo runtime tests, and they need Kustomize v5.8.1; the pre-merge
+Recipe Check job runs them by explicit file path. Run them the same way locally,
+with Kustomize on `PATH` or `KUSTOMIZE_BIN` set:
+
+```bash
+python3 -m pytest --noconftest docs/tests/test_*.py
+```
+
 The validator checks that the build targets exactly one beta DGD, verifies the
 canonical component positions, rejects base-owned cluster fields and duplicate
 environment names, replays the selected Component and case patch operations in


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved recipe test collection to reliably include explicitly selected test files and newly added modules.
  * Updated repository-wide test discovery to avoid unintended collection conflicts.

* **Documentation**
  * Added instructions for running scaffold regression tests, including required pytest options and Kustomize setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->