### PR TITLE
feat(epp): add concurrent SGLang prefill/decode adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,6 +2525,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.4",
+ "eventsource-stream",
  "futures",
  "reqwest 0.12.28",
  "serde",
@@ -2535,6 +2536,7 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3380,6 +3382,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 

--- a/deploy/inference-gateway/sidecar/Cargo.toml
+++ b/deploy/inference-gateway/sidecar/Cargo.toml
@@ -19,15 +19,17 @@ path = "src/bin/dynamo-epp-sidecar.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
+eventsource-stream = "0.2.3"
 futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+uuid = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 tower = { version = "0.5", features = ["util"] }

--- a/deploy/inference-gateway/sidecar/README.md
+++ b/deploy/inference-gateway/sidecar/README.md
@@ -31,6 +31,63 @@ shutdown before their streams are forced closed. Configure this deadline with
 while the sidecar accepts requests and `503 Service Unavailable` once draining
 starts. Readiness does not indicate that EPP endpoint propagation is complete.
 
-Backend-specific P/D execution is implemented separately. Until an adapter is
-linked, requests containing a valid prefill endpoint return `501 Not
-Implemented`; decode-only passthrough remains available.
+The default `DYN_SIDECAR_PD_BACKEND=unavailable` keeps backend P/D execution
+disabled: requests containing a valid prefill endpoint return `501 Not
+Implemented`, while decode-only passthrough remains available. Set
+`DYN_SIDECAR_PD_BACKEND=sglang` to enable the SGLang adapter. Other values are
+rejected at startup.
+
+## SGLang Prefill/Decode Adapter
+
+The adapter supports the native `/v1/chat/completions` protocol in SGLang
+release **0.5.19**. For every disaggregated request, it checks both workers'
+`GET /server_info` responses for the supported version and the expected
+`prefill` or `decode` mode. Other releases and mismatched worker roles are
+rejected before inference dispatch. Decode-only passthrough does not use this
+adapter or require these probes.
+Streaming responses must use SGLang's BOM-free UTF-8 SSE format.
+
+The selected prefill HTTP endpoint comes from EPP's authoritative
+`x-prefiller-host-port` header. Gateway must remove any client-supplied value
+before EPP sets this header; the sidecar must not be exposed directly to
+untrusted callers. The bootstrap host comes from that endpoint,
+and the bootstrap port comes from the prefill worker's server information.
+The adapter replaces client-supplied bootstrap fields and `rid` values with
+sidecar-owned request IDs and one trusted bootstrap tuple shared by both
+workers. It preserves the original messages, sampling settings, and streaming
+mode. Parallel sampling is limited to `n=1` (including the default when `n` is
+omitted).
+
+Prefill and decode requests start concurrently. Only decode response bytes
+reach Gateway, and only after the adapter has consumed and validated the full
+prefill response, including successful termination of a JSON or SSE response.
+An error event or an `abort` finish reason is a failure even with HTTP `200`.
+While prefill is pending, the adapter also reads and checks decode's response
+body so decode errors can cancel prefill promptly. It retains the exact bytes
+read ahead and forwards them before the remaining decode stream.
+The sidecar emits no synthetic SSE preamble. Prefill failure, decode failure,
+client cancellation, and response-stream teardown cancel the paired work.
+The workers transfer KV bytes directly; the sidecar never proxies KV payloads.
+
+The original request and the complete prefill response are each limited to
+32 MiB; each server-information response is limited to 1 MiB. The decode
+prefix read before prefill completes is also limited to 32 MiB. Exceeding that
+limit cancels both legs; after prefill completion, decode streaming has no
+total-response-size limit. The configured
+connection and idle-read timeouts also apply to adapter upstream requests.
+Inference HTTP errors retain their status and `Retry-After` header in an
+OpenAI-style error response. Discovery and protocol failures return `502`;
+upstream network timeouts return `504`.
+
+Cancellation closes upstream connections and attempts explicit backend aborts
+with a five-second deadline. These aborts are best effort: an HTTP `200` from
+the abort endpoint does not establish that backend execution or KV transfer
+has stopped. The workers must have no separate `admin_api_key`, or the
+forwarded inference authorization must also grant access to the abort
+endpoint. Shutdown waits for the adapter's outstanding cleanup attempts after
+HTTP request draining completes.
+
+EPP owns worker selection and paired reservation accounting. The adapter uses
+the shared request, response, and cancellation contract; it does not create or
+release EPP reservations itself. A complete GAIE/EPP deployment and real-GPU
+KV-transfer validation are outside the adapter's current validation boundary.

--- a/deploy/inference-gateway/sidecar/src/bin/dynamo-epp-sidecar.rs
+++ b/deploy/inference-gateway/sidecar/src/bin/dynamo-epp-sidecar.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use dynamo_epp_sidecar::{Config, UnavailablePdAdapter};
+use dynamo_epp_sidecar::{Config, PdAdapter, PdBackend, SglangPdAdapter, UnavailablePdAdapter};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -11,5 +11,14 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
-    dynamo_epp_sidecar::run(Config::from_env()?, Arc::new(UnavailablePdAdapter)).await
+    let config = Config::from_env()?;
+    let adapter: Arc<dyn PdAdapter> = match config.pd_backend {
+        PdBackend::Unavailable => Arc::new(UnavailablePdAdapter),
+        PdBackend::Sglang => Arc::new(SglangPdAdapter::new(
+            config.decode_engine_url.clone(),
+            config.connect_timeout,
+            config.read_timeout,
+        )?),
+    };
+    dynamo_epp_sidecar::run(config, adapter).await
 }

--- a/deploy/inference-gateway/sidecar/src/config.rs
+++ b/deploy/inference-gateway/sidecar/src/config.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ffi::OsString;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -12,15 +14,37 @@ const DECODE_ENGINE_PORT_ENV: &str = "DYN_DECODE_ENGINE_PORT";
 const CONNECT_TIMEOUT_MS_ENV: &str = "DYN_SIDECAR_CONNECT_TIMEOUT_MS";
 const READ_TIMEOUT_MS_ENV: &str = "DYN_SIDECAR_READ_TIMEOUT_MS";
 const DRAIN_TIMEOUT_MS_ENV: &str = "DYN_SIDECAR_DRAIN_TIMEOUT_MS";
+const PD_BACKEND_ENV: &str = "DYN_SIDECAR_PD_BACKEND";
 
 const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_READ_TIMEOUT_MS: u64 = 300_000;
 const DEFAULT_DRAIN_TIMEOUT_MS: u64 = 30_000;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PdBackend {
+    #[default]
+    Unavailable,
+    Sglang,
+}
+
+impl FromStr for PdBackend {
+    type Err = anyhow::Error;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw {
+            "unavailable" => Ok(Self::Unavailable),
+            "sglang" => Ok(Self::Sglang),
+            _ => bail!("{PD_BACKEND_ENV} must be unavailable or sglang, got {raw:?}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub listen_addr: SocketAddr,
     pub decode_engine_url: Url,
+    /// Backend protocol used when EPP selects a prefill endpoint.
+    pub pd_backend: PdBackend,
     /// Maximum time allowed to establish a connection to the decode engine.
     pub connect_timeout: Duration,
     /// Maximum idle time between reads from a streaming decode response.
@@ -37,11 +61,21 @@ impl Config {
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), sidecar_port),
             decode_engine_url: Url::parse(&format!("http://localhost:{decode_engine_port}"))
                 .context("failed to construct local decode-engine URL")?,
+            pd_backend: pd_backend_from_value(std::env::var_os(PD_BACKEND_ENV))?,
             connect_timeout: duration_from_env(CONNECT_TIMEOUT_MS_ENV, DEFAULT_CONNECT_TIMEOUT_MS)?,
             read_timeout: duration_from_env(READ_TIMEOUT_MS_ENV, DEFAULT_READ_TIMEOUT_MS)?,
             drain_timeout: duration_from_env(DRAIN_TIMEOUT_MS_ENV, DEFAULT_DRAIN_TIMEOUT_MS)?,
         })
     }
