### PR TITLE
feat(gms/vllm): allocate KV cache from persistent pools

### DIFF
--- a/lib/gpu_memory_service/integrations/vllm/install_vmm_ipc_kv.py
+++ b/lib/gpu_memory_service/integrations/vllm/install_vmm_ipc_kv.py
@@ -1,0 +1,736 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install hook: route vLLM's KV-cache allocation through GMS-owned
+VMM-IPC persistent allocations.
+
+Engine code (typically the vLLM worker) imports this module BEFORE
+the model is loaded. The installer monkey-patches the V1 KV cache
+allocation path (``Worker._allocate_kv_cache_tensors`` /
+``GPUWorker._initialize_kv_caches`` depending on vLLM version) so
+the per-layer ``torch.empty`` / ``torch.zeros`` calls allocate from
+a GMS persistent pool instead of the default ``cudaMalloc`` pool.
+
+Effect:
+  - daemon owns the KV pool's physical pages (cuMemCreate),
+  - engine has its own VA into the same pages,
+  - daemon can read/write directly via its va_daemon → no D2D copy
+    on evict/restore,
+  - engine restart with the same engine_id re-attaches to the SAME
+    physical pages → KV survives without recompute.
+
+Gates:
+  GMS_VLLM_VMM_IPC_KV=0            optional test/debug disable
+  GMS_VLLM_VMM_IPC_SOCKET=<path>   daemon UDS (default: derived from device)
+  GMS_VLLM_VMM_IPC_ENGINE_ID=<id>  identifier for (engine_id, tag) keying
+                                   (default: derived stable Dynamo id)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import sys
+import time
+from collections import Counter
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
+    get_gms_persistent_kv_socket,
+)
+from gpu_memory_service.integrations.vllm.kv_identity import (
+    allocation_engine_id,
+    allocation_shared,
+    use_existing_shared_geometry,
+)
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED = False
+_LAZY_HOOK_INSTALLED = False
+_GEOMETRY_PATCH_INSTALLED = False
+_KV_CACHE_PROFILING: ContextVar[bool] = ContextVar(
+    "gms_vllm_kv_cache_profiling", default=False
+)
+
+
+@contextmanager
+def _persistent_kv_zeros_as_empty(enabled: bool):
+    """Avoid touching reserve-only or reattached persistent KV pages.
+
+    vLLM allocates KV buffers with ``torch.zeros``. Private-bootstrap mode
+    has reserve-only VAs, while a cold replacement maps the primary's existing
+    physical pages. Zero-filling either would respectively poison the CUDA
+    context or silently destroy the KV being recovered. During those allocation
+    windows, replace only int8 zero allocations with ``torch.empty`` so vLLM
+    can build tensor views without writing to KV. A genuinely new shared pool
+    keeps vLLM's normal zero initialization.
+    """
+    if not enabled:
+        yield
+        return
+
+    import torch
+
+    original_zeros = torch.zeros
+    replacements = 0
+
+    def zeros_as_empty(*args, **kwargs):
+        nonlocal replacements
+        if kwargs.get("dtype") is torch.int8:
+            replacements += 1
+            return torch.empty(*args, **kwargs)
+        return original_zeros(*args, **kwargs)
+
+    torch.zeros = zeros_as_empty
+    try:
+        yield
+    finally:
+        torch.zeros = original_zeros
+        if replacements:
+            logger.info(
+                "[GMS-VMM-IPC] allocated %d persistent KV tensors with "
+                "torch.empty to preserve existing or reserve-only pages",
+                replacements,
+            )
+
+
+def _is_enabled() -> bool:
+    return env_enabled_by_default("GMS_VLLM_VMM_IPC_KV", default=True)
+
+
+def _resolve_socket(device: int) -> str:
+    return get_gms_persistent_kv_socket(device, "GMS_VLLM_VMM_IPC_SOCKET")
+
+
+def _engine_id(device: int = 0) -> str:
+    return allocation_engine_id(device)
+
+
+def _current_cuda_device() -> int:
+    import torch
+
+    return int(torch.cuda.current_device())
+
+
+def _device_index(device) -> int:
+    if isinstance(device, int):
+        return int(device)
+    index = getattr(device, "index", None)
+    if index is not None:
+        return int(index)
+    try:
+        return _current_cuda_device()
+    except Exception:
+        logger.debug(
+            "[GMS-VMM-IPC] Failed to resolve current CUDA device; using cuda:0",
+            exc_info=True,
+        )
+        return 0
+
+
+def _int_env_value(name: str, value: str | None, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r for GMS KV geometry", name, value)
+        return default
+
+
+def _shared_kv_enabled() -> bool:
+    return allocation_shared()
+
+
+def _install_kv_leases() -> bool:
+    try:
+        from gpu_memory_service.integrations.vllm.install_kv_leases import (
+            install as install_kv_leases,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-VMM-IPC] vLLM KV lease installer unavailable", exc_info=True)
+        return False
+    try:
+        return bool(install_kv_leases())
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-VMM-IPC] vLLM KV lease install failed")
+        raise
+
+
+
+def _kv_layout_fingerprint(kv_cache_config) -> str:
+    """Stable digest of KV-layout-relevant parameters.
+
+    The persistent identity is otherwise gated only by aligned-size equality on
+    reattach, so a config change that preserves size but changes meaning -- most
+    dangerously a KV dtype change (bf16 -> fp8 halves element size but a shared
+    attacher may still map the larger old allocation) -- would silently reuse
+    incompatible bytes as a different layout. Folding this fingerprint into the
+    tag forces a distinct identity so reattach fails cleanly instead. The KV
+    spec's per-rank head counts / page sizes already encode the TP degree.
+    """
+    parts: list[str] = []
+    for group in getattr(kv_cache_config, "kv_cache_groups", ()) or ():
+        spec = getattr(group, "kv_cache_spec", None)
+        if spec is None:
+            continue
+        for attr in (
+            "block_size",
+            "num_kv_heads",
+            "head_size",
+            "dtype",
+            "use_mla",
+            "page_size_bytes",
+        ):
+            val = getattr(spec, attr, None)
+            if val is not None:
+                parts.append(f"{attr}={val}")
+    if not parts:
+        return "unknown"
+    return hashlib.sha1("\0".join(parts).encode("utf-8")).hexdigest()[:12]
+
+
+def _semantic_kv_tensor_tag(index: int, kv_cache_tensor, layout_fp: str) -> str:
+    shared_by = tuple(
+        sorted(str(layer) for layer in getattr(kv_cache_tensor, "shared_by", ()) or ())
+    )
+    if shared_by:
+        key = "\0".join(shared_by)
+    else:
+        key = f"anonymous:{index}:{getattr(kv_cache_tensor, 'size', '')}"
+    digest = hashlib.sha1(
+        (layout_fp + "\0" + key).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"kv_pool:v2:{digest}"
+
+
+def _semantic_kv_tensor_tag_plan(kv_cache_config) -> list[str]:
+    layout_fp = _kv_layout_fingerprint(kv_cache_config)
+    base_tags = [
+        _semantic_kv_tensor_tag(index, kv_cache_tensor, layout_fp)
+        for index, kv_cache_tensor in enumerate(
+            getattr(kv_cache_config, "kv_cache_tensors", ()) or ()
+        )
+    ]
+    counts = Counter(base_tags)
+    seen: dict[str, int] = {}
+    planned_tags: list[str] = []
+    for base_tag in base_tags:
+        if counts[base_tag] == 1:
+            planned_tags.append(base_tag)
+            continue
+        duplicate_index = seen.get(base_tag, 0)
+        seen[base_tag] = duplicate_index + 1
+        planned_tags.append(f"{base_tag}:dup{duplicate_index}")
+    return planned_tags
+
+
+def _persistent_tag_plan_reattaches(
+    manager, engine_id: str, tag_plan: list[str]
+) -> bool:
+    """Return whether every semantic KV allocation already exists.
+
+    A complete plan means this process is reattaching and must not zero the
+    mapped pages. No matching tags means a new pool and retains normal vLLM
+    initialization. A partial plan is unsafe: mixing preserved and new tensors
+    would create a layout whose metadata cannot describe its contents.
+    """
+    if not tag_plan:
+        return False
+    existing = {
+        str(getattr(allocation, "tag", ""))
+        for allocation in manager.list_persistent(
+            engine_id=engine_id, include_unclaimed=True
+        )
+    }
+    planned = set(tag_plan)
+    present = planned & existing
+    if os.environ.get("GMS_KV_DIRECTORY_DIAGNOSTICS"):
+        logger.warning(
+            "[GMS-VMM-IPC] persistent plan engine_id=%s "
+            "planned=%d existing=%d matching=%d",
+            engine_id,
+            len(planned),
+            len(existing),
+            len(present),
+        )
+    if not present:
+        return False
+    missing = planned - existing
+    if missing:
+        raise RuntimeError(
+            "GMS persistent KV semantic tag plan is only partially present: "
+            f"found={len(present)} missing={len(missing)}. Refusing to mix "
+            "preserved and newly initialized KV tensors."
+        )
+    return True
+
+
+def _geometry_device() -> int:
+    for name in ("GMS_VLLM_KV_LEASE_DEVICE", "LOCAL_RANK"):
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r for GMS KV geometry", name, value)
+    return 0
+
+
+def _existing_shared_kv_blocks(*, wait_ms: int = 0) -> int | None:
+    if not use_existing_shared_geometry():
+        return None
+    if env_enabled_by_default("GMS_KV_LEASE_SHM_RESET", default=False):
+        return None
+
+    from gpu_memory_service.integrations.common.kv_lease_client import (
+        kv_leases_enabled,
+        read_any_kv_lease_namespace_total_blocks,
+        read_kv_lease_namespace_total_blocks,
+    )
+
+    if not kv_leases_enabled("vllm"):
+        return None
+
+    device = _geometry_device()
+    deadline = time.monotonic() + max(0, wait_ms) / 1000.0
+    logged_wait = False
+    while True:
+        namespace, total_blocks = read_kv_lease_namespace_total_blocks(
+            "vllm",
+            device,
+            namespace_suffix="block-pool",
+        )
+        if total_blocks is None:
+            namespace, total_blocks = read_any_kv_lease_namespace_total_blocks("vllm")
+        if total_blocks is not None:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        if not logged_wait:
+            logger.info(
+                "[GMS-VMM-IPC] Waiting up to %d ms for existing KV lease "
+                "namespace geometry",
+                wait_ms,
+            )
+            logged_wait = True
+        time.sleep(min(0.05, remaining))
+
+    logger.info(
+        "[GMS-VMM-IPC] Reusing existing KV lease namespace geometry: "
+        "namespace=%s blocks=%d",
+        namespace,
+        total_blocks,
+    )
+    return int(total_blocks)
+
+
+def _available_memory_exhausted(available_memory) -> bool:
+    try:
+        if isinstance(available_memory, (int, float)):
+            values = [available_memory]
+        else:
+            values = list(available_memory)
+    except TypeError:
+        return False
+    if not values:
+        return False
+    try:
+        return min(int(value) for value in values) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _geometry_wait_ms(available_memory) -> int:
+    if not _available_memory_exhausted(available_memory):
+        return 0
+    name = "GMS_VLLM_KV_GEOMETRY_WAIT_MS"
+    value = os.environ.get(name)
+    if value is not None:
+        return max(0, _int_env_value(name, value, 300_000))
+
+    if value is None:
+        name = "GMS_KV_LEASE_GEOMETRY_WAIT_MS"
+        value = os.environ.get(name)
+    return max(0, _int_env_value(name, value, 300_000))
+
+
+def _wrap_get_kv_cache_configs(original):
+    if getattr(original, "_gms_geometry_patched", False):
+        return original
+
+    def _patched_get_kv_cache_configs(vllm_config, kv_cache_specs, available_memory):
+        existing_blocks = _existing_shared_kv_blocks(
+            wait_ms=_geometry_wait_ms(available_memory)
+        )
+        if existing_blocks is None:
+            return original(vllm_config, kv_cache_specs, available_memory)
+
+        cache_config = getattr(vllm_config, "cache_config", None)
+        if cache_config is None:
+            return original(vllm_config, kv_cache_specs, available_memory)
+
+        previous_override = getattr(cache_config, "num_gpu_blocks_override", None)
+        if previous_override is not None and int(previous_override) != existing_blocks:
+            logger.warning(
+                "[GMS-VMM-IPC] Existing shared KV pool has %d blocks; "
+                "temporarily replacing num_gpu_blocks_override=%s during attach",
+                existing_blocks,
+                previous_override,
+            )
+
+        cache_config.num_gpu_blocks_override = existing_blocks
+        try:
+            return original(vllm_config, kv_cache_specs, available_memory)
+        finally:
+            cache_config.num_gpu_blocks_override = previous_override
+
+    _patched_get_kv_cache_configs._gms_geometry_patched = True
+    _patched_get_kv_cache_configs._gms_geometry_original = original
+    return _patched_get_kv_cache_configs
+
+
+def install_geometry_patch() -> bool:
+    """Patch vLLM KV sizing to reuse existing GMS shared-KV geometry.
+
+    VMM-IPC reattach already works once vLLM reaches tensor allocation. The
+    missing piece is earlier: vLLM profiles currently free HBM before it builds
+    KVCacheConfig. A shadow/restarted engine can therefore fail or shrink its KV
+    block count before it reaches the GMS persistent allocation path. When the
+    primary has already initialized the shared lease namespace, its header is
+    the authoritative logical block count for subsequent attachers.
+
+    vLLM imports ``get_kv_cache_configs`` into ``vllm.v1.engine.core`` by value,
+    so patching only ``kv_cache_utils`` is not enough if engine core is imported
+    after the first GMS hook. Keep this function idempotent while still updating
+    the late-bound engine-core alias whenever it becomes available.
+    """
+    global _GEOMETRY_PATCH_INSTALLED
+    if not _is_enabled():
+        return False
+
+    try:
+        from vllm.v1.core import kv_cache_utils
+    except ImportError:
+        logger.debug(
+            "[GMS-VMM-IPC] vLLM KV cache utils unavailable; geometry patch skipped"
+        )
+        return False
+
+    changed = False
+    current = kv_cache_utils.get_kv_cache_configs
+    if getattr(current, "_gms_geometry_patched", False):
+        patched = current
+    else:
+        patched = _wrap_get_kv_cache_configs(current)
+        kv_cache_utils.get_kv_cache_configs = patched
+        _GEOMETRY_PATCH_INSTALLED = True
+        changed = True
+
+    engine_core = sys.modules.get("vllm.v1.engine.core")
+    if engine_core is not None and hasattr(engine_core, "get_kv_cache_configs"):
+        if getattr(engine_core, "get_kv_cache_configs") is not patched:
+            engine_core.get_kv_cache_configs = patched
+            changed = True
+
+    if changed:
+        logger.info("[GMS-VMM-IPC] patched vLLM KV cache geometry attach path")
+    return changed
+
+
+def install() -> bool:
+    """Monkey-patch vLLM's KV-cache tensor allocation. Returns True iff
+    a patch was actually installed. Safe to call multiple times; idempotent."""
+    global _INSTALLED
+    if not _is_enabled():
+        logger.debug(
+            "[GMS-VMM-IPC] GMS_VLLM_VMM_IPC_KV not set; skipping install",
+        )
+        return False
+    install_geometry_patch()
+    _install_kv_leases()
+    if _INSTALLED:
+        return False
+
+    # vLLM has two model-runner code paths:
+    #   V1: GPUModelRunner.initialize_kv_cache_tensors → _allocate_kv_cache_tensors
+    #       (in vllm.v1.worker.gpu_model_runner)
+    #   V2: gpu.attn_utils._allocate_kv_cache (module-level function called
+    #       from vllm.v1.worker.gpu.model_runner.GPUModelRunner.initialize_kv_cache)
+    # Patch BOTH so we don't depend on VLLM_USE_V2_MODEL_RUNNER.
+
+    from gpu_memory_service.client.torch.allocator import (
+        clear_persistent_allocator_tag_plan,
+        get_or_create_persistent_allocator,
+        gms_use_persistent_pool,
+        set_persistent_allocator_tag_plan,
+    )
+
+    # ---- V2 patch: module-level _allocate_kv_cache ----
+    try:
+        from vllm.v1.worker.gpu import attn_utils as _gpu_attn_utils
+
+        if hasattr(_gpu_attn_utils, "_allocate_kv_cache"):
+            _orig_v2_alloc = _gpu_attn_utils._allocate_kv_cache
+            if getattr(_orig_v2_alloc, "_gms_vmm_ipc_patched", False):
+                _orig_v2_alloc = getattr(
+                    _orig_v2_alloc, "_gms_original", _orig_v2_alloc
+                )
+
+            def _patched_v2_allocate_kv_cache(
+                kv_cache_config, shared_layers=None, device=None, *args, **kwargs
+            ):
+                # Current vLLM passes (kv_cache_config, shared_layers, device).
+                # Older snapshots passed (kv_cache_config, device). Keep both
+                # shapes working so this integration can ride upstream churn.
+                if device is None:
+                    alloc_device = shared_layers
+                    original_args = (kv_cache_config, shared_layers, *args)
+                else:
+                    alloc_device = device
+                    original_args = (kv_cache_config, shared_layers, device, *args)
+
+                if _KV_CACHE_PROFILING.get():
+                    logger.debug(
+                        "[GMS-VMM-IPC] bypassing persistent pool for vLLM "
+                        "profiling KV allocation"
+                    )
+                    return _orig_v2_alloc(*original_args, **kwargs)
+
+                dev_idx = _device_index(alloc_device)
+                socket = _resolve_socket(dev_idx)
+                engine_id = _engine_id(dev_idx)
+                logger.debug(
+                    "[GMS-VMM-IPC] V2 allocation pid=%d device=%d",
+                    os.getpid(),
+                    dev_idx,
+                )
+                try:
+                    shared_kv = _shared_kv_enabled()
+                    manager = get_or_create_persistent_allocator(
+                        socket,
+                        dev_idx,
+                        engine_id,
+                        tag="kv_pool",
+                        shared=shared_kv,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        "GMS vLLM persistent KV allocator registration failed"
+                    ) from exc
+                tag_plan = _semantic_kv_tensor_tag_plan(kv_cache_config)
+                reattaching = _persistent_tag_plan_reattaches(
+                    manager, engine_id, tag_plan
+                )
+                if tag_plan:
+                    set_persistent_allocator_tag_plan("kv_pool", tag_plan)
+                logger.debug(
+                    "[GMS-VMM-IPC] V2 persistent pool engine_id=%s device=%d "
+                    "reattaching=%s semantic_tags=%d",
+                    engine_id,
+                    dev_idx,
+                    reattaching,
+                    len(tag_plan),
+                )
+                try:
+                    with gms_use_persistent_pool("kv_pool", dev_idx):
+                        with _persistent_kv_zeros_as_empty(
+                            reattaching
+                        ):
+                            return _orig_v2_alloc(*original_args, **kwargs)
+                finally:
+                    if tag_plan:
+                        clear_persistent_allocator_tag_plan("kv_pool")
+
+            _patched_v2_allocate_kv_cache._gms_vmm_ipc_patched = True
+            _patched_v2_allocate_kv_cache._gms_original = _orig_v2_alloc
+            _gpu_attn_utils._allocate_kv_cache = _patched_v2_allocate_kv_cache  # type: ignore[assignment]
+            logger.debug(
+                "[GMS-VMM-IPC] patched V2 allocation in pid=%d",
+                os.getpid(),
+            )
+    except ImportError:
+        pass
+
+    # ---- V1 patch: GPUModelRunner.initialize_kv_cache_tensors ----
+    try:
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+    except ImportError:
+        logger.warning(
+            "[GMS-VMM-IPC] vLLM v1 GPUModelRunner not importable; V1 install skipped",
+        )
+        _INSTALLED = True  # V2 may have succeeded
+        return True
+
+    if not hasattr(GPUModelRunner, "initialize_kv_cache_tensors"):
+        logger.warning(
+            "[GMS-VMM-IPC] vLLM GPUModelRunner.initialize_kv_cache_tensors "
+            "not found; V1 install skipped",
+        )
+        _INSTALLED = True
+        return True
+
+    if hasattr(GPUModelRunner, "initialize_kv_cache"):
+        original_initialize_kv_cache = GPUModelRunner.initialize_kv_cache
+        if not getattr(original_initialize_kv_cache, "_gms_profiling_guard", False):
+
+            def _patched_initialize_kv_cache(self, *args, **kwargs):
+                is_profiling = bool(kwargs.get("is_profiling", False))
+                if len(args) >= 2:
+                    is_profiling = bool(args[1])
+                if not is_profiling:
+                    return original_initialize_kv_cache(self, *args, **kwargs)
+                token = _KV_CACHE_PROFILING.set(True)
+                try:
+                    return original_initialize_kv_cache(self, *args, **kwargs)
+                finally:
+                    _KV_CACHE_PROFILING.reset(token)
+
+            _patched_initialize_kv_cache._gms_profiling_guard = True
+            _patched_initialize_kv_cache._gms_original = original_initialize_kv_cache
+            GPUModelRunner.initialize_kv_cache = _patched_initialize_kv_cache  # type: ignore[assignment]
+
+    original = GPUModelRunner.initialize_kv_cache_tensors
+
+    def _patched_initialize_kv_cache_tensors(self, *args, **kwargs):
+        logger.debug(
+            "[GMS-VMM-IPC] V1 allocation in pid=%d",
+            os.getpid(),
+        )
+        if _KV_CACHE_PROFILING.get():
+            logger.debug(
+                "[GMS-VMM-IPC] bypassing persistent pool for vLLM profiling "
+                "KV tensor initialization"
+            )
+            return original(self, *args, **kwargs)
+
+        device = _device_index(getattr(self, "device", 0))
+        socket = _resolve_socket(device)
+        engine_id = _engine_id(device)
+        try:
+            shared_kv = _shared_kv_enabled()
+            manager = get_or_create_persistent_allocator(
+                socket,
+                device,
+                engine_id,
+                tag="kv_pool",
+                shared=shared_kv,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "GMS vLLM persistent KV allocator registration failed"
+            ) from exc
+        logger.info(
+            "[GMS-VMM-IPC] Allocating vLLM KV-cache through GMS "
+            "persistent pool (engine_id=%s, device=%d)",
+            engine_id,
+            device,
+        )
+        kv_cache_config = args[0] if args else kwargs.get("kv_cache_config")
+        tag_plan = _semantic_kv_tensor_tag_plan(kv_cache_config)
+        reattaching = _persistent_tag_plan_reattaches(manager, engine_id, tag_plan)
+        if tag_plan:
+            set_persistent_allocator_tag_plan("kv_pool", tag_plan)
+        logger.debug(
+            "[GMS-VMM-IPC] V1 persistent pool engine_id=%s device=%d "
+            "reattaching=%s semantic_tags=%d",
+            engine_id,
+            device,
+            reattaching,
+            len(tag_plan),
+        )
+        try:
+            with gms_use_persistent_pool("kv_pool", device):
+                with _persistent_kv_zeros_as_empty(
+                    reattaching
+                ):
+                    return original(self, *args, **kwargs)
+        finally:
+            if tag_plan:
+                clear_persistent_allocator_tag_plan("kv_pool")
+
+    GPUModelRunner.initialize_kv_cache_tensors = _patched_initialize_kv_cache_tensors  # type: ignore[assignment]
+    _INSTALLED = True
+    logger.info(
+        "[GMS-VMM-IPC install] patched GPUModelRunner.initialize_kv_cache_tensors",
+    )
+    return True
+
+
+def install_lazy() -> None:
+    """Register a sys.meta_path finder that calls install() the first
+    time `vllm.v1.worker.gpu_model_runner` is loaded. Designed for use
+    from a .pth file (Python startup): avoids eagerly importing vLLM,
+    which would interfere with pytest's assertion rewriter and other
+    startup-sensitive consumers (e.g. anyio)."""
+    global _LAZY_HOOK_INSTALLED
+    if _LAZY_HOOK_INSTALLED:
+        return
+    if not _is_enabled():
+        return
+
+    targets = {
+        "vllm.v1.core.block_pool",  # Scheduler-side KV lease publication
+        "vllm.v1.engine.core",  # KV sizing call-site imports get_kv_cache_configs by value
+        "vllm.v1.worker.gpu_model_runner",  # V1 path
+        "vllm.v1.worker.gpu.attn_utils",  # V2 path
+    }
+
+    class _PatchAfterLoad:
+        def __init__(self, real_loader):
+            self._real = real_loader
+
+        def create_module(self, spec):
+            if hasattr(self._real, "create_module"):
+                return self._real.create_module(spec)
+            return None
+
+        def exec_module(self, module):
+            self._real.exec_module(module)
+            try:
+                install()
+            except Exception:  # noqa: BLE001
+                logger.exception("[GMS-VMM-IPC] post-load install raised")
+                raise
+
+    class _Finder:
+        def find_spec(self, name, path=None, target_pkg=None):
+            if name not in targets:
+                return None
+            for finder in sys.meta_path:
+                if finder is self:
+                    continue
+                if hasattr(finder, "find_spec"):
+                    spec = finder.find_spec(name, path, target_pkg)
+                    if spec is not None and spec.loader is not None:
+                        try:
+                            sys.meta_path.remove(self)
+                        except ValueError:
+                            pass
+                        spec.loader = _PatchAfterLoad(spec.loader)
+                        return spec
+            return None
+
+    sys.meta_path.insert(0, _Finder())
+    _LAZY_HOOK_INSTALLED = True
+    logger.debug(
+        "[GMS-VMM-IPC] lazy hook armed; will install on first import of %s",
+        sorted(targets),
+    )
+
+
+# Eager install (when this module is imported AFTER vllm — e.g. tests
+# that import vllm first then enable the hook). The .pth file calls
+# install_lazy() instead to avoid eagerly importing vllm.
+if _is_enabled() and "vllm.v1.worker.gpu_model_runner" in sys.modules:
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-VMM-IPC] Auto-install raised")
+        raise

