### PR TITLE
docs(recipes): add upstream vLLM image disclaimer to Qwen3.8-Flash-Next

### DIFF
--- a/docs/fern/pages/recipes/model-recipes/qwen-3-8-flash-next.mdx
+++ b/docs/fern/pages/recipes/model-recipes/qwen-3-8-flash-next.mdx
@@ -5,6 +5,8 @@ title: "Qwen3.8-Flash-Next"
 subtitle: "Serve Qwen3.8-Flash-Next with Dynamo and vLLM on B200, aggregated or disaggregated."
 ---
 
+This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+
 import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />

--- a/recipes/qwen3.8-flash-next/README.md
+++ b/recipes/qwen3.8-flash-next/README.md
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
+This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+
 # Qwen3.8-Flash-Next Recipes
 
 Recipes for [Qwen3.8-Flash-Next](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) on Dynamo + vLLM.

--- a/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic-12gpu/deploy.yaml
+++ b/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic-12gpu/deploy.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+#
 # Qwen3.8-Flash-Next on vLLM via Dynamo, aggregated, B200 (TP=4), agentic workload
 # (64K ISL / 400 OSL, 90% prefix reuse).
 #

--- a/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic-8gpu/deploy.yaml
+++ b/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic-8gpu/deploy.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+#
 # Qwen3.8-Flash-Next on vLLM via Dynamo, aggregated, B200 (TP=4), agentic workload
 # (64K ISL / 400 OSL, 90% prefix reuse).
 #

--- a/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic/deploy.yaml
+++ b/recipes/qwen3.8-flash-next/vllm/agg-b200-agentic/deploy.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+#
 # Qwen3.8-Flash-Next on vLLM via Dynamo, aggregated, B200 (TP=4), agentic workload
 # (64K ISL / 400 OSL, 90% prefix reuse).
 #

--- a/recipes/qwen3.8-flash-next/vllm/disagg-b200-agentic-2p1d/deploy.yaml
+++ b/recipes/qwen3.8-flash-next/vllm/disagg-b200-agentic-2p1d/deploy.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+#
 # Qwen3.8-Flash-Next on vLLM via Dynamo, disaggregated 2P1D, B200 (TP=4 per worker,
 # 12 GPUs total), agentic workload (64K ISL / 400 OSL, 90% prefix reuse).
 #

--- a/recipes/qwen3.8-flash-next/vllm/disagg-b200-agentic/deploy.yaml
+++ b/recipes/qwen3.8-flash-next/vllm/disagg-b200-agentic/deploy.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image’s open-source license and codec terms before use or redistribution.
+#
 # Qwen3.8-Flash-Next on vLLM via Dynamo, disaggregated 1P1D, B200 (TP=4 per worker,
 # 8 GPUs total), agentic workload (64K ISL / 400 OSL, 90% prefix reuse).
 #


### PR DESCRIPTION
## Summary

- Adds the upstream third-party vLLM container image disclaimer to the Qwen3.8-Flash-Next recipe files introduced in #14033.
- Covers the recipe README, Fern docs page, and all five deploy.yaml manifests.

## Disclaimer

> This recipe references an upstream third-party vLLM container image. NVIDIA does not publish or distribute this image. Users should review the upstream image's open-source license and codec terms before use or redistribution.

## Files updated

- \ecipes/qwen3.8-flash-next/README.md\
- \docs/fern/pages/recipes/model-recipes/qwen-3-8-flash-next.mdx\
- \ecipes/qwen3.8-flash-next/vllm/agg-b200-agentic/deploy.yaml\
- \ecipes/qwen3.8-flash-next/vllm/agg-b200-agentic-8gpu/deploy.yaml\
- \ecipes/qwen3.8-flash-next/vllm/agg-b200-agentic-12gpu/deploy.yaml\
- \ecipes/qwen3.8-flash-next/vllm/disagg-b200-agentic/deploy.yaml\
- \ecipes/qwen3.8-flash-next/vllm/disagg-b200-agentic-2p1d/deploy.yaml\

## Related

- Follow-up to #14033

## Test plan

- [x] Disclaimer placement matches the GLM-5.3-Flash recipe pattern (README after SPDX, MDX after frontmatter, deploy.yaml as comment after SPDX header)
- [ ] Docs CI / markdown lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added licensing and redistribution notices to the Qwen 3.8 Flash Next recipe documentation and deployment configurations.
  - Clarified that the referenced vLLM container image is provided by a third party and is not distributed by NVIDIA.
  - Directed users to review applicable open-source license and codec terms before using or redistributing the image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->