+}
+
+fn pd_backend_from_value(value: Option<OsString>) -> Result<PdBackend> {
+    let Some(raw) = value else {
+        return Ok(PdBackend::default());
+    };
+    raw.into_string()
+        .map_err(|_| anyhow::anyhow!("{PD_BACKEND_ENV} must be valid UTF-8"))?
+        .parse()
 }
 
 fn duration_from_env(name: &str, default_ms: u64) -> Result<Duration> {
@@ -74,4 +108,46 @@ fn port_from_env(name: &str, default: u16) -> Result<u16> {
         bail!("{name} must be greater than zero");
     }
     Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pd_backend_defaults_to_unavailable() {
+        assert_eq!(pd_backend_from_value(None).unwrap(), PdBackend::Unavailable);
+    }
+
+    #[test]
+    fn pd_backend_requires_an_explicit_supported_name() {
+        assert_eq!(
+            pd_backend_from_value(Some("sglang".into())).unwrap(),
+            PdBackend::Sglang
+        );
+        assert_eq!(
+            pd_backend_from_value(Some("unavailable".into())).unwrap(),
+            PdBackend::Unavailable
+        );
+        for raw in ["", "SGLang", "vllm", " sglang", "sglang "] {
+            assert!(
+                pd_backend_from_value(Some(raw.into()))
+                    .unwrap_err()
+                    .to_string()
+                    .contains(PD_BACKEND_ENV)
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pd_backend_rejects_non_utf8_values() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let error = pd_backend_from_value(Some(OsString::from_vec(vec![0xff]))).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("{PD_BACKEND_ENV} must be valid UTF-8")
+        );
+    }
 }

--- a/deploy/inference-gateway/sidecar/src/error.rs
+++ b/deploy/inference-gateway/sidecar/src/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::Json;
-use axum::http::StatusCode;
+use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 
@@ -23,6 +23,11 @@ pub enum SidecarError {
         status: StatusCode,
         code: &'static str,
         message: String,
+    },
+    #[error("P/D engine rejected the request with HTTP {status}")]
+    EngineRejected {
+        status: StatusCode,
+        retry_after: Option<HeaderValue>,
     },
 }
 
@@ -67,6 +72,11 @@ impl SidecarError {
                 code,
                 message,
             } => (status, code, message),
+            Self::EngineRejected { status, .. } => (
+                status,
+                "pd_engine_rejected",
+                format!("The P/D engine rejected the request with HTTP {status}"),
+            ),
         }
     }
 }