--- a/lib/gpu_memory_service/tests/test_vmm_ipc_failover.py
+++ b/lib/gpu_memory_service/tests/test_vmm_ipc_failover.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end failover proof in VMM-IPC mode.
+
+Engine A allocates KV tensors via gms_use_persistent_pool and stamps
+known patterns. Engine A "dies" (process simulation: tear down its
+client manager + close its handles to the persistent allocations).
+Daemon retains the physical pages. Engine B starts fresh, registers
+under the SAME engine_id, calls gms_use_persistent_pool, gets
+tensors that wrap the SAME PHYSICAL PAGES, and reads the patterns
+back byte-identically.
+
+This is the equivalent of test_failover_at_scale but for the new
+VMM-IPC ownership model — proves that the layer that the per-engine
+installers (P3-P5) sit on top of correctly preserves KV across
+engine restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():  # pragma: no cover
+    pytest.skip("CUDA required", allow_module_level=True)
+
+
+# The async daemon thread raises CancelledError on teardown — that's
+# the expected shutdown path. Silence pytest's strict thread-exception
+# warning for this file.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::pytest.PytestUnhandledThreadExceptionWarning",
+)
+
+
+def _start_daemon(socket_path: str, device: int):
+    from gpu_memory_service.server.rpc import GMSRPCServer
+
+    server = GMSRPCServer(socket_path, device=device, allocation_retry_interval=0.05)
+    holder: dict = {}
+
+    def _runner():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        holder["loop"] = loop
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if server._server is not None and os.path.exists(socket_path):
+            break
+        time.sleep(0.05)
+    assert os.path.exists(socket_path), "daemon did not bind socket"
+    return server, t, holder
+
+
+def _stop_daemon(server, t, holder):
+    loop = holder.get("loop")
+    if loop is not None:
+
+        def _cancel():
+            if server._server is not None:
+                server._server.close()
+
+        loop.call_soon_threadsafe(_cancel)
+    t.join(timeout=5)
+
+
+def _simulate_engine_restart():
+    """Tear down whatever the engine-side allocator left behind so the
+    next get_or_create_persistent_allocator() registers a fresh state.
+    This mimics what happens when the engine subprocess actually dies."""
+    from gpu_memory_service.client.torch import allocator as A
+
+    for tag, state in list(A._tag_states.items()):
+        try:
+            state.manager.abort()
+        except Exception:  # noqa: BLE001
+            pass
+        A._tag_states.pop(tag, None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_allocator_registry():
+    """Wipe the process-global allocator registry around each test
+    to keep state from previous test modules from leaking in. Real
+    engine processes don't share state with each other; this fixture
+    makes the in-process tests match that invariant."""
+    _simulate_engine_restart()
+    yield
+    _simulate_engine_restart()
+
+
+def test_vmm_ipc_engine_restart_preserves_kv_bytes(tmp_path):
+    from gpu_memory_service.client.torch.allocator import (
+        get_or_create_persistent_allocator,
+        gms_use_persistent_pool,
+    )
+
+    device = int(os.environ.get("GMS_TEST_CUDA_DEVICE", "0"))
+    if torch.cuda.device_count() == 0:
+        pytest.skip("no CUDA devices")
+    torch.cuda.set_device(device)
+    _ = torch.empty(1, device=f"cuda:{device}")
+
+    sock = str(tmp_path / "failover-vmm-ipc.sock")
+    server, daemon_thread, holder = _start_daemon(sock, device)
+    try:
+        engine_id = "failover-test-engine"
+        N_LAYERS = 8
+        N_ELEMS = 64 * 1024  # 256 KiB per layer at int32
+        # The first allocation will be rounded up to the VMM
+        # granularity (typically 2 MiB) but Torch's mempool block
+        # size is much larger. To keep this test fast we use a
+        # modest per-layer size and let Torch coalesce.
+
+        # === Engine A: allocate + write known patterns ===
+        get_or_create_persistent_allocator(
+            sock,
+            device,
+            engine_id,
+            tag="kv_pool",
+        )
+        patterns: list[int] = []
+        tensors_a: list[torch.Tensor] = []
+        with gms_use_persistent_pool("kv_pool", device):
+            for layer in range(N_LAYERS):
+                tensors_a.append(
+                    torch.empty(N_ELEMS, dtype=torch.int32, device=f"cuda:{device}")
+                )
+        for layer, t_ in enumerate(tensors_a):
+            pat = 0x10000000 + (layer * 0x100)
+            patterns.append(pat)
+            t_.fill_(pat)
+        torch.cuda.synchronize(device)
+
+        # Verify the daemon sees the same bytes. The daemon's
+        # PersistentAllocationManager will have one persistent
+        # allocation (probably — Torch coalesces into one big block).
+        # Either way, every (engine_id, sub_tag) pair must be present
+        # in the daemon's claimed set.
+        persistent = server._gms.persistent
+        engine_a_allocs = sorted(
+            persistent.list(engine_id),
+            key=lambda a: a.tag,
+        )
+        assert (
+            engine_a_allocs
+        ), "Engine A should have at least one persistent allocation"
+        for alloc in engine_a_allocs:
+            assert persistent.is_claimed(alloc.engine_id, alloc.tag)
+
+        # Snapshot what's in HBM via the engine tensors (for ground truth).
+        ground_truth = [t_.clone().cpu() for t_ in tensors_a]
+
+        # === Engine A "dies" ===
+        del tensors_a
+        _simulate_engine_restart()
+
+        # After the simulated restart the daemon's allocations
+        # persist but the claims are released (cleanup_connection
+        # already ran on the closed connection).
+        for alloc in engine_a_allocs:
+            # Will become unclaimed when the daemon processes the
+            # disconnect. Allow a brief window for cleanup to settle.
+            for _ in range(50):
+                if not persistent.is_claimed(alloc.engine_id, alloc.tag):
+                    break
+                time.sleep(0.02)
+            assert not persistent.is_claimed(alloc.engine_id, alloc.tag), (
+                f"claim should be released after engine A disconnect: "
+                f"{alloc.engine_id}/{alloc.tag}"
+            )
+
+        # === Engine B: same engine_id, fresh client ===
+        get_or_create_persistent_allocator(
+            sock,
+            device,
+            engine_id,
+            tag="kv_pool",
+        )
+        tensors_b: list[torch.Tensor] = []
+        # IMPORTANT: For Engine B's tensors to land at the SAME
+        # PHYSICAL PAGES, the allocation requests have to follow the
+        # same order/shape. The daemon's auto-tag counter resets per
+        # process (because _TagState is per-process), so when engine
+        # B's pluggable allocator calls `kv_pool#0`, `kv_pool#1`, ...
+        # those keys match what engine A used → reattach.
+        with gms_use_persistent_pool("kv_pool", device):
+            for layer in range(N_LAYERS):
+                tensors_b.append(
+                    torch.empty(N_ELEMS, dtype=torch.int32, device=f"cuda:{device}")
+                )
+
+        # Verify Engine B's tensors contain Engine A's data — proves
+        # the same physical pages.
+        for layer, t_ in enumerate(tensors_b):
+            got = t_.cpu()
+            want = ground_truth[layer]
+            assert torch.equal(got, want), (
+                f"layer {layer}: Engine B's tensor does NOT match "
+                f"Engine A's pre-restart contents (first 4 ints: "
+                f"got={got[:4].tolist()} want={want[:4].tolist()})"
+            )
+        print(
+            f"[vmm-ipc failover] {N_LAYERS} layers × {N_ELEMS * 4 // 1024} KiB "
+            f"survived engine restart byte-identically"
+        )
+    finally:
+        _simulate_engine_restart()
+        _stop_daemon(server, daemon_thread, holder)
+
+
+def test_vmm_ipc_sleep_wake_remaps_persistent_kv_bytes(tmp_path):
+    from gpu_memory_service.client.torch.allocator import (
+        get_gms_client_memory_manager,
+        get_or_create_persistent_allocator,
+        gms_use_persistent_pool,
+    )
+    from gpu_memory_service.common.locks import RequestedLockType
+
+    device = int(os.environ.get("GMS_TEST_CUDA_DEVICE", "0"))
+    if torch.cuda.device_count() == 0:
+        pytest.skip("no CUDA devices")
+    torch.cuda.set_device(device)
+    _ = torch.empty(1, device=f"cuda:{device}")
+
+    sock = str(tmp_path / "sleep-wake-vmm-ipc.sock")
+    server, daemon_thread, holder = _start_daemon(sock, device)
+    try:
+        engine_id = "sleep-wake-test-engine"
+        get_or_create_persistent_allocator(
+            sock,
+            device,
+            engine_id,
+            tag="kv_pool",
+        )
+        with gms_use_persistent_pool("kv_pool", device):
+            tensor = torch.empty(128 * 1024, dtype=torch.int32, device=f"cuda:{device}")
+        tensor.fill_(0x51525354)
+        torch.cuda.synchronize(device)
+        expected = tensor.clone().cpu()
+
+        manager = get_gms_client_memory_manager("kv_pool")
+        assert manager is not None
+        assert manager.socket_path == sock
+        manager.unmap_all_vas()
+        manager.abort()
+
+        manager.connect(RequestedLockType.RW)
+        assert manager.socket_path == sock
+        manager.remap_persistent_vas(engine_id)
+
+        observed = tensor.cpu()
+        assert torch.equal(observed, expected)
+    finally:
+        _simulate_engine_restart()
+        _stop_daemon(server, daemon_thread, holder)


### PR DESCRIPTION
## Summary

- Install vLLM KV tensors into daemon-owned persistent VMM allocations.
- Attach a shadow to the same compatible pool without client-local scratch storage.
- Exercise allocation, remapping, and failover cleanup.

## Why this checkpoint

This connects vLLM's native KV tensors to the lifetime mechanism established in the first eight checkpoints.

## Validation

- Focused persistent-pool checkpoint: 12 tests passed.
- Cumulative exact-source MVP suites passed.

## Stack

Checkpoint 9/17 for #12053.

- Previous: #14581
- Next: #13398