### PR TITLE
fix(gms): harden failover lock handoff

### DIFF
--- a/components/src/dynamo/common/gms_failover.py
+++ b/components/src/dynamo/common/gms_failover.py
@@ -10,7 +10,13 @@ import logging
 import os
 import time
 import uuid
-from typing import Any, Callable
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable
+
+from dynamo.common.utils.env import env_bool as _truthy_env
+from dynamo.common.utils.env import env_float as _float_env
+from dynamo.common.utils.env import env_int as _int_env
+from dynamo.common.utils.env import env_set_unless_false
 
 logger = logging.getLogger(__name__)
 
@@ -19,38 +25,10 @@ DEFAULT_FAILOVER_TAGS = ("kv_cache", "weights")
 KEEP_SHADOW_READY_ENV = "DYN_GMS_FAILOVER_KEEP_SHADOW_READY"
 
 
-def _truthy_env(name: str, *, default: bool = False) -> bool:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    return value.lower() in {"1", "true", "yes", "on"}
-
-
-def _int_env(name: str, default: int) -> int:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError:
-        logger.warning("Ignoring invalid %s=%r", name, value)
-        return default
-
-
-def _float_env(name: str, default: float) -> float:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    try:
-        return float(value)
-    except ValueError:
-        logger.warning("Ignoring invalid %s=%r", name, value)
-        return default
-
-
 def _promotion_warmup_enabled(backend_name: str | None = None) -> bool:
     if backend_name:
-        backend_env = f"DYN_{backend_name.upper().replace('-', '_')}_GMS_FAILOVER_PROMOTION_WARMUP"
+        backend = backend_name.upper().replace("-", "_")
+        backend_env = f"DYN_{backend}_GMS_FAILOVER_PROMOTION_WARMUP"
         if backend_env in os.environ:
             return _truthy_env(backend_env)
     return _truthy_env("DYN_GMS_FAILOVER_PROMOTION_WARMUP", default=True)
@@ -189,6 +167,43 @@ async def run_gms_failover_promotion_warmup(
     )
 
 