@@ -87,9 +97,13 @@ struct ErrorBody {
 impl IntoResponse for SidecarError {
     fn into_response(self) -> Response {
         let error = self.to_string();
+        let retry_after = match &self {
+            Self::EngineRejected { retry_after, .. } => retry_after.clone(),
+            _ => None,
+        };
         let (status, code, message) = self.into_response_fields();
         tracing::warn!(%error, %status, code, "Sidecar request failed");
-        (
+        let mut response = (
             status,
             Json(ErrorEnvelope {
                 error: ErrorBody {
@@ -100,6 +114,12 @@ impl IntoResponse for SidecarError {
                 },
             }),
         )
-            .into_response()
+            .into_response();
+        if let Some(retry_after) = retry_after {
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, retry_after);
+        }
+        response
     }
 }

--- a/deploy/inference-gateway/sidecar/src/lib.rs
+++ b/deploy/inference-gateway/sidecar/src/lib.rs
@@ -6,11 +6,13 @@ pub mod error;
 pub mod metadata;
 mod proxy;
 pub mod server;
+pub mod sglang;
 
-pub use config::Config;
+pub use config::{Config, PdBackend};
 pub use error::SidecarError;
 pub use metadata::{PREFILLER_HOST_PORT, PrefillEndpoint};
 pub use server::{PdAdapter, SidecarState, UnavailablePdAdapter, router};
+pub use sglang::SglangPdAdapter;
 
 use std::future::IntoFuture;
 use std::sync::Arc;
@@ -20,6 +22,12 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 pub async fn run(config: Config, adapter: Arc<dyn PdAdapter>) -> Result<()> {
+    let result = serve(config, adapter.clone()).await;
+    adapter.shutdown().await;
+    result
+}
+
+async fn serve(config: Config, adapter: Arc<dyn PdAdapter>) -> Result<()> {
     let listener = TcpListener::bind(config.listen_addr).await?;
     tracing::info!(listen_addr = %config.listen_addr, "Starting EPP decode sidecar");
     let draining = CancellationToken::new();

--- a/deploy/inference-gateway/sidecar/src/proxy.rs
+++ b/deploy/inference-gateway/sidecar/src/proxy.rs
@@ -52,7 +52,7 @@ pub async fn forward(
     Ok(response)
 }
 
-fn target_url(base_url: &Url, request_uri: &axum::http::Uri) -> Url {
+pub(crate) fn target_url(base_url: &Url, request_uri: &axum::http::Uri) -> Url {
     let mut target = base_url.clone();
     let base_path = base_url.path().trim_end_matches('/');
     let request_path = request_uri.path();
@@ -62,7 +62,7 @@ fn target_url(base_url: &Url, request_uri: &axum::http::Uri) -> Url {
     target
 }
 
-fn strip_proxy_headers(headers: &mut HeaderMap) {
+pub(crate) fn strip_proxy_headers(headers: &mut HeaderMap) {
     headers.remove(header::HOST);
     headers.remove(header::CONTENT_LENGTH);
 

--- a/deploy/inference-gateway/sidecar/src/server.rs
+++ b/deploy/inference-gateway/sidecar/src/server.rs
@@ -25,6 +25,9 @@ pub trait PdAdapter: Send + Sync + 'static {
         prefill_endpoint: PrefillEndpoint,
         cancellation: CancellationToken,
     ) -> Result<Response<Body>, SidecarError>;
+
+    /// Wait for backend cleanup after the HTTP server exits.
+    async fn shutdown(&self) {}
 }
 
 #[derive(Debug, Default)]

--- a/deploy/inference-gateway/sidecar/src/sglang.rs
+++ b/deploy/inference-gateway/sidecar/src/sglang.rs
@@ -1,0 +1,659 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::body::{Body, Bytes};
+use axum::http::{HeaderMap, Request, Response, StatusCode, header};
+use eventsource_stream::{EventStreamError, Eventsource};
+use futures::{Stream, StreamExt, stream};
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
+use tokio_util::task::TaskTracker;
+use uuid::Uuid;
+
+use crate::error::SidecarError;
+use crate::metadata::PrefillEndpoint;
+use crate::proxy::{strip_proxy_headers, target_url};
+use crate::server::PdAdapter;
+
+const SUPPORTED_VERSION: &str = "0.5.19";
+const MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
+const MAX_SERVER_INFO_BYTES: usize = 1024 * 1024;
+const ABORT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// OpenAI HTTP P/D adapter for the SGLang 0.5.19 release protocol.
+pub struct SglangPdAdapter {
+    client: Client,
+    decode_engine_url: Url,
+    cleanup: TaskTracker,
+}
+
+impl SglangPdAdapter {
+    pub fn new(
+        decode_engine_url: Url,
+        connect_timeout: Duration,
+        read_timeout: Duration,
+    ) -> Result<Self, reqwest::Error> {
+        Ok(Self {
+            client: Client::builder()
+                .no_proxy()
+                .redirect(reqwest::redirect::Policy::none())
+                .connect_timeout(connect_timeout)
+                .read_timeout(read_timeout)
+                .build()?,
+            decode_engine_url,
+            cleanup: TaskTracker::new(),
+        })
+    }
+
+    async fn dispatch(
+        &self,
+        request: Request<Body>,
+        prefill_endpoint: PrefillEndpoint,
+        cancellation: CancellationToken,
+    ) -> Result<Response<Body>, SidecarError> {
+        let (parts, body) = request.into_parts();
+        let bytes = read_request(body).await?;
+        let mut payload: Value = serde_json::from_slice(&bytes).map_err(|_| {
+            SidecarError::adapter(
+                StatusCode::BAD_REQUEST,
+                "invalid_pd_request",
+                "P/D requests must contain a JSON object",
+            )
+        })?;
+        let object = payload.as_object_mut().ok_or_else(|| {
+            SidecarError::adapter(
+                StatusCode::BAD_REQUEST,
+                "invalid_pd_request",
+                "P/D requests must contain a JSON object",
+            )
+        })?;
+        if object.get("n").is_some_and(|n| n.as_u64() != Some(1)) {
+            return Err(SidecarError::adapter(
+                StatusCode::BAD_REQUEST,
+                "unsupported_pd_sampling",
+                "SGLang P/D requests currently support only n=1",
+            ));
+        }
+        let streaming = match object.get("stream") {
+            None | Some(Value::Null) => false,
+            Some(Value::Bool(value)) => *value,
+            _ => {
+                return Err(SidecarError::adapter(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_pd_request",
+                    "stream must be a boolean",
+                ));
+            }
+        };
+
+        let prefill_url = Url::parse(&format!("http://{prefill_endpoint}"))
+            .map_err(|_| protocol_error("Selected prefill endpoint is not a valid HTTP URL"))?;
+        let mut headers = parts.headers;
+        strip_proxy_headers(&mut headers);
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        // Discovery and cancellation only need backend credentials, not
+        // inference-specific headers or a client-controlled request identifier.
+        let mut control_headers = HeaderMap::new();
+        if let Some(authorization) = headers.get(header::AUTHORIZATION) {
+            control_headers.insert(header::AUTHORIZATION, authorization.clone());
+        }
+        let (prefill_info, _) = tokio::try_join!(
+            self.server_info(&prefill_url, &control_headers, "prefill"),
+            self.server_info(&self.decode_engine_url, &control_headers, "decode"),
+        )?;
+        let bootstrap_port = prefill_info
+            .disaggregation_bootstrap_port
+            .filter(|port| *port != 0)
+            .ok_or_else(|| {
+                protocol_error("Prefill engine did not advertise a valid bootstrap port")
+            })?;
+        let host = prefill_endpoint.authority().host();
+        let host = host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(host);
+        let rid = Uuid::new_v4().simple().to_string();
+        let room = (Uuid::new_v4().as_u128() & i64::MAX as u128) as u64;
+        object.insert("bootstrap_host".into(), json!(host));
+        object.insert("bootstrap_port".into(), json!(bootstrap_port));
+        object.insert("bootstrap_room".into(), json!(room));
+        object.insert("rid".into(), json!(rid));
+        let bytes = Bytes::from(serde_json::to_vec(&payload).expect("JSON values serialize"));
+
+        let prefill_guard = self.abort_guard(&prefill_url, &control_headers, &rid, "prefill");
+        let decode_guard =
+            self.abort_guard(&self.decode_engine_url, &control_headers, &rid, "decode");
+        // Both requests are polled together. Prefill completion, not its HTTP
+        // headers, is the gate for exposing any decode response to Gateway.
+        let prefill = async {
+            let mut guard = prefill_guard;
+            let response = self
+                .client
+                .post(target_url(&prefill_url, &parts.uri))
+                .headers(headers.clone())
+                .body(bytes.clone())
+                .send()
+                .await
+                .map_err(|error| upstream_error(error, "prefill"))?;
+            require_inference_success(&response)?;
+            let bytes = read_limited(response, MAX_BODY_BYTES, "prefill").await?;
+            validate_prefill(bytes, streaming).await?;
+            guard.complete();
+            Ok::<_, SidecarError>(())
+        };
+        let decode = async {
+            let guard = decode_guard;
+            let response = self
+                .client
+                .post(target_url(&self.decode_engine_url, &parts.uri))
+                .headers(headers.clone())
+                .body(bytes.clone())
+                .send()
+                .await
+                .map_err(|error| upstream_error(error, "decode"))?;
+            require_inference_success(&response)?;
+            Ok::<_, SidecarError>((response, guard))
+        };
+        tokio::pin!(prefill, decode);
+        let mut prefill_done = false;
+        let (decode_response, mut guard) = tokio::select! {
+            result = &mut prefill => {
+                result?;
+                prefill_done = true;
+                decode.await?
+            }
+            result = &mut decode => result?,
+        };
+        let status = decode_response.status();
+        let mut headers = decode_response.headers().clone();
+        strip_proxy_headers(&mut headers);
+        let mut decode_bytes: DecodeBytes = Box::pin(decode_response.bytes_stream());
+        let mut prefix = Vec::new();
+        if !prefill_done {
+            // Decode can fail after its 200 headers, while prefill is still
+            // transferring KV. Observe both bodies until prefill completes.
+            tokio::select! {
+                result = &mut prefill => result?,
+                result = prefetch_decode(&mut decode_bytes, &mut prefix, streaming) => {
+                    result?;
+                    guard.complete();
+                    prefill.await?;
+                }
+            }
+        }
+        let prefix = stream::iter((!prefix.is_empty()).then(|| Ok(Bytes::from(prefix))));
+        let body = Body::from_stream(DecodeStream {
+            inner: Some(Box::pin(prefix.chain(decode_bytes))),
+            guard: Some(guard),
+            cancelled: Box::pin(cancellation.cancelled_owned()),
+        });
+        let mut response = Response::new(body);
+        *response.status_mut() = status;
+        *response.headers_mut() = headers;
+        Ok(response)
+    }
+
+    async fn server_info(
+        &self,
+        base_url: &Url,
+        headers: &HeaderMap,
+        role: &'static str,
+    ) -> Result<ServerInfo, SidecarError> {
+        let response = self
+            .client
+            .get(target_url(base_url, &"/server_info".parse().unwrap()))
+            .headers(headers.clone())
+            .send()
+            .await
+            .map_err(|error| upstream_error(error, role))?;
+        require_success(&response, role)?;
+        let bytes = read_limited(response, MAX_SERVER_INFO_BYTES, role).await?;
+        let info: ServerInfo = serde_json::from_slice(&bytes)
+            .map_err(|_| protocol_error("Invalid SGLang /server_info response"))?;
+        if info.version != SUPPORTED_VERSION || info.disaggregation_mode != role {
+            return Err(protocol_error(&format!(
+                "The {role} engine must run SGLang {SUPPORTED_VERSION} in {role} mode"
+            )));
+        }
+        Ok(info)
+    }
+
+    fn abort_guard(
+        &self,
+        base_url: &Url,
+        headers: &HeaderMap,
+        rid: &str,
+        role: &'static str,
+    ) -> AbortOnDrop {
+        AbortOnDrop {
+            pending: true,
+            client: self.client.clone(),
+            cleanup: self.cleanup.clone(),
+            url: target_url(base_url, &"/abort_request".parse().unwrap()),
+            headers: headers.clone(),
+            rid: rid.to_owned(),
+            role,
+        }
+    }
+}
+
+#[async_trait]
+impl PdAdapter for SglangPdAdapter {
+    async fn execute(
+        &self,
+        request: Request<Body>,
+        prefill_endpoint: PrefillEndpoint,
+        cancellation: CancellationToken,
+    ) -> Result<Response<Body>, SidecarError> {
+        tokio::select! {
+            result = self.dispatch(request, prefill_endpoint, cancellation.clone()) => result,
+            () = cancellation.cancelled() => Err(SidecarError::Cancelled),
+        }
+    }
+
+    async fn shutdown(&self) {
+        self.cleanup.close();
+        self.cleanup.wait().await;
+    }
+}
+
+#[derive(Deserialize)]
+struct ServerInfo {
+    version: String,
+    disaggregation_mode: String,
+    disaggregation_bootstrap_port: Option<u16>,
+}
+
+fn protocol_error(message: &str) -> SidecarError {
+    SidecarError::adapter(StatusCode::BAD_GATEWAY, "sglang_pd_protocol_error", message)
+}
+
+fn upstream_error(error: reqwest::Error, role: &str) -> SidecarError {
+    let status = if error.is_timeout() {
+        StatusCode::GATEWAY_TIMEOUT
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+    SidecarError::adapter(
+        status,
+        "sglang_pd_upstream_error",
+        format!("The {role} engine request failed"),
+    )
+}
+
+fn require_success(response: &reqwest::Response, role: &str) -> Result<(), SidecarError> {
+    if !response.status().is_success() {
+        return Err(SidecarError::adapter(
+            StatusCode::BAD_GATEWAY,
+            "sglang_pd_upstream_error",
+            format!("The {role} engine returned HTTP {}", response.status()),
+        ));
+    }
+    Ok(())
+}
+
+fn require_inference_success(response: &reqwest::Response) -> Result<(), SidecarError> {
+    let status = response.status();
+    if status.is_client_error() || status.is_server_error() {
+        return Err(SidecarError::EngineRejected {
+            status,
+            retry_after: response.headers().get(header::RETRY_AFTER).cloned(),
+        });
+    }
+    require_success(response, "P/D")
+}
+
+async fn read_limited(
+    mut response: reqwest::Response,
+    limit: usize,
+    role: &str,
+) -> Result<Bytes, SidecarError> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| upstream_error(error, role))?
+    {
+        if chunk.len() > limit.saturating_sub(bytes.len()) {
+            return Err(protocol_error(&format!(
+                "The {role} engine response exceeded its size limit"
+            )));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(bytes))
+}
+
+async fn validate_prefill(bytes: Bytes, streaming: bool) -> Result<(), SidecarError> {
+    if !streaming {
+        return if validate_completion_json(&bytes, "prefill")? {
+            Ok(())
+        } else {
+            Err(protocol_error("Prefill response has no completed choice"))
+        };
+    }
+    validate_event_stream(stream::iter([Ok(bytes)]), "prefill").await
+}
+
+async fn prefetch_decode(
+    source: &mut DecodeBytes,
+    prefix: &mut Vec<u8>,
+    streaming: bool,
+) -> Result<(), SidecarError> {
+    // The parser borrows the source. On prefill completion it is dropped, but
+    // all bytes it consumed (including partial events/UTF-8) remain in prefix.
+    let mut recorded = source.map(|chunk| {
+        let chunk = chunk.map_err(|error| upstream_error(error, "decode"))?;
+        if chunk.len() > MAX_BODY_BYTES.saturating_sub(prefix.len()) {
+            return Err(protocol_error(
+                "Decode prefix exceeded 32 MiB before prefill completed",
+            ));
+        }
+        prefix.extend_from_slice(&chunk);
+        Ok(chunk)
+    });
+    if streaming {
+        validate_event_stream(recorded, "decode").await
+    } else {
+        while let Some(chunk) = recorded.next().await {
+            chunk?;
+        }
+        if !validate_completion_json(prefix, "decode")? {
+            return Err(protocol_error("Decode response has no completed choice"));
+        }
+        Ok(())
+    }
+}
+
+async fn validate_event_stream<S>(source: S, role: &str) -> Result<(), SidecarError>
+where
+    S: Stream<Item = Result<Bytes, SidecarError>> + Unpin,
+{
+    // eventsource-stream 0.2.3 slices a leading BOM at byte 1 and panics.
+    // SGLang emits no BOM; reject it before the parser sees its third byte,
+    // including when the UTF-8 sequence is split across HTTP chunks.
+    let mut first_bytes: Vec<u8> = Vec::new();
+    let checked = source.map(|chunk| {
+        let chunk = chunk?;
+        first_bytes.extend(chunk.iter().take(3 - first_bytes.len()));
+        if first_bytes == [0xef, 0xbb, 0xbf] {
+            return Err(protocol_error(
+                "SGLang event streams must not start with a UTF-8 BOM",
+            ));
+        }
+        Ok(chunk)
+    });
+    let mut events = checked.eventsource();
+    let mut done = false;
+    let mut finished = false;
+    while let Some(event) = events.next().await {
+        let event = event.map_err(|error| match error {
+            EventStreamError::Transport(error) => error,
+            _ => protocol_error(&format!("Invalid {role} event stream")),
+        })?;
+        if done {
+            return Err(protocol_error(&format!(
+                "The {role} engine sent data after [DONE]"
+            )));
+        }
+        if event.data == "[DONE]" {
+            done = true;
+        } else {
+            finished |= validate_completion_json(event.data.as_bytes(), role)?;
+        }
+    }
+    if !done || !finished {
+        return Err(protocol_error(&format!(
+            "The {role} event stream ended without a completed choice and [DONE]"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_completion_json(bytes: &[u8], role: &str) -> Result<bool, SidecarError> {
+    let value: Value = serde_json::from_slice(bytes)
+        .map_err(|_| protocol_error(&format!("Invalid {role} JSON response")))?;
+    if !value.is_object()
+        || value.get("object").and_then(Value::as_str) == Some("error")
+        || value.get("error").is_some_and(|error| !error.is_null())
+        || value
+            .get("choices")
+            .and_then(Value::as_array)
+            .is_some_and(|choices| {
+                choices.iter().any(|choice| {
+                    choice.get("finish_reason").and_then(Value::as_str) == Some("abort")
+                })
+            })
+    {
+        return Err(protocol_error(&format!(
+            "The {role} engine reported an error"
+        )));
+    }
+    Ok(value
+        .get("choices")
+        .and_then(Value::as_array)
+        .is_some_and(|choices| {
+            choices.iter().any(|choice| {
+                choice
+                    .get("finish_reason")
+                    .and_then(Value::as_str)
+                    .is_some_and(|reason| {
+                        matches!(
+                            reason,
+                            "stop" | "length" | "tool_calls" | "function_call" | "content_filter"
+                        )
+                    })
+            })
+        }))
+}
+
+async fn read_request(body: Body) -> Result<Bytes, SidecarError> {
+    let mut chunks = body.into_data_stream();
+    let mut bytes = Vec::new();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.map_err(|_| {
+            SidecarError::adapter(
+                StatusCode::BAD_REQUEST,
+                "invalid_pd_request",
+                "Cannot read P/D request body",
+            )
+        })?;
+        if chunk.len() > MAX_BODY_BYTES.saturating_sub(bytes.len()) {
+            return Err(SidecarError::adapter(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "invalid_pd_request",
+                "P/D request exceeds the 32 MiB limit",
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(bytes))
+}
+
+// Each guard owns one leg, including a leg whose HTTP send future is dropped.
+// Abort is best effort: SGLang ignores unknown rids, so closing the original
+// connection is also required; a successful abort HTTP status is not an ack
+// that model execution has stopped.
+struct AbortOnDrop {
+    pending: bool,
+    client: Client,
+    cleanup: TaskTracker,
+    url: Url,
+    headers: HeaderMap,
+    rid: String,
+    role: &'static str,
+}
+
+impl AbortOnDrop {
+    fn complete(&mut self) {
+        self.pending = false;
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if !self.pending {
+            return;
+        }
+        let request = self
+            .client
+            .post(self.url.clone())
+            .headers(self.headers.clone())
+            .json(&json!({"rid": self.rid, "abort_all": false}))
+            .timeout(ABORT_TIMEOUT);
+        let role = self.role;
+        self.cleanup.spawn(async move {
+            match request.send().await {
+                Ok(response) if response.status().is_success() => {}
+                Ok(response) => {
+                    tracing::warn!(role, status = %response.status(), "SGLang abort was rejected")
+                }
+                Err(_) => tracing::warn!(role, "SGLang abort request failed"),
+            }
+        });
+    }
+}
+
+type DecodeBytes = Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>;
+
+struct DecodeStream {
+    // Drop the connection before scheduling the best-effort abort.
+    inner: Option<DecodeBytes>,
+    guard: Option<AbortOnDrop>,
+    cancelled: Pin<Box<WaitForCancellationFutureOwned>>,
+}
+
+impl Stream for DecodeStream {
+    type Item = Result<Bytes, reqwest::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if std::future::Future::poll(self.cancelled.as_mut(), cx).is_ready() {
+            self.inner.take();
+            self.guard.take();
+            return Poll::Ready(None);
+        }
+        let Some(inner) = self.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match inner.as_mut().poll_next(cx) {
+            Poll::Ready(None) => {
+                if let Some(mut guard) = self.guard.take() {
+                    guard.complete();
+                }
+                self.inner.take();
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.inner.take();
+                self.guard.take();
+                Poll::Ready(Some(Err(error)))
+            }
+            result => result,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn accepts_complete_prefill_json_and_sse() {
+        validate_prefill(
+            Bytes::from_static(br#"{"choices":[{"finish_reason":"length"}]}"#),
+            false,
+        )
+        .await
+        .unwrap();
+        validate_prefill(
+            Bytes::from_static(b": comment\r\ndata: {\"choices\":[{\"finish_reason\":\"length\"}]}\r\n\r\ndata: [DONE]\r\n\r\n"),
+            true,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_prefill_errors_and_incomplete_streams() {
+        for (body, streaming) in [
+            ("", false),
+            ("null", false),
+            ("[]", false),
+            ("{}", false),
+            ("data: [DONE]\n\n", true),
+            (r#"{"object":"error","message":"failed"}"#, false),
+            (r#"{"error":{"message":"failed"}}"#, false),
+            (r#"{"choices":[{"finish_reason":"abort"}]}"#, false),
+            (
+                "data: {\"error\":{\"message\":\"failed\"}}\n\ndata: [DONE]\n\n",
+                true,
+            ),
+            ("data: {\"choices\":[]}\n\n", true),
+            ("data: not-json\n\ndata: [DONE]\n\n", true),
+            ("data: [DONE]\n\ndata: {\"choices\":[]}\n\n", true),
+        ] {
+            assert!(
+                validate_prefill(Bytes::from(body), streaming)
+                    .await
+                    .is_err(),
+                "{body}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn request_body_limit_and_read_errors_are_client_errors() {
+        let chunk = Bytes::from(vec![b' '; 1024 * 1024]);
+        let body = Body::from_stream(stream::iter(
+            (0..33).map(move |_| Ok::<_, std::io::Error>(chunk.clone())),
+        ));
+        assert_eq!(
+            read_request(body)
+                .await
+                .unwrap_err()
+                .into_response()
+                .status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+        );
+        let body = Body::from_stream(stream::iter([Err::<Bytes, _>(std::io::Error::other(
+            "client disconnected",
+        ))]));
+        assert_eq!(
+            read_request(body)
+                .await
+                .unwrap_err()
+                .into_response()
+                .status(),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_bom_without_panicking_even_across_chunks() {
+        for chunks in [
+            vec![Bytes::from_static(b"\xef\xbb\xbfdata: [DONE]\n\n")],
+            vec![
+                Bytes::from_static(b"\xef"),
+                Bytes::from_static(b"\xbb"),
+                Bytes::from_static(b"\xbfdata: [DONE]\n\n"),
+            ],
+        ] {
+            assert!(
+                validate_event_stream(stream::iter(chunks.into_iter().map(Ok)), "decode")
+                    .await
+                    .is_err()
+            );
+        }
+    }
+}

--- a/deploy/inference-gateway/sidecar/tests/sglang_pd.rs
+++ b/deploy/inference-gateway/sidecar/tests/sglang_pd.rs
@@ -1,0 +1,981 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::{Body, Bytes, to_bytes};
+use axum::extract::State;
+use axum::http::{HeaderMap, Request, Response, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use dynamo_epp_sidecar::{
+    PREFILLER_HOST_PORT, PdAdapter, PrefillEndpoint, SglangPdAdapter, SidecarState, router,
+};
+use futures::{StreamExt, stream};
+use reqwest::Url;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::{Barrier, Semaphore, mpsc};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+const DEADLINE: Duration = Duration::from_secs(10);
+const PREFILL_SSE: &str = "data: {\"id\":\"prefill\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a\"},\"finish_reason\":\"length\"}]}\n\ndata: [DONE]\n\n";
+const DECODE_SSE: &str = ": keepalive\n\ndata: {\"id\":\"decode\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"answer\"},\"finish_reason\":\"stop\"}]}\r\n\r\ndata: [DONE]\n\n";
+const DECODE_FIRST_SSE: &[u8] = b"data: {\"id\":\"decode\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"first\"},\"finish_reason\":null}]}\n\n";
+
+async fn bounded<T>(future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(DEADLINE, future)
+        .await
+        .expect("mock HTTP operation did not complete")
+}
+
+#[derive(Clone, Debug)]
+struct Observed {
+    path: String,
+    headers: HeaderMap,
+    body: Bytes,
+}
+
+type MockReceiver<T> = Arc<Mutex<Option<mpsc::UnboundedReceiver<T>>>>;
+
+#[derive(Clone)]
+enum Reply {
+    Full(Bytes),
+    Streaming(MockReceiver<Bytes>),
+    Failing(MockReceiver<Result<Bytes, std::io::Error>>),
+}
+
+#[derive(Clone)]
+struct MockSpec {
+    info: Value,
+    status: StatusCode,
+    content_type: &'static str,
+    retry_after: Option<&'static str>,
+    reply: Reply,
+    barrier: Option<Arc<Barrier>>,
+    before_headers: Option<Arc<Semaphore>>,
+    abort_gate: Option<Arc<Semaphore>>,
+}
+
+impl MockSpec {
+    fn new(mode: &str) -> Self {
+        Self {
+            info: json!({
+                "version": "0.5.19",
+                "disaggregation_mode": mode,
+                "disaggregation_bootstrap_port": 8998,
+            }),
+            status: StatusCode::OK,
+            content_type: "application/json",
+            retry_after: None,
+            reply: Reply::Full(Bytes::from(
+                json!({
+                    "id": mode,
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "test",
+                    "choices": [{"index": 0, "message": {"role": "assistant", "content": "a"}, "finish_reason": "length"}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+                })
+                .to_string(),
+            )),
+            barrier: None,
+            before_headers: None,
+            abort_gate: None,
+        }
+    }
+
+    fn sse(mut self, body: &'static str) -> Self {
+        self.content_type = "text/event-stream";
+        self.reply = Reply::Full(Bytes::from_static(body.as_bytes()));
+        self
+    }
+
+    fn held(mut self) -> Self {
+        self.before_headers = Some(Arc::new(Semaphore::new(0)));
+        self
+    }
+
+    fn streaming(mut self) -> (Self, mpsc::UnboundedSender<Bytes>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.content_type = "text/event-stream";
+        self.reply = Reply::Streaming(Arc::new(Mutex::new(Some(rx))));
+        (self, tx)
+    }
+
+    fn failing_stream(mut self) -> (Self, mpsc::UnboundedSender<Result<Bytes, std::io::Error>>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.content_type = "text/event-stream";
+        self.reply = Reply::Failing(Arc::new(Mutex::new(Some(rx))));
+        (self, tx)
+    }
+}
+
+#[derive(Clone)]
+struct MockState {
+    spec: MockSpec,
+    observed: Arc<Mutex<Vec<Observed>>>,
+    generated: Arc<Semaphore>,
+    aborted: Arc<Semaphore>,
+    emitted: Arc<Semaphore>,
+    stop: CancellationToken,
+}
+
+async fn mock_request(State(state): State<MockState>, request: Request<Body>) -> Response<Body> {
+    let (parts, body) = request.into_parts();
+    let body = to_bytes(body, usize::MAX).await.unwrap();
+    let path = parts.uri.path().to_owned();
+    state.observed.lock().unwrap().push(Observed {
+        path: path.clone(),
+        headers: parts.headers,
+        body,
+    });
+    match path.as_str() {
+        "/server_info" => axum::Json(state.spec.info).into_response(),
+        "/abort_request" => {
+            state.aborted.add_permits(1);
+            if let Some(gate) = &state.spec.abort_gate {
+                tokio::select! {
+                    permit = gate.acquire() => permit.unwrap().forget(),
+                    () = state.stop.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+                }
+            }
+            StatusCode::OK.into_response()
+        }
+        "/v1/chat/completions" => {
+            state.generated.add_permits(1);
+            if let Some(barrier) = &state.spec.barrier {
+                tokio::select! {
+                    _ = barrier.wait() => {},
+                    () = state.stop.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+                }
+            }
+            if let Some(gate) = &state.spec.before_headers {
+                tokio::select! {
+                    permit = gate.acquire() => permit.unwrap().forget(),
+                    () = state.stop.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+                }
+            }
+            let body = match state.spec.reply {
+                Reply::Full(bytes) => Body::from(bytes),
+                Reply::Streaming(receiver) => {
+                    let receiver = receiver.lock().unwrap().take().unwrap();
+                    Body::from_stream(stream::unfold(
+                        (receiver, state.emitted.clone()),
+                        |(mut receiver, emitted)| async move {
+                            receiver.recv().await.map(|bytes| {
+                                emitted.add_permits(1);
+                                (Ok::<_, Infallible>(bytes), (receiver, emitted))
+                            })
+                        },
+                    ))
+                }
+                Reply::Failing(receiver) => {
+                    let receiver = receiver.lock().unwrap().take().unwrap();
+                    Body::from_stream(stream::unfold(
+                        (receiver, state.emitted.clone()),
+                        |(mut receiver, emitted)| async move {
+                            receiver.recv().await.map(|chunk| {
+                                if chunk.is_ok() {
+                                    emitted.add_permits(1);
+                                }
+                                (chunk, (receiver, emitted))
+                            })
+                        },
+                    ))
+                }
+            };
+            let mut response = Response::builder()
+                .status(state.spec.status)
+                .header("content-type", state.spec.content_type)
+                .header("x-engine-response", "untouched");
+            if let Some(retry_after) = state.spec.retry_after {
+                response = response.header("retry-after", retry_after);
+            }
+            response.body(body).unwrap()
+        }
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+struct MockServer {
+    url: Url,
+    state: MockState,
+    task: JoinHandle<()>,
+}
+
+impl MockServer {
+    async fn start(spec: MockSpec) -> Self {
+        let state = MockState {
+            spec,
+            observed: Arc::default(),
+            generated: Arc::new(Semaphore::new(0)),
+            aborted: Arc::new(Semaphore::new(0)),
+            emitted: Arc::new(Semaphore::new(0)),
+            stop: CancellationToken::new(),
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let app = Router::new()
+            .route("/server_info", get(mock_request))
+            .route("/abort_request", post(mock_request))
+            .route("/v1/chat/completions", post(mock_request))
+            .with_state(state.clone());
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        Self { url, state, task }
+    }
+
+    async fn generated(&self) {
+        bounded(self.state.generated.acquire())
+            .await
+            .unwrap()
+            .forget();
+    }
+
+    async fn aborted(&self) {
+        bounded(self.state.aborted.acquire())
+            .await
+            .unwrap()
+            .forget();
+    }
+
+    async fn emitted(&self) {
+        bounded(self.state.emitted.acquire())
+            .await
+            .unwrap()
+            .forget();
+    }
+
+    fn requests(&self, path: &str) -> Vec<Observed> {
+        self.state
+            .observed
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.path == path)
+            .cloned()
+            .collect()
+    }
+
+    fn generations(&self) -> Vec<Value> {
+        self.requests("/v1/chat/completions")
+            .iter()
+            .map(|r| serde_json::from_slice(&r.body).unwrap())
+            .collect()
+    }
+
+    fn aborts(&self) -> Vec<Value> {
+        self.requests("/abort_request")
+            .iter()
+            .map(|r| serde_json::from_slice(&r.body).unwrap())
+            .collect()
+    }
+
+    fn endpoint(&self) -> PrefillEndpoint {
+        let mut headers = HeaderMap::new();
+        headers.insert(PREFILLER_HOST_PORT, self.authority().parse().unwrap());
+        PrefillEndpoint::parse_headers(&headers).unwrap().unwrap()
+    }
+
+    fn authority(&self) -> String {
+        format!(
+            "{}:{}",
+            self.url.host_str().unwrap(),
+            self.url.port().unwrap()
+        )
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.state.stop.cancel();
+        self.task.abort();
+    }
+}
+
+struct Pair {
+    prefill: MockServer,
+    decode: MockServer,
+    adapter: Arc<SglangPdAdapter>,
+}
+
+impl Pair {
+    async fn new(prefill: MockSpec, decode: MockSpec) -> Self {
+        Self::with_timeout(prefill, decode, Duration::from_secs(5)).await
+    }
+
+    async fn with_timeout(prefill: MockSpec, decode: MockSpec, read_timeout: Duration) -> Self {
+        let prefill = MockServer::start(prefill).await;
+        let decode = MockServer::start(decode).await;
+        let adapter = Arc::new(
+            SglangPdAdapter::new(decode.url.clone(), Duration::from_secs(2), read_timeout).unwrap(),
+        );
+        Self {
+            prefill,
+            decode,
+            adapter,
+        }
+    }
+
+    fn app(&self, force_shutdown: CancellationToken) -> Router {
+        router(
+            SidecarState::new(
+                self.decode.url.clone(),
+                Duration::from_secs(2),
+                Duration::from_secs(5),
+                self.adapter.clone(),
+                CancellationToken::new(),
+                force_shutdown,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn request(&self, body: &Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer inference-key")
+            .header(PREFILLER_HOST_PORT, self.prefill.authority())
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    async fn response(&self, body: &Value) -> Response<Body> {
+        bounded(
+            self.app(CancellationToken::new())
+                .oneshot(self.request(body)),
+        )
+        .await
+        .unwrap()
+    }
+
+    async fn both_generated(&self) {
+        tokio::join!(self.prefill.generated(), self.decode.generated());
+    }
+
+    async fn shutdown(&self) {
+        bounded(self.adapter.shutdown()).await;
+    }
+
+    fn assert_abort_matches(&self, server: &MockServer) {
+        let generations = server.generations();
+        let aborts = server.aborts();
+        assert_eq!(aborts.len(), 1, "expected exactly one request-scoped abort");
+        assert_eq!(
+            aborts[0],
+            json!({"rid": generations[0]["rid"], "abort_all": false})
+        );
+    }
+}
+
+fn chat() -> Value {
+    json!({"model":"test", "messages":[{"role":"user","content":"hello"}], "max_tokens":32, "stream":false})
+}
+
+fn simultaneous(mut prefill: MockSpec, mut decode: MockSpec) -> (MockSpec, MockSpec) {
+    let barrier = Arc::new(Barrier::new(2));
+    prefill.barrier = Some(barrier.clone());
+    decode.barrier = Some(barrier);
+    (prefill, decode)
+}
+
+#[tokio::test]
+async fn dispatches_both_legs_concurrently_and_preserves_chat_fields() {
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").sse(PREFILL_SSE),
+        MockSpec::new("decode").sse(DECODE_SSE),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let mut rooms = Vec::new();
+    let mut rids = Vec::new();
+    for n in [None, Some(json!(1))] {
+        let mut body = json!({
+            "model":"test", "messages":[{"role":"user","content":"hello"}],
+            "stream":true, "stream_options":{"include_usage":true},
+            "max_tokens":256, "max_completion_tokens":128, "min_tokens":3,
+            "temperature":0.25, "seed":17, "stop":["end"],
+            "tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{}}}}],
+            "tool_choice":"auto", "response_format":{"type":"json_object"},
+            "unknown_extension":{"preserve":[1,2,3]},
+            "rid":"client-forged", "bootstrap_host":"forged.invalid", "bootstrap_port":1, "bootstrap_room":0,
+        });
+        if let Some(n) = n {
+            body["n"] = n;
+        }
+        let response = pair.response(&body).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["x-engine-response"], "untouched");
+        assert_eq!(
+            bounded(to_bytes(response.into_body(), usize::MAX))
+                .await
+                .unwrap(),
+            DECODE_SSE
+        );
+        let prefill = pair.prefill.generations().pop().unwrap();
+        let decode = pair.decode.generations().pop().unwrap();
+        assert_eq!(prefill, decode);
+        assert_eq!(prefill["bootstrap_host"], "127.0.0.1");
+        assert_eq!(prefill["bootstrap_port"], 8998);
+        assert_ne!(prefill["rid"], body["rid"]);
+        let room = prefill["bootstrap_room"].as_u64().unwrap();
+        assert!(room <= i64::MAX as u64);
+        assert!(!rooms.contains(&room));
+        rooms.push(room);
+        let rid = prefill["rid"].as_str().unwrap().to_owned();
+        assert!(!rids.contains(&rid));
+        rids.push(rid);
+        let mut actual = prefill;
+        for field in ["bootstrap_host", "bootstrap_port", "bootstrap_room", "rid"] {
+            actual.as_object_mut().unwrap().remove(field);
+            body.as_object_mut().unwrap().remove(field);
+        }
+        assert_eq!(actual, body);
+    }
+    pair.shutdown().await;
+    for server in [&pair.prefill, &pair.decode] {
+        assert_eq!(server.requests("/server_info").len(), 2);
+        assert!(
+            server.aborts().is_empty(),
+            "normal EOS must not abort completed requests"
+        );
+        for request in server.requests("/v1/chat/completions") {
+            assert!(!request.headers.contains_key(PREFILLER_HOST_PORT));
+            assert_eq!(request.headers["authorization"], "Bearer inference-key");
+        }
+    }
+}
+
+#[tokio::test]
+async fn prefill_http_failure_aborts_decode_waiting_for_headers() {
+    let mut prefill = MockSpec::new("prefill");
+    prefill.status = StatusCode::SERVICE_UNAVAILABLE;
+    prefill.reply = Reply::Full(Bytes::from_static(
+        b"{\"object\":\"error\",\"message\":\"prefill unavailable\",\"code\":503}",
+    ));
+    let (prefill, decode) = simultaneous(prefill, MockSpec::new("decode").held());
+    let pair = Pair::new(prefill, decode).await;
+    assert_eq!(
+        pair.response(&chat()).await.status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn prefill_sse_error_after_success_chunk_prevents_decode_response() {
+    let error_sse = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a\"},\"finish_reason\":null}]}\n\ndata: {\"error\":{\"object\":\"error\",\"message\":\"KV transfer failed\",\"type\":\"INTERNAL_SERVER_ERROR\",\"param\":null,\"code\":500}}\n\ndata: [DONE]\n\n";
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").sse(error_sse),
+        MockSpec::new("decode").sse(DECODE_SSE),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    assert_eq!(pair.response(&body).await.status(), StatusCode::BAD_GATEWAY);
+    pair.shutdown().await;
+}
+
+#[tokio::test]
+async fn prefill_sse_without_done_aborts_pending_decode() {
+    let truncated = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a\"},\"finish_reason\":\"length\"}]}\n\n";
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").sse(truncated),
+        MockSpec::new("decode").held(),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    assert_eq!(pair.response(&body).await.status(), StatusCode::BAD_GATEWAY);
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn graceful_prefill_abort_is_failure_in_both_json_and_sse() {
+    for streaming in [false, true] {
+        let mut prefill = MockSpec::new("prefill");
+        if streaming {
+            prefill = prefill.sse("data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"abort\"}]}\n\ndata: [DONE]\n\n");
+        } else {
+            prefill.reply = Reply::Full(Bytes::from(json!({
+                "id":"prefill", "object":"chat.completion", "created":1, "model":"test",
+                "choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"abort"}],
+            }).to_string()));
+        }
+        let (prefill, decode) = simultaneous(prefill, MockSpec::new("decode").held());
+        let pair = Pair::new(prefill, decode).await;
+        let mut body = chat();
+        body["stream"] = json!(streaming);
+        assert_eq!(pair.response(&body).await.status(), StatusCode::BAD_GATEWAY);
+        pair.shutdown().await;
+        pair.assert_abort_matches(&pair.decode);
+    }
+}
+
+#[tokio::test]
+async fn validates_server_version_mode_and_bootstrap_before_dispatch() {
+    for (target, key, value) in [
+        ("prefill", "version", json!("0.5.18")),
+        ("decode", "disaggregation_mode", json!("prefill")),
+        ("prefill", "disaggregation_bootstrap_port", json!(0)),
+    ] {
+        let mut prefill = MockSpec::new("prefill");
+        let mut decode = MockSpec::new("decode");
+        if target == "prefill" {
+            prefill.info[key] = value;
+        } else {
+            decode.info[key] = value;
+        }
+        let pair = Pair::new(prefill, decode).await;
+        assert_eq!(
+            pair.response(&chat()).await.status(),
+            StatusCode::BAD_GATEWAY
+        );
+        pair.shutdown().await;
+        assert!(pair.prefill.generations().is_empty());
+        assert!(pair.decode.generations().is_empty());
+        assert!(pair.prefill.aborts().is_empty());
+        assert!(pair.decode.aborts().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn rejects_parallel_sampling_before_engine_generation() {
+    let pair = Pair::new(MockSpec::new("prefill"), MockSpec::new("decode")).await;
+    for n in [
+        Value::Null,
+        json!(0),
+        json!(2),
+        json!(-1),
+        json!("1"),
+        json!(true),
+    ] {
+        let mut body = chat();
+        body["n"] = n;
+        assert_eq!(pair.response(&body).await.status(), StatusCode::BAD_REQUEST);
+    }
+    pair.shutdown().await;
+    assert!(pair.prefill.generations().is_empty());
+    assert!(pair.decode.generations().is_empty());
+    assert!(pair.prefill.aborts().is_empty());
+    assert!(pair.decode.aborts().is_empty());
+}
+
+#[tokio::test]
+async fn decode_error_cancels_prefill_without_waiting_for_prefill_completion() {
+    let mut decode = MockSpec::new("decode");
+    decode.status = StatusCode::BAD_REQUEST;
+    decode.reply = Reply::Full(Bytes::from_static(
+        b"{\"object\":\"error\",\"message\":\"decode rejected\",\"code\":400}",
+    ));
+    let (prefill, decode) = simultaneous(MockSpec::new("prefill").held(), decode);
+    let pair = Pair::new(prefill, decode).await;
+    assert_eq!(
+        pair.response(&chat()).await.status(),
+        StatusCode::BAD_REQUEST
+    );
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+}
+
+#[tokio::test]
+async fn decode_sse_error_cancels_prefill_before_prefill_completes() {
+    let decode_error = "data: {\"error\":{\"object\":\"error\",\"message\":\"decode failed\",\"type\":\"INTERNAL_SERVER_ERROR\",\"param\":null,\"code\":500}}\n\ndata: [DONE]\n\n";
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").held(),
+        MockSpec::new("decode").sse(decode_error),
+    );
+    let pair = Pair::with_timeout(prefill, decode, Duration::from_secs(30)).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    let response = tokio::time::timeout(Duration::from_secs(1), pair.response(&body))
+        .await
+        .expect("decode SSE error must cancel prefill before its read timeout");
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+}
+
+#[tokio::test]
+async fn inference_rate_limit_preserves_status_and_retry_after_on_either_leg() {
+    for failing_prefill in [true, false] {
+        let mut failed = MockSpec::new(if failing_prefill { "prefill" } else { "decode" });
+        failed.status = StatusCode::TOO_MANY_REQUESTS;
+        failed.retry_after = Some("7");
+        failed.reply = Reply::Full(Bytes::from_static(b"{\"object\":\"error\",\"message\":\"engine overloaded\",\"type\":\"TooManyRequests\",\"code\":429}"));
+        let (prefill, decode) = if failing_prefill {
+            simultaneous(failed, MockSpec::new("decode").held())
+        } else {
+            simultaneous(MockSpec::new("prefill").held(), failed)
+        };
+        let pair = Pair::new(prefill, decode).await;
+        let response = pair.response(&chat()).await;
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()["retry-after"], "7");
+        let body: Value = serde_json::from_slice(
+            &bounded(to_bytes(response.into_body(), usize::MAX))
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(body["error"]["message"].as_str().is_some());
+        pair.shutdown().await;
+        pair.assert_abort_matches(if failing_prefill {
+            &pair.decode
+        } else {
+            &pair.prefill
+        });
+    }
+}
+
+#[tokio::test]
+async fn read_timeout_maps_to_504_and_cleans_up_both_legs() {
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").held(),
+        MockSpec::new("decode").held(),
+    );
+    let pair = Pair::with_timeout(prefill, decode, Duration::from_millis(100)).await;
+    assert_eq!(
+        pair.response(&chat()).await.status(),
+        StatusCode::GATEWAY_TIMEOUT
+    );
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn dropping_execute_before_headers_aborts_both_dispatched_requests() {
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").held(),
+        MockSpec::new("decode").held(),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let adapter = pair.adapter.clone();
+    let request = pair.request(&chat());
+    let endpoint = pair.prefill.endpoint();
+    let mut task = AbortOnDrop(tokio::spawn(async move {
+        adapter
+            .execute(request, endpoint, CancellationToken::new())
+            .await
+    }));
+    pair.both_generated().await;
+    task.0.abort();
+    assert!((&mut task.0).await.unwrap_err().is_cancelled());
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn dropping_decode_stream_aborts_decode_and_closes_upstream_stream() {
+    let (decode, sender) = MockSpec::new("decode").streaming();
+    sender.send(Bytes::from_static(DECODE_FIRST_SSE)).unwrap();
+    let pair = Pair::new(MockSpec::new("prefill").sse(PREFILL_SSE), decode).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    let response = pair.response(&body).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut stream = response.into_body().into_data_stream();
+    assert_eq!(
+        bounded(stream.next()).await.unwrap().unwrap(),
+        DECODE_FIRST_SSE
+    );
+    drop(stream);
+    bounded(sender.closed()).await;
+    pair.decode.aborted().await;
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.decode);
+    assert!(pair.prefill.aborts().is_empty());
+}
+
+#[tokio::test]
+async fn force_cancellation_cleans_up_both_inflight_legs() {
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").held(),
+        MockSpec::new("decode").held(),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let force_shutdown = CancellationToken::new();
+    let app = pair.app(force_shutdown.clone());
+    let mut task = AbortOnDrop(tokio::spawn(app.oneshot(pair.request(&chat()))));
+    pair.both_generated().await;
+    force_shutdown.cancel();
+    assert_eq!(
+        bounded(&mut task.0).await.unwrap().unwrap().status(),
+        StatusCode::BAD_GATEWAY
+    );
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn requests_without_prefill_metadata_keep_decode_only_wire_body() {
+    let pair = Pair::new(
+        MockSpec::new("prefill"),
+        MockSpec::new("decode").sse(DECODE_SSE),
+    )
+    .await;
+    let original = b"{  \"stream\": true, \"n\": 3, \"unknown\": [1, 2], \"messages\": [] }";
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(original.as_slice()))
+        .unwrap();
+    let response = bounded(pair.app(CancellationToken::new()).oneshot(request))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        bounded(to_bytes(response.into_body(), usize::MAX))
+            .await
+            .unwrap(),
+        DECODE_SSE
+    );
+    pair.shutdown().await;
+    assert!(pair.prefill.state.observed.lock().unwrap().is_empty());
+    assert_eq!(
+        pair.decode.requests("/v1/chat/completions")[0].body,
+        original.as_slice()
+    );
+    assert!(pair.decode.requests("/server_info").is_empty());
+    assert!(pair.decode.aborts().is_empty());
+}
+
+struct AbortOnDrop<T>(JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+#[tokio::test]
+async fn prefill_completion_preserves_partial_sse_and_utf8_decode_prefixes_byte_for_byte() {
+    const WIRE: &[u8] = b"data: {\"id\":\"decode\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\xe4\xbd\xa0\xe5\xa5\xbd\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+    let utf8_split = WIRE.iter().position(|byte| *byte == 0xe4).unwrap() + 1;
+    for split in [2, utf8_split] {
+        let prefill = MockSpec::new("prefill").sse(PREFILL_SSE).held();
+        let prefill_gate = prefill.before_headers.as_ref().unwrap().clone();
+        let (decode, sender) = MockSpec::new("decode").streaming();
+        let (prefill, decode) = simultaneous(prefill, decode);
+        let pair = Pair::new(prefill, decode).await;
+        let mut body = chat();
+        body["stream"] = json!(true);
+        let mut task = AbortOnDrop(tokio::spawn(
+            pair.app(CancellationToken::new())
+                .oneshot(pair.request(&body)),
+        ));
+        pair.both_generated().await;
+        sender.send(Bytes::copy_from_slice(&WIRE[..split])).unwrap();
+        pair.decode.emitted().await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut task.0)
+                .await
+                .is_err()
+        );
+        prefill_gate.add_permits(1);
+        let response = tokio::time::timeout(Duration::from_secs(1), &mut task.0)
+            .await
+            .expect("complete prefill must release even an incomplete decode SSE event")
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let mut stream = response.into_body().into_data_stream();
+        let prefix = bounded(stream.next()).await.unwrap().unwrap();
+        assert_eq!(prefix, &WIRE[..split]);
+        sender.send(Bytes::copy_from_slice(&WIRE[split..])).unwrap();
+        drop(sender);
+        let mut received = prefix.to_vec();
+        while let Some(chunk) = bounded(stream.next()).await {
+            received.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(received, WIRE);
+        pair.shutdown().await;
+        assert!(pair.prefill.aborts().is_empty());
+        assert!(pair.decode.aborts().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn decode_body_connection_failure_after_200_cancels_pending_prefill() {
+    let (decode, sender) = MockSpec::new("decode").failing_stream();
+    let (prefill, decode) = simultaneous(MockSpec::new("prefill").held(), decode);
+    let pair = Pair::with_timeout(prefill, decode, Duration::from_secs(30)).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    let mut task = AbortOnDrop(tokio::spawn(
+        pair.app(CancellationToken::new())
+            .oneshot(pair.request(&body)),
+    ));
+    pair.both_generated().await;
+    sender
+        .send(Ok(Bytes::from_static(DECODE_FIRST_SSE)))
+        .unwrap();
+    pair.decode.emitted().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut task.0)
+            .await
+            .is_err()
+    );
+    sender
+        .send(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "mock decode connection reset",
+        )))
+        .unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(1), &mut task.0)
+        .await
+        .expect("decode body failure must interrupt pending prefill")
+        .unwrap()
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+}
+
+#[tokio::test]
+async fn decode_prefix_above_32_mib_is_bounded_while_prefill_is_pending() {
+    let (decode, sender) = MockSpec::new("decode").streaming();
+    let (prefill, decode) = simultaneous(MockSpec::new("prefill").held(), decode);
+    let pair = Pair::with_timeout(prefill, decode, Duration::from_secs(30)).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    let mut task = AbortOnDrop(tokio::spawn(
+        pair.app(CancellationToken::new())
+            .oneshot(pair.request(&body)),
+    ));
+    pair.both_generated().await;
+    let mut event = b"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"".to_vec();
+    event.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    event.extend_from_slice(b"\"},\"finish_reason\":null}]}\n\n");
+    let mut oversized = Vec::with_capacity(32 * 1024 * 1024 + event.len());
+    while oversized.len() <= 32 * 1024 * 1024 {
+        oversized.extend_from_slice(&event);
+    }
+    sender.send(Bytes::from(oversized)).unwrap();
+    let response = tokio::time::timeout(Duration::from_secs(5), &mut task.0)
+        .await
+        .expect("oversized decode prefix must fail before prefill's 30-second timeout")
+        .unwrap()
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    bounded(sender.closed()).await;
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn client_tcp_disconnect_before_headers_aborts_both_legs() {
+    let (prefill, decode) = simultaneous(
+        MockSpec::new("prefill").held(),
+        MockSpec::new("decode").held(),
+    );
+    let pair = Pair::new(prefill, decode).await;
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let app = pair.app(CancellationToken::new());
+    let _server = AbortOnDrop(tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap()
+    }));
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let request = client
+        .post(format!("http://{address}/v1/chat/completions"))
+        .header(PREFILLER_HOST_PORT, pair.prefill.authority())
+        .json(&chat());
+    let mut task = AbortOnDrop(tokio::spawn(async move { request.send().await }));
+    pair.both_generated().await;
+    task.0.abort();
+    assert!((&mut task.0).await.unwrap_err().is_cancelled());
+    drop(client);
+    tokio::join!(pair.prefill.aborted(), pair.decode.aborted());
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.prefill);
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn decode_response_waits_for_complete_prefill_stream_even_after_decode_bytes_arrive() {
+    let (prefill, prefill_sender) = MockSpec::new("prefill").streaming();
+    let (decode, decode_sender) = MockSpec::new("decode").streaming();
+    let (prefill, decode) = simultaneous(prefill, decode);
+    let pair = Pair::new(prefill, decode).await;
+    let mut body = chat();
+    body["stream"] = json!(true);
+    let mut task = AbortOnDrop(tokio::spawn(
+        pair.app(CancellationToken::new())
+            .oneshot(pair.request(&body)),
+    ));
+    pair.both_generated().await;
+    prefill_sender.send(Bytes::from_static(b"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a\"},\"finish_reason\":null}]}\n\n")).unwrap();
+    decode_sender
+        .send(Bytes::from_static(DECODE_SSE.as_bytes()))
+        .unwrap();
+    tokio::join!(pair.prefill.emitted(), pair.decode.emitted());
+    // Both engines have emitted bytes. P remains open until its explicit error below.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut task.0)
+            .await
+            .is_err(),
+        "decode response escaped before prefill completed"
+    );
+    prefill_sender.send(Bytes::from_static(b"data: {\"error\":{\"object\":\"error\",\"message\":\"transfer failed\",\"type\":\"INTERNAL_SERVER_ERROR\",\"param\":null,\"code\":500}}\n\ndata: [DONE]\n\n")).unwrap();
+    drop(prefill_sender);
+    assert_eq!(
+        bounded(&mut task.0).await.unwrap().unwrap().status(),
+        StatusCode::BAD_GATEWAY
+    );
+    bounded(decode_sender.closed()).await;
+    pair.shutdown().await;
+    pair.assert_abort_matches(&pair.decode);
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_abort_response_and_bounds_a_stalled_abort() {
+    for release_abort in [true, false] {
+        let abort_gate = Arc::new(Semaphore::new(0));
+        let mut decode = MockSpec::new("decode");
+        decode.abort_gate = Some(abort_gate.clone());
+        let (decode, sender) = decode.streaming();
+        sender.send(Bytes::from_static(DECODE_FIRST_SSE)).unwrap();
+        // Keep the transport's read deadline above the dedicated five-second abort deadline.
+        let pair = Pair::with_timeout(
+            MockSpec::new("prefill").sse(PREFILL_SSE),
+            decode,
+            Duration::from_secs(30),
+        )
+        .await;
+        let mut body = chat();
+        body["stream"] = json!(true);
+        let response = pair.response(&body).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        drop(response);
+        pair.decode.aborted().await;
+        let mut shutdown = Box::pin(pair.adapter.shutdown());
+        assert!(
+            futures::poll!(&mut shutdown).is_pending(),
+            "shutdown skipped its active abort cleanup"
+        );
+        if release_abort {
+            abort_gate.add_permits(1);
+        }
+        tokio::time::timeout(Duration::from_secs(6), &mut shutdown)
+            .await
+            .expect("abort cleanup exceeded its five-second deadline plus scheduling allowance");
+        bounded(sender.closed()).await;
+        pair.assert_abort_matches(&pair.decode);
+        assert!(pair.prefill.aborts().is_empty());
+    }
+}


### PR DESCRIPTION
## Overview

Add the SGLang prefill/decode adapter to the standalone EPP HTTP decode sidecar. This is separate from the native gRPC sidecar under `lib/sidecar`.

Draft: the HTTP protocol and lifecycle are tested with real TCP engine mocks; real SGLang GPU/KV-transfer and full GAIE/EPP deployment validation remain pending.

## Summary

- Enable the adapter with `DYN_SIDECAR_PD_BACKEND=sglang`, preserving the default unavailable adapter and unchanged decode-only passthrough.
- Validate SGLang 0.5.19 worker roles, derive the selected prefill bootstrap endpoint, and inject one sidecar-owned room/rid into both original Chat Completions requests.
- Dispatch P/D concurrently, expose only decode bytes after prefill succeeds, and coordinate errors, cancellation, stream teardown, and bounded abort cleanup.

## Details

While prefill is pending, observe decode body failures after HTTP 200 and retain the exact consumed prefix for replay, including partial SSE/UTF-8 data. Preserve inference HTTP error statuses and `Retry-After`; reject graceful aborts, malformed/truncated prefill responses, and unsupported parallel sampling (`n != 1`).

Original requests, complete prefill responses, and decode prefixes buffered while prefill is pending are bounded at 32 MiB. Server information is bounded at 1 MiB. The adapter does not proxy KV bytes or manage EPP reservations.

Backend abort is best effort and bounded to five seconds. SGLang can ignore an unknown rid, so HTTP 200 from `/abort_request` is not proof that GPU execution has stopped. The selected workers must allow the forwarded credentials to access the abort endpoint, and Gateway must strip client-supplied routing metadata.

## Validation

On Linux, Rust/Cargo 1.96.1, four CPU build jobs, at `ff1aea8afcc45f2b9e4df6d8eb2fd52f31bdec45`:

- `cargo test --locked -p dynamo-epp-sidecar`: **44 passed** (23 unit + 21 real-TCP integration tests).
- `cargo clippy --locked -p dynamo-epp-sidecar --all-targets -- -D warnings`: passed.
- `cargo fmt -p dynamo-epp-sidecar -- --check`: passed.
- Full-patch whitespace checks: passed. The implementation baseline had 16 passing tests.

Coverage includes simultaneous dispatch, request preservation, client TCP disconnect, HTTP/SSE errors on either leg, HTTP 200 followed by connection failure, partial-prefix replay, bounded read-ahead, and shutdown cleanup. A decode-SSE-error regression was verified failing before concurrent body observation and passing after the fix.

Full `pre-commit run --from-ref HEAD^ --to-ref HEAD` did not complete: hook bootstrap stalled fetching `timothycrosley/isort` and was stopped after 90 seconds. No full pre-commit or upstream CI pass is claimed.

Real SGLang inference, GPU/KV transfer, performance, and full deployment have not been validated.

## Where should the reviewer start?

- `deploy/inference-gateway/sidecar/src/sglang.rs`: bootstrap adaptation, concurrent body observation, and request-scoped cleanup.
- `deploy/inference-gateway/sidecar/tests/sglang_pd.rs`: protocol and lifecycle regressions over real TCP sockets.
- `deploy/inference-gateway/sidecar/README.md`: configuration, trust boundaries, and supported scope.

## Related Issues

- Relates to #13412 and #13413.
- Builds on the shared sidecar contract from #13669 / #13405 and DEP #11661.
- Paired selection/reservation accounting in #13407 remains outside this PR.

AI-assisted. Reviewed by the author before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable prefill/decode backend support, including SGLang.
  - Added streaming and non-streaming inference handling with request IDs, metadata validation, size limits, timeouts, and cancellation support.
  - Added standardized upstream rejection responses with status and retry information.

- **Bug Fixes**
  - Improved handling of malformed responses, failed requests, incomplete streams, and interrupted operations.
  - Added cleanup and abort behavior for unfinished backend requests.

- **Documentation**
  - Documented backend configuration and SGLang adapter behavior, validation, limits, and error handling.

- **Tests**
  - Added extensive coverage for successful, streaming, failure, timeout, cancellation, and shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->