### PR TITLE
fix(sglang): stop the elastic-EP scale-up worker crash-looping at startup

### DIFF
--- a/tests/fault_tolerance/deploy/templates/sglang/run_sglang_elastic_ep_scale_up_test.sh
+++ b/tests/fault_tolerance/deploy/templates/sglang/run_sglang_elastic_ep_scale_up_test.sh
@@ -167,6 +167,7 @@ launch_joiner() {
       --elastic-ep-backend mooncake --mooncake-ib-device $IB_DEVICE \
       --enable-eplb --ep-num-redundant-experts 24 \
       --elastic-ep-initial-size 4 --max-ep-size 8 \
+      --cuda-graph-backend-decode disabled --cuda-graph-backend-prefill disabled \
       --elastic-ep-join-mode scale --elastic-ep-join-rank-offset $rank_offset \
       --dist-init-addr $DIST_INIT_ADDR \
       --host 127.0.0.1 --port $((30000 + rank_offset)) \

--- a/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
+++ b/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
@@ -31,6 +31,11 @@
 #     --mooncake-ib-device to the node's IB device list before applying.
 #   * DYN_SYSTEM_ENABLED=true so the leader exposes the :9090 system server that
 #     serves /engine/control/*.
+#   * BOTH the decode and the prefill CUDA graph disabled: SGLang asserts this
+#     before it permits elastic-EP runtime scale-up, and the worker exits on
+#     startup otherwise. --moe-a2a-backend nixl disables the prefill side on its
+#     own, as a side effect, but nothing disables the decode side, so both are
+#     passed explicitly below (--cuda-graph-backend-decode/-prefill disabled).
 #
 # The joining group is NOT launched by the operator yet (that orchestration is
 # tracked separately). The accompanying run_sglang_elastic_ep_scale_up_test.sh
@@ -128,6 +133,11 @@ spec:
             - "4"
             - --max-ep-size
             - "8"
+            # Elastic-EP scale-up is asserted to run with both CUDA graphs off.
+            - --cuda-graph-backend-decode
+            - disabled
+            - --cuda-graph-backend-prefill
+            - disabled
             # Stable rendezvous address the joining group dials on scale-up.
             # Sourced from SGLANG_ELASTIC_SCALE_DIST_INIT (single source of truth).
             - --dist-init-addr

--- a/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
+++ b/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
@@ -130,7 +130,6 @@ spec:
             - "4"
             - --max-ep-size
             - "8"
-            # Elastic-EP scale-up is asserted to run with both CUDA graphs off.
             - --cuda-graph-backend-decode
             - disabled
             - --cuda-graph-backend-prefill

--- a/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
+++ b/tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml
@@ -31,11 +31,8 @@
 #     --mooncake-ib-device to the node's IB device list before applying.
 #   * DYN_SYSTEM_ENABLED=true so the leader exposes the :9090 system server that
 #     serves /engine/control/*.
-#   * BOTH the decode and the prefill CUDA graph disabled: SGLang asserts this
-#     before it permits elastic-EP runtime scale-up, and the worker exits on
-#     startup otherwise. --moe-a2a-backend nixl disables the prefill side on its
-#     own, as a side effect, but nothing disables the decode side, so both are
-#     passed explicitly below (--cuda-graph-backend-decode/-prefill disabled).
+#   * BOTH the decode and the prefill CUDA graph disabled, passed explicitly
+#     below: SGLang asserts this for elastic-EP scale-up and exits on startup.
 #
 # The joining group is NOT launched by the operator yet (that orchestration is
 # tracked separately). The accompanying run_sglang_elastic_ep_scale_up_test.sh


### PR DESCRIPTION
Source issue: [DYN-4325](https://linear.app/nvidia/issue/DYN-4325).

## Overview:

SGLang will not start an elastic-EP deployment that can scale up unless both its decode and its prefill CUDA graph are disabled. A CUDA graph is a replayed, fixed-shape execution plan, and elastic EP changes that shape at runtime, so SGLang asserts the two are off during argument resolution. The elastic-EP test manifest passed no CUDA-graph flag at all, so `SGLangDecodeWorker` hit that assertion and crash-looped before serving anything.

## Details:

`tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml` now passes `--cuda-graph-backend-decode disabled` and `--cuda-graph-backend-prefill disabled` in the worker's argument list, and its header `REQUIREMENTS` comment records the precondition. `--moe-a2a-backend nixl` already disabled the prefill side as a side effect, but nothing disabled the decode side, so both phases are now set explicitly. `run_sglang_elastic_ep_scale_up_test.sh` gets the same two flags in `launch_joiner`, which its own comment already requires to match the manifest.

These per-phase flags are used instead of `--disable-cuda-graph`, which is deprecated in the pinned `sglang==0.5.19` and sits below the per-phase flags in precedence, so a later tuning flag would silently bring the crash back. The SGLang recipes under `recipes/glm-5.2/sglang/` already spell it this way.

One gap stays open: `launch_joiner` still passes no `--node-rank 1`, which SGLang asserts separately for `--elastic-ep-join-mode scale`. That is an independent defect, so this change alone does not make the scale-up script run end to end.

## Where should the reviewer start?

`tests/fault_tolerance/deploy/templates/sglang/sglang_elastic_ep.yaml`, to confirm the two flags land inside `spec.services.SGLangDecodeWorker.extraPodSpec.mainContainer.args` and not in a sibling mapping.

## Validation

This manifest needs eight 80 GiB GPUs and RDMA on a Kubernetes cluster, which was not available, and no CI job covers `tests/fault_tolerance/deploy/*`. Instead: `pre-commit run --files <the two changed files> --hook-stage manual` passed, and loading the YAML with `yaml.safe_load` confirmed the flags sit in the worker's `args` list as adjacent flag/value pairs. The assertion and the flag precedence were read from the `sglang` v0.5.19 sources named above.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue (an internal NVIDIA ticket tracks this work; it is linked at the top of this description)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of elastic expert-parallel scale-up operations by ensuring newly joined workers use compatible runtime settings, with CUDA graph backends disabled for decoding and prefilling.

- **Documentation**
  - Clarified that CUDA graph acceleration must be disabled for both decoding and prefilling during elastic scale-up scenarios.
  - Updated deployment guidance to reflect the required configuration for successful worker integration and consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->