+@dataclass
+class GmsFailoverActivation:
+    """Result of failover gating.
+
+    Holding ``lock`` keeps the kernel flock fd alive for the active engine.
+    Attach it to the long-lived request handler once the handler exists.
+    """
+
+    enabled: bool = False
+    lock: Any | None = None
+
+    def attach_to(self, target: Any) -> None:
+        if self.lock is not None:
+            setattr(target, "_gms_failover_lock", self.lock)
+
+
+def release_attached_gms_failover_lock_nowait(
+    target: Any,
+    *,
+    backend_name: str,
+) -> bool:
+    """Release a concrete flock from a watchdog thread, if supported."""
+
+    lock = getattr(target, "_gms_failover_lock", None)
+    release_nowait = getattr(lock, "release_nowait", None)
+    if lock is None or not callable(release_nowait):
+        return False
+    if not release_nowait():
+        return False
+    setattr(target, "_gms_failover_lock", None)
+    logger.info(
+        "[GMS failover] %s released active lock from watchdog thread",
+        backend_name,
+    )
+    return True
+
+
 async def release_attached_gms_failover_lock(
     target: Any,
     *,
@@ -204,10 +219,14 @@ async def release_attached_gms_failover_lock(
     lock = getattr(target, "_gms_failover_lock", None)
     if lock is None:
         logger.info(
-            "[GMS failover] %s controlled handoff requested but no active lock is attached",
+            "[GMS failover] %s controlled handoff requested but no active lock "
+            "is attached",
             backend_name,
         )
         return False
+
+    if release_attached_gms_failover_lock_nowait(target, backend_name=backend_name):
+        return True
 
     release = getattr(lock, "release", None)
     if release is None:
@@ -272,6 +291,15 @@ def _promote_content_directory_after_fence(backend_name: str, role: str) -> "set
 
     mode = resolve_directory_mode()
     if mode == "off":
+        return set()
+    if not os.environ.get("GMS_KV_DIRECTORY_MANIFEST", "").strip():
+        message = (
+            "GMS KV failover requires GMS_KV_DIRECTORY_MANIFEST so promotion "
+            "uses the same model/layout identity as the inference engine"
+        )
+        if mode == "authoritative":
+            raise RuntimeError(message)
+        logger.warning("[GMS failover] %s %s", backend_name, message)
         return set()
     socket_path = _directory_socket(backend_name)
     if not socket_path:
@@ -341,6 +369,7 @@ def _reclaim_foreign_kv_leases_after_fence(
         return
     try:
         from gpu_memory_service.integrations.common.kv_lease_client import (
+            default_kv_lease_namespace_suffix,
             reclaim_foreign_kv_leases_in_shm_dir,
             resolve_lease_device,
         )
@@ -353,6 +382,7 @@ def _reclaim_foreign_kv_leases_after_fence(
             device,
             max_blocks_per_file=_failover_reclaim_max_blocks_per_file(),
             protected_blocks=protected_blocks,
+            namespace_suffix=default_kv_lease_namespace_suffix(engine),
         )
         elapsed_ms = (time.monotonic() - started) * 1000.0
         if result.files or result.reclaimed_blocks or result.errors:
@@ -407,4 +437,236 @@ async def run_gms_failover_post_lock_fence(
         )
     _reclaim_foreign_kv_leases_after_fence(
         backend_name, role, protected_blocks=protected_blocks
+    )
+
+
+def _controller_from(owner: Any) -> Any:
+    controller = getattr(owner, "_quiesce_controller", owner)
+    if controller is None:
+        raise RuntimeError(
+            "GMS failover shadow mode requires an engine quiesce controller"
+        )
+    return controller
+
+
+def _lock_factory_or_default(
+    lock_factory: Callable[[str], Any] | None
+) -> Callable[[str], Any]:
+    if lock_factory is not None:
+        return lock_factory
+
+    from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+    return FlockFailoverLock
+
+
+def _failover_lock_inputs(
+    lock_factory: Callable[[str], Any] | None,
+) -> tuple[str, str, bool, Any]:
+    factory = _lock_factory_or_default(lock_factory)
+    lock_path = os.environ.get("FAILOVER_LOCK_PATH", DEFAULT_FAILOVER_LOCK_PATH)
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    engine_name = f"engine-{engine_id}"
+    is_shadow = engine_id != primary_engine_id
+    return lock_path, engine_name, is_shadow, factory(lock_path)
+
+
+def _reject_removed_private_bootstrap(backend_name: str) -> None:
+    backend = backend_name.upper().replace("-", "_")
+    removed = (
+        "DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV",
+        f"DYN_{backend}_GMS_PRIVATE_BOOTSTRAP_KV",
+        f"GMS_{backend}_PRIVATE_BOOTSTRAP_KV",
+    )
+    # Permissive on purpose: a banned option must not slip past this
+    # guard because it was spelled `enabled` rather than `1`.
+    enabled = [name for name in removed if env_set_unless_false(name)]
+    if enabled:
+        raise RuntimeError(
+            "GMS private-bootstrap KV is no longer supported because its "
+            "scratch isolation was removed; unset " + ", ".join(enabled)
+        )
+
+
+def _keep_shadow_ready() -> bool:
+    return _truthy_env(KEEP_SHADOW_READY_ENV, default=True)
+
+
+async def _try_acquire_active_lock(lock: Any, engine_name: str) -> bool:
+    """Try to become active without blocking.
+
+    Inter-pod failover replacement pods can reuse pod index 0 after a failover,
+    while the active holder is now index 1. Static primary-index checks would
+    make that replacement block forever without quiescing. The lock is the
+    source of truth: if it is free, this worker is active; if it is busy, this
+    worker must become a warm shadow and wait.
+    """
+
+    try:
+        from gpu_memory_service.failover_lock.interface import FailoverLockError
+    except ImportError:  # pragma: no cover - default lock import would also fail.
+        FailoverLockError = RuntimeError  # type: ignore[assignment]
+
+    try:
+        await lock.acquire(engine_id=engine_name, timeout=0.0)
+        return True
+    except TypeError:
+        # Minimal test doubles may not accept keyword arguments. Treat those as
+        # uncontended locks so existing unit fakes keep the simple acquire path.
+        await lock.acquire(engine_name)
+        return True
+    except FailoverLockError:
+        return False
+
+
+async def acquire_gms_failover_lock_before_init(
+    *,
+    backend_name: str,
+    lock_factory: Callable[[str], Any] | None = None,
+) -> GmsFailoverActivation:
+    """Acquire the failover lock before engine initialization.
+
+    Use this when the backend may write shared GMS KV during warmup/init. It
+    serializes primary and shadow initialization so only the active engine can
+    create CUDA contexts and mutate the shared KV namespace.
+    """
+
+    if not _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"):
+        return GmsFailoverActivation()
+
+    lock_path, engine_name, is_shadow, lock = _failover_lock_inputs(lock_factory)
+    role = "shadow" if is_shadow else "primary"
+    logger.info(
+        "[GMS failover] %s %s acquiring active lock before engine init at %s",
+        backend_name,
+        role,
+        lock_path,
+    )
+    await lock.acquire(engine_id=engine_name)
+    logger.info(
+        "[GMS failover] %s %s acquired active lock before engine init",
+        backend_name,
+        role,
+    )
+    await run_gms_failover_post_lock_fence(backend_name=backend_name, role=role)
+    return GmsFailoverActivation(
+        enabled=True,
+        lock=lock,
+    )
+
+
+async def prepare_gms_failover(
+    owner: Any,
+    runtime: Any,
+    *,
+    backend_name: str,
+    tags: Iterable[str] = DEFAULT_FAILOVER_TAGS,
+    lock_factory: Callable[[str], Any] | None = None,
+    promotion_warmup: Callable[[], Awaitable[None]] | None = None,
+    warm_standby_before_quiesce: bool = False,
+    activation_barrier: Callable[[], Awaitable[None]] | None = None,
+) -> GmsFailoverActivation:
+    """Gate model registration until this engine owns the shared GMS namespace.
+
+    Bulwark injects ``ENGINE_ID`` and ``FAILOVER_LOCK_PATH`` for all pods. This
+    helper only activates when ``DYN_GMS_FAILOVER_SHADOW_MODE`` is true, so
+    standalone GMS deployments keep the vanilla Dynamo registration path.
+    """
+
+    if not _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"):
+        return GmsFailoverActivation()
+
+    _reject_removed_private_bootstrap(backend_name)
+    lock_path, engine_name, _is_shadow, lock = _failover_lock_inputs(lock_factory)
+
+    logger.info(
+        "[GMS failover] %s attempting active lock at %s",
+        backend_name,
+        lock_path,
+    )
+    if await _try_acquire_active_lock(lock, engine_name):
+        logger.info("[GMS failover] %s active", backend_name)
+        await run_gms_failover_post_lock_fence(
+            backend_name=backend_name,
+            role="active",
+        )
+        if activation_barrier is not None:
+            await activation_barrier()
+        return GmsFailoverActivation(
+            enabled=True,
+            lock=lock,
+        )
+    logger.info(
+        "[GMS failover] %s active lock is held; preparing warm shadow",
+        backend_name,
+    )
+
+    standby_prewarmed = False
+    if warm_standby_before_quiesce:
+        if promotion_warmup is None:
+            raise RuntimeError("warm_standby_before_quiesce requires promotion_warmup")
+        logger.info(
+            "[GMS failover] %s warming lease-protected standby before quiesce",
+            backend_name,
+        )
+        await promotion_warmup()
+        standby_prewarmed = True
+
+    controller = _controller_from(owner)
+    tag_list = list(tags)
+
+    role = "shadow"
+    logger.info(
+        "[GMS failover] %s %s quiescing before discovery registration",
+        backend_name,
+        role,
+    )
+    await controller.quiesce(tag_list)
+
+    set_health_status = getattr(runtime, "set_health_status", None)
+    keep_shadow_ready = _keep_shadow_ready()
+    if set_health_status is not None:
+        if keep_shadow_ready:
+            # Warm shadows stay Kubernetes-ready but remain out of route
+            # discovery until they acquire the active lock.
+            set_health_status(True)
+        else:
+            set_health_status(False)
+
+    logger.info(
+        "[GMS failover] %s %s waiting for active lock at %s",
+        backend_name,
+        role,
+        lock_path,
+    )
+    await lock.acquire(engine_id=engine_name)
+    logger.info(
+        "[GMS failover] %s %s acquired active lock",
+        backend_name,
+        role,
+    )
+    await run_gms_failover_post_lock_fence(backend_name=backend_name, role=role)
+    if activation_barrier is not None:
+        await activation_barrier()
+
+    await controller.resume(tag_list)
+    mark_resumed = getattr(controller, "mark_resumed", None)
+    if mark_resumed is not None:
+        mark_resumed()
+
+    if promotion_warmup is not None and not standby_prewarmed:
+        await promotion_warmup()
+
+    if not keep_shadow_ready and set_health_status is not None:
+        set_health_status(True)
+
+    logger.info(
+        "[GMS failover] %s %s resumed; registering with discovery",
+        backend_name,
+        role,
+    )
+    return GmsFailoverActivation(
+        enabled=True,
+        lock=lock,
     )

--- a/components/src/dynamo/common/tests/test_gms_failover.py
+++ b/components/src/dynamo/common/tests/test_gms_failover.py
@@ -4,7 +4,10 @@
 import pytest
 
 from dynamo.common.gms_failover import (
+    acquire_gms_failover_lock_before_init,
+    prepare_gms_failover,
     release_attached_gms_failover_lock,
+    release_attached_gms_failover_lock_nowait,
     run_gms_failover_post_lock_fence,
     run_gms_failover_promotion_warmup,
 )
@@ -73,6 +76,237 @@ class _BusyOnTryLock(_Lock):
         await super().acquire(engine_id, timeout=timeout)
 
 
+@pytest.mark.asyncio
+async def test_gms_failover_disabled_keeps_vanilla_path(monkeypatch):
+    monkeypatch.delenv("DYN_GMS_FAILOVER_SHADOW_MODE", raising=False)
+    owner = _Owner()
+    runtime = _Runtime()
+
+    activation = await prepare_gms_failover(
+        owner,
+        runtime,
+        backend_name="test",
+        lock_factory=_Lock,
+    )
+
+    assert activation.enabled is False
+    assert owner._quiesce_controller.quiesce_calls == []
+    assert owner._quiesce_controller.resume_calls == []
+    assert runtime.health == []
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_primary_acquires_without_quiesce(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/locks/failover.lock")
+    owner = _Owner()
+
+    activation = await prepare_gms_failover(
+        owner,
+        _Runtime(),
+        backend_name="test",
+        lock_factory=_Lock,
+    )
+
+    assert activation.enabled is True
+    assert activation.lock.path == "/locks/failover.lock"
+    assert activation.lock.acquired == ["engine-0"]
+    assert owner._quiesce_controller.quiesce_calls == []
+
+
+@pytest.mark.asyncio
+async def test_activation_barrier_runs_before_shadow_resume(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    owner = _Owner()
+    events = []
+
+    async def barrier():
+        assert owner._quiesce_controller.resume_calls == []
+        events.append("all-ranks-fenced")
+
+    await prepare_gms_failover(
+        owner,
+        _Runtime(),
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+        activation_barrier=barrier,
+    )
+
+    assert events == ["all-ranks-fenced"]
+    assert owner._quiesce_controller.resume_calls == [["kv_cache"]]
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_shadow_waits_quiesced_then_resumes(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    owner = _Owner()
+    runtime = _Runtime()
+
+    activation = await prepare_gms_failover(
+        owner,
+        runtime,
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+    )
+
+    assert activation.enabled is True
+    assert activation.lock.acquired == ["engine-1"]
+    assert owner._quiesce_controller.quiesce_calls == [["kv_cache"]]
+    assert owner._quiesce_controller.resume_calls == [["kv_cache"]]
+    assert owner._quiesce_controller.mark_resumed_calls == 1
+    assert runtime.health == [True]
+
+    class _Handler:
+        pass
+
+    handler = _Handler()
+    activation.attach_to(handler)
+    assert getattr(handler, "_gms_failover_lock") is activation.lock
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_can_warm_shadow_before_quiesce(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    events = []
+
+    class Controller(_Controller):
+        async def quiesce(self, tags):
+            events.append("quiesce")
+            return await super().quiesce(tags)
+
+        async def resume(self, tags):
+            events.append("resume")
+            return await super().resume(tags)
+
+    owner = _Owner()
+    owner._quiesce_controller = Controller()
+
+    async def warmup():
+        events.append("warmup")
+
+    activation = await prepare_gms_failover(
+        owner,
+        _Runtime(),
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+        promotion_warmup=warmup,
+        warm_standby_before_quiesce=True,
+    )
+
+    assert activation.enabled is True
+    assert events == ["warmup", "quiesce", "resume"]
+
+
+@pytest.mark.asyncio
+async def test_prequiesce_warmup_requires_callback(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    with pytest.raises(RuntimeError, match="requires promotion_warmup"):
+        await prepare_gms_failover(
+            _Owner(),
+            _Runtime(),
+            backend_name="test",
+            lock_factory=_BusyOnTryLock,
+            warm_standby_before_quiesce=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_can_mark_waiting_shadow_unready_when_configured(
+    monkeypatch,
+):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_KEEP_SHADOW_READY", "false")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    owner = _Owner()
+    runtime = _Runtime()
+
+    activation = await prepare_gms_failover(
+        owner,
+        runtime,
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+    )
+
+    assert activation.enabled is True
+    assert runtime.health == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_replacement_primary_index_becomes_shadow_when_lock_busy(
+    monkeypatch,
+):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    # Replacement pods can reuse index 0 after a failover while index 1 is the
+    # current active holder. The lock, not the static index, must decide role.
+    monkeypatch.setenv("ENGINE_ID", "0")
+    owner = _Owner()
+    runtime = _Runtime()
+
+    activation = await prepare_gms_failover(
+        owner,
+        runtime,
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+    )
+
+    assert activation.enabled is True
+    assert activation.lock.acquired == ["engine-0"]
+    assert owner._quiesce_controller.quiesce_calls == [["kv_cache"]]
+    assert owner._quiesce_controller.resume_calls == [["kv_cache"]]
+    assert owner._quiesce_controller.mark_resumed_calls == 1
+    assert runtime.health == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    (
+        "DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV",
+        "DYN_TEST_GMS_PRIVATE_BOOTSTRAP_KV",
+        "GMS_TEST_PRIVATE_BOOTSTRAP_KV",
+    ),
+)
+async def test_gms_failover_private_bootstrap_fails_closed(monkeypatch, name):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv(name, "true")
+
+    with pytest.raises(
+        RuntimeError, match="private-bootstrap KV is no longer supported"
+    ):
+        await prepare_gms_failover(
+            _Owner(),
+            _Runtime(),
+            backend_name="test",
+            tags=["kv_cache"],
+            lock_factory=_Lock,
+        )
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_pre_init_lock_acquires_without_quiesce(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/locks/failover.lock")
+
+    activation = await acquire_gms_failover_lock_before_init(
+        backend_name="test",
+        lock_factory=_Lock,
+    )
+
+    assert activation.enabled is True
+    assert activation.lock.path == "/locks/failover.lock"
+    assert activation.lock.acquired == ["engine-1"]
+
+
+@pytest.mark.asyncio
 async def test_gms_failover_promotion_warmup_drains_non_error_stream(monkeypatch):
     monkeypatch.delenv("DYN_GMS_FAILOVER_PROMOTION_WARMUP", raising=False)
     seen = []
@@ -158,6 +392,140 @@ async def test_gms_failover_post_lock_fence_honors_backend_override(monkeypatch)
     assert sleeps == [0.025]
 
 
+def test_explicit_directory_manifest_is_complete_shared_identity(monkeypatch):
+    from gms_kv_ring.common.content_directory import resolve_manifest_id
+
+    monkeypatch.setenv("GMS_KV_DIRECTORY_MANIFEST", "model-layout-v7")
+
+    assert (
+        resolve_manifest_id("vllm", 16, keyspace="vllm-native-hbm-v1")
+        == "model-layout-v7"
+    )
+    assert resolve_manifest_id("vllm", 0) == "model-layout-v7"
+
+
+def test_authoritative_failover_requires_explicit_directory_manifest(monkeypatch):
+    from dynamo.common.gms_failover import _promote_content_directory_after_fence
+
+    monkeypatch.setenv("GMS_KV_DIRECTORY_MODE", "authoritative")
+    monkeypatch.setenv("GMS_KV_DIRECTORY_SOCKET", "/tmp/not-contacted.sock")
+    monkeypatch.delenv("GMS_KV_DIRECTORY_MANIFEST", raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="requires GMS_KV_DIRECTORY_MANIFEST",
+    ):
+        _promote_content_directory_after_fence("vllm", "shadow")
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_promotes_directory_before_lease_reclaim(monkeypatch):
+    monkeypatch.setenv("GMS_KV_DIRECTORY_MODE", "shadow")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_POST_LOCK_FENCE_MS", "0")
+    order = []
+
+    def promote(backend_name, role):
+        order.append(("promote", backend_name, role))
+
+        return {7, 9}
+
+    async def to_thread(fn, *args):
+        return fn(*args)
+
+    def reclaim(backend_name, role, protected_blocks=None):
+        order.append(("reclaim", backend_name, role, protected_blocks))
+
+    monkeypatch.setattr(
+        "dynamo.common.gms_failover._promote_content_directory_after_fence",
+        promote,
+    )
+    monkeypatch.setattr("dynamo.common.gms_failover.asyncio.to_thread", to_thread)
+    monkeypatch.setattr(
+        "dynamo.common.gms_failover._reclaim_foreign_kv_leases_after_fence",
+        reclaim,
+    )
+
+    await run_gms_failover_post_lock_fence(backend_name="vllm", role="shadow")
+
+    assert order == [
+        ("promote", "vllm", "shadow"),
+        ("reclaim", "vllm", "shadow", {7, 9}),
+    ]
+
+
+def test_post_fence_reclaim_uses_allocator_namespace(monkeypatch):
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.common import kv_lease_client
+
+    from dynamo.common import gms_failover
+
+    monkeypatch.setenv("GMS_KV_LEASES", "1")
+    calls = []
+
+    monkeypatch.setattr(kv_lease_client, "resolve_lease_device", lambda _env: 0)
+    monkeypatch.setattr(
+        kv_lease_client,
+        "reclaim_foreign_kv_leases_in_shm_dir",
+        lambda engine, device, **kwargs: (
+            calls.append((engine, device, kwargs))
+            or SimpleNamespace(files=1, reclaimed_blocks=2, errors=0)
+        ),
+    )
+
+    gms_failover._reclaim_foreign_kv_leases_after_fence(
+        "sglang", "shadow", protected_blocks={7}
+    )
+
+    assert calls[0][0:2] == ("sglang", 0)
+    assert calls[0][2]["namespace_suffix"] == "page-pool"
+    assert calls[0][2]["protected_blocks"] == {7}
+
+
+@pytest.mark.asyncio
+async def test_gms_failover_shadow_runs_warmup_before_ready(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_KEEP_SHADOW_READY", "false")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    order = []
+
+    class _OrderedController:
+        async def quiesce(self, tags):
+            order.append(("quiesce", list(tags)))
+
+        async def resume(self, tags):
+            order.append(("resume", list(tags)))
+
+        def mark_resumed(self):
+            order.append(("mark_resumed", None))
+
+    class _OrderedOwner:
+        _quiesce_controller = _OrderedController()
+
+    async def promotion_warmup():
+        order.append(("warmup", None))
+
+    runtime = _Runtime()
+    activation = await prepare_gms_failover(
+        _OrderedOwner(),
+        runtime,
+        backend_name="test",
+        tags=["kv_cache"],
+        lock_factory=_BusyOnTryLock,
+        promotion_warmup=promotion_warmup,
+    )
+
+    assert activation.enabled is True
+    assert order == [
+        ("quiesce", ["kv_cache"]),
+        ("resume", ["kv_cache"]),
+        ("mark_resumed", None),
+        ("warmup", None),
+    ]
+    assert runtime.health == [False, True]
+
+
+@pytest.mark.asyncio
 async def test_release_attached_gms_failover_lock_releases_and_detaches():
     class _Handler:
         pass
@@ -183,3 +551,21 @@ async def test_release_attached_gms_failover_lock_without_lock_is_noop():
     released = await release_attached_gms_failover_lock(handler, backend_name="test")
 
     assert released is False
+
+
+def test_release_attached_gms_failover_lock_nowait_releases_and_detaches():
+    class _NowaitLock:
+        def __init__(self):
+            self.released = 0
+
+        def release_nowait(self):
+            self.released += 1
+            return True
+
+    handler = _Owner()
+    lock = _NowaitLock()
+    handler._gms_failover_lock = lock
+
+    assert release_attached_gms_failover_lock_nowait(handler, backend_name="test")
+    assert lock.released == 1
+    assert handler._gms_failover_lock is None

--- a/components/src/dynamo/common/utils/env.py
+++ b/components/src/dynamo/common/utils/env.py
@@ -3,18 +3,59 @@
 
 """Helpers for parsing environment variables."""
 
+import logging
 import os
 
-_TRUTHY = ("true", "1", "yes")
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("true", "1", "yes", "on")
 
 
 def env_bool(name: str, *, default: bool = False) -> bool:
     """Return True if env var `name` is set to a truthy value.
 
-    Truthy values (case-insensitive): "true", "1", "yes". Any other non-empty
-    value is treated as False. When the var is unset or empty, returns `default`.
+    Truthy values (case-insensitive): "true", "1", "yes", "on". Any other
+    non-empty value is treated as False. When the var is unset or empty,
+    returns `default`.
     """
     raw = os.environ.get(name)
     if not raw:
         return default
-    return raw.lower() in _TRUTHY
+    return raw.strip().lower() in _TRUTHY
+
+
+def env_set_unless_false(name: str) -> bool:
+    """True when `name` is set to anything that is not explicitly falsey.
+
+    Use this only for guards that refuse a banned or removed option. There the
+    permissive reading is the safe one: `env_bool` would let a typo such as
+    `FOO=enabled` slip past the guard, while this reports it as set.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def env_int(name: str, default: int) -> int:
+    """Return env var `name` as an int, or `default` when unset or invalid."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d", name, raw, default)
+        return default
+
+
+def env_float(name: str, default: float) -> float:
+    """Return env var `name` as a float, or `default` when unset or invalid."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %s", name, raw, default)
+        return default

--- a/lib/gpu_memory_service/failover_lock/flock/lock.py
+++ b/lib/gpu_memory_service/failover_lock/flock/lock.py
@@ -5,6 +5,7 @@ import asyncio
 import fcntl
 import logging
 import os
+import threading
 import time
 
 from gpu_memory_service.failover_lock.interface import FailoverLock, FailoverLockError
@@ -30,6 +31,7 @@ class FlockFailoverLock(FailoverLock):
         self._lock_path = lock_path
         self._fd: int | None = None
         self._engine_id: str | None = None
+        self._state_lock = threading.Lock()
         # True once acquire() had to wait for a predecessor to release the lock
         # (a real failover), False if it acquired immediately (initial bootup).
         self._was_contended: bool = False
@@ -97,41 +99,37 @@ class FlockFailoverLock(FailoverLock):
                 f"{engine_id}: {e}"
             ) from e
 
-        self._fd = fd
-        self._engine_id = engine_id
-
-        # Write identity into the lock file for observability (owner() reads
-        # this). We use raw fd ops because we must keep the fd open — closing
-        # it would release the flock. ftruncate clears any stale content from
-        # the previous holder, lseek rewinds, write stamps our id.
-        os.ftruncate(self._fd, 0)
-        os.lseek(self._fd, 0, os.SEEK_SET)
-        os.write(self._fd, engine_id.encode())
+        # Write identity before publishing the held fd. Keeping the fd open is
+        # what owns the kernel flock.
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, engine_id.encode())
+        with self._state_lock:
+            self._fd = fd
+            self._engine_id = engine_id
 
         logger.info("Failover lock acquired: %s", engine_id)
 
     async def release(self) -> None:
-        if self._fd is None:
-            return
+        self.release_nowait()
 
-        # Guard: only the holder should release. If we don't hold the lock
-        # (e.g. double-release or programming error), closing the fd is a
-        # no-op for flock semantics — but log a warning for visibility.
-        try:
-            current = await self.owner()
-            if current != self._engine_id:
-                logger.warning(
-                    "Releasing lock but owner is %r, expected %r",
-                    current,
-                    self._engine_id,
-                )
-        except OSError as e:
-            logger.debug("Could not read owner during release: %s", e)
+    def release_nowait(self) -> bool:
+        """Release from a liveness/watchdog thread without an event loop.
 
-        logger.info("Failover lock released: %s", self._engine_id)
-        os.close(self._fd)
-        self._fd = None
-        self._engine_id = None
+        Taking and clearing the fd under one lock makes concurrent graceful and
+        crash-path releases idempotent. ``close(2)`` releases the flock.
+        """
+        with self._state_lock:
+            fd = self._fd
+            engine_id = self._engine_id
+            if fd is None:
+                return False
+            self._fd = None
+            self._engine_id = None
+
+        logger.info("Failover lock released: %s", engine_id)
+        os.close(fd)
+        return True
 
     async def owner(self) -> str | None:
         try:

--- a/lib/gpu_memory_service/tests/test_failover_lock.py
+++ b/lib/gpu_memory_service/tests/test_failover_lock.py
@@ -244,3 +244,29 @@ async def test_cross_process_race(lock_path):
 
     # Both finished — both eventually acquired
     assert {r["engine_id"] for r in results} == {"p1", "p2"}
+
+
+@pytest.mark.asyncio
+async def test_release_nowait_is_thread_safe_and_idempotent(lock_path):
+    lock = FlockFailoverLock(lock_path)
+    await lock.acquire("engine-thread")
+
+    results = []
+
+    def release():
+        results.append(lock.release_nowait())
+
+    import threading
+
+    threads = [threading.Thread(target=release) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(results) == [False, True]
+    assert lock._fd is None
+
+    contender = FlockFailoverLock(lock_path)
+    await contender.acquire("contender", timeout=0.1)
+    await contender.release()


### PR DESCRIPTION
## Summary

- Fence directory promotion before reclaiming foreign leases.
- Make release and recovery ownership safe across errors and process death.
- Colocate typed environment parsing with the lifecycle code that depends on it.

## Why this checkpoint

These fixes sit directly after the primitive they harden, making the race conditions and their invariants visible to reviewers.

## Validation

- Focused handoff-hardening checkpoint: 32 tests passed.
- Cumulative common and daemon suites passed.

## Stack

Checkpoint 13/17 for #12053.

- Previous: #14584
- Next: #14587