### PR TITLE
fix(container/vllm): patch exaone_moe lm_head prefix so K-EXAONE 2.0 NVFP4 loads

### DIFF
--- a/container/deps/vllm/patches/01-exaone-moe-lm-head-prefix.patch
+++ b/container/deps/vllm/patches/01-exaone-moe-lm-head-prefix.patch
@@ -1,0 +1,38 @@
+From: Cheng Wang <chengwa@nvidia.com>
+Subject: [PATCH] fix(k-exaone-2): pass prefix to ParallelLMHead in exaone_moe so quantization exclusions match
+
+K-EXAONE-2.0-750B-A37B-NVFP4 fails to load on vLLM 0.28.0 and 0.29.0:
+
+  vocab_parallel_embedding.py weight_loader
+  RuntimeError: The size of tensor a (3072) must match the size of tensor b
+                (6144) at non-singleton dimension 1
+
+exaone_moe.py constructs ParallelLMHead without a `prefix`, so it defaults to
+"". VocabParallelEmbedding.__init__ then calls
+quant_config.get_quant_method(self, prefix=""), and
+ModelOptNvFp4Config.is_layer_excluded("") cannot match any of the checkpoint's
+223 exclusion patterns. lm_head is therefore quantized and allocated as a
+packed NVFP4 param [vocab, hidden/2] = [.., 3072], which rejects the
+checkpoint's unquantized BF16 lm_head.weight [153600, 6144].
+
+Verified CPU-only against the checkpoint's own quantization config:
+  is_layer_excluded('lm_head') = True   is_layer_excluded('') = False
+  get_quant_method(ParallelLMHead, prefix='lm_head') -> UnquantizedLinearMethod
+  get_quant_method(ParallelLMHead, prefix='')        -> NVFP4 linear method
+
+The file already imports maybe_prefix and already uses it for "model" a few
+lines above. qwen3_moe.py and exaone4.py (same model family) both pass the
+prefix correctly; exaone_moe.py is the outlier.
+
+Only manifests for checkpoints that exclude lm_head from quantization, which is
+why BF16-validated upstream support PRs never hit it.
+
+--- a/vllm/model_executor/models/exaone_moe.py
++++ b/vllm/model_executor/models/exaone_moe.py
+@@ -521,5 +521,6 @@
+                 else lora_config.lora_vocab_padding_size,
+                 quant_config=quant_config,
++                prefix=maybe_prefix(prefix, "lm_head"),
+             )
+             if config.tie_word_embeddings:
+                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -264,6 +264,16 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" %}
+# Apply vLLM hotfixes to the installed package tree. Patches are applied with
+# --fuzz=5 to tolerate minor line-number drift across nightly builds.
+RUN --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
+    SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    for p in $(ls /tmp/vllm_patches/*.patch 2>/dev/null | sort); do \
+        patch --fuzz=5 -p1 -d "${SITE_PACKAGES}" < "$p"; \
+    done
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
## Summary

`LGAI-EXAONE/K-EXAONE-2.0-750B-A37B-NVFP4` cannot be served on vLLM **0.28.0 or 0.29.0** — it fails during weight load:

```
vllm/model_executor/layers/vocab_parallel_embedding.py  weight_loader
RuntimeError: The size of tensor a (3072) must match the size of tensor b (6144)
              at non-singleton dimension 1
```

This adds the vLLM patch directory plus the apply step, and one patch fixing it.

## Root cause

`vllm/model_executor/models/exaone_moe.py` constructs `ParallelLMHead` **without a `prefix`**, so it defaults to `""`. `VocabParallelEmbedding.__init__` then calls `quant_config.get_quant_method(self, prefix="")`, and `ModelOptNvFp4Config.is_layer_excluded("")` matches none of the checkpoint's 223 exclusion patterns. `lm_head` is therefore quantized and allocated as a **packed NVFP4** param `[vocab, hidden/2]` = `[.., 3072]`, which rejects the checkpoint's unquantized BF16 `lm_head.weight` `[153600, 6144]`.

Verified CPU-only against the checkpoint's own quantization config:

```
exclude_modules: 223
is_layer_excluded('lm_head') = True
is_layer_excluded('')        = False
get_quant_method(ParallelLMHead, prefix='lm_head') -> UnquantizedLinearMethod
get_quant_method(ParallelLMHead, prefix='')        -> NVFP4 linear method
```

The header weights confirm the checkpoint is correct — `lm_head.weight` and `model.embed_tokens.weight` are both `BF16 [153600, 6144]`, and both are listed in `ignore` / `exclude_modules`.

This only manifests for checkpoints that **exclude `lm_head` from quantization**, which is why BF16-validated upstream support PRs never hit it.

## Changes

- `container/deps/vllm/patches/` + apply step in `vllm_runtime.Dockerfile` (`patch --fuzz=5 -p1` into site-packages, filename order, cuda only) — same mechanism used for the SGLang/vLLM hotfixes elsewhere.
- `01-exaone-moe-lm-head-prefix.patch` — adds `prefix=maybe_prefix(prefix, "lm_head")`.

## Test plan / results

| config | patch | result |
|---|---|---|
| Dynamo DGD, `--quantization modelopt_fp4` | no | crash @ shard 53 |
| Dynamo DGD, flag removed | no | crash @ shard 53 |
| raw vLLM 0.29.0 | no | crash @ shard 53 |
| raw `vllm serve` 0.28.0 | **yes** | 53/53 shards, KV 3,475,818 tokens, `finish_reason=stop`, coherent |
| Dynamo DGD (vllm-runtime-nightly) B200 TP4 | **yes** | worker Ready, coherent through frontend |

Patch verified to apply at **exact offsets** to vLLM 0.28.0 (no fuzz needed).

## Upstream

The real fix belongs in vLLM: `exaone_moe.py` already imports `maybe_prefix` and uses it for `"model"` a few lines above, and `qwen3_moe.py` / `exaone4.py` both pass the prefix correctly — `exaone_moe.py` is the outlier. Current vLLM `main` is still unfixed (and has since dropped `org_num_embeddings`/`padding_size` from the same call). I'll file the upstream one-liner; this patch is a bridge until it lands and a base image carries it.

## Note

Draft to trigger the build pipeline. Overlaps in intent with #12513, which introduces the same patch directory on its own branch — whichever merges second needs a trivial renumber/rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)