### PR TITLE
feat(gms/vllm): orchestrate warm shadow takeover

### DIFF
--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -12,6 +12,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.common.engine_monitor import EngineHealthMonitorConfig
+from dynamo.common.utils.graceful_shutdown import is_shutdown_in_progress
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -116,14 +117,15 @@ class VllmEngineMonitor:
                     await asyncio.sleep(self.health_config.interval)
 
             except (EngineDeadError, asyncio.TimeoutError) as e:
-                if self.shutdown_event and self.shutdown_event.is_set():
-                    logger.warning(
-                        "%s: %s while worker shutdown is in progress; "
-                        "stopping health monitoring.",
-                        self.__class__.__name__,
-                        type(e).__name__,
+                if (
+                    self.shutdown_event and self.shutdown_event.is_set()
+                ) or is_shutdown_in_progress():
+                    logger.info(
+                        "vLLM AsyncLLM health check stopped during graceful shutdown: %s",
+                        e,
                     )
                     break
+
                 logger.error(f"Traceback: {traceback.format_exc()}")
                 logger.error(f"vLLM AsyncLLM health check failed: {e}")
                 logger.warning("Initiating Dynamo Runtime shutdown.")

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -48,6 +48,7 @@ from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
 from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
 from dynamo.common.lora.manager import LoRAInfo, get_lora_manager
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
@@ -375,15 +376,22 @@ class VllmEnginePauseController:
     def needs_resume_recovery(self) -> bool:
         return self._generation_paused
 
-    async def pause(self, *args: object) -> bool:
+    async def pause(self, *args: object, clear_cache: bool = True) -> bool:
         if self._is_paused or self._generation_paused:
             return False
 
         level = args[0] if args else None
-        await self._engine_client.pause_generation()
+        if clear_cache:
+            await self._engine_client.pause_generation()
+        else:
+            await self._engine_client.pause_generation(clear_cache=False)
         self._generation_paused = True
         try:
-            if level is None:
+            engine_core = getattr(self._engine_client, "engine_core", None)
+            call_utility = getattr(engine_core, "call_utility_async", None)
+            if not clear_cache and level is not None and callable(call_utility):
+                await call_utility("gms_sleep_no_clear", level, "abort")
+            elif level is None:
                 await self._engine_client.sleep()
             else:
                 await self._engine_client.sleep(level)
@@ -1401,16 +1409,26 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     )
 
                 # Step 2: Abort in-flight requests and wait for them to drain so
-                # generation is fully paused before unmapping memory.
-                if not await self._pause_controller.pause(level):
+                # generation is fully paused before unmapping memory. Preserve KV
+                # when ownership is handed to a waiting shadow.
+                preserve_kv = bool(body.get("release_failover_lock"))
+                if not await self._pause_controller.pause(
+                    level, clear_cache=not preserve_kv
+                ):
                     return {
                         "status": "ok",
                         "message": "Engine already sleeping",
                     }
 
+                lock_released = (
+                    await release_attached_gms_failover_lock(self, backend_name="vllm")
+                    if preserve_kv
+                    else False
+                )
                 return {
                     "status": "ok",
                     "message": f"Engine slept (level={level})",
+                    "failover_lock_released": lock_released,
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")

--- a/components/src/dynamo/vllm/headless.py
+++ b/components/src/dynamo/vllm/headless.py
@@ -19,9 +19,25 @@ so secondary nodes run neither this headless mode nor the backend at all.
 from __future__ import annotations
 
 import argparse
-import os
+import logging
 
 from .args import Config
+
+logger = logging.getLogger(__name__)
+GMS_VLLM_WORKER_CLS = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+
+
+def _configure_gms_vllm_worker(engine_args) -> None:
+    current = getattr(engine_args, "worker_cls", None)
+    if current not in (None, "auto", GMS_VLLM_WORKER_CLS):
+        logger.warning(
+            "[GMS] Overriding user-provided vLLM worker_cls=%s with %s because "
+            "--load-format=gms requires the GMS worker integration",
+            current,
+            GMS_VLLM_WORKER_CLS,
+        )
+    engine_args.worker_cls = GMS_VLLM_WORKER_CLS
+    import gpu_memory_service.integrations.vllm.worker  # noqa: F401
 
 
 def build_headless_namespace(config: Config) -> argparse.Namespace:
@@ -45,11 +61,9 @@ def run_dynamo_headless(config: Config) -> None:
     no Dynamo endpoints. Bypasses DistributedRuntime entirely (no NATS/etcd).
     """
     # Propagate worker_cls for custom load formats so headless workers use
-    # the same model loader settings as the leader node.
+    # the same model loader and patches as the leader node.
     if config.engine_args.load_format == "gms":
-        config.engine_args.worker_cls = (
-            "gpu_memory_service.integrations.vllm.worker.GMSWorker"
-        )
+        _configure_gms_vllm_worker(config.engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -57,12 +71,14 @@ def run_dynamo_headless(config: Config) -> None:
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
             configure_gms_lock_mode(config.engine_args)
             configure_mx_ports(config.engine_args)
 
     # ModelExpress uses vLLM's plugin path with --load-format=modelexpress.
     # Dynamo does not set a custom worker class here.
+
+    # Detect failed secondary ranks before the NCCL collective timeout.
+    _maybe_start_vllm_rank_liveness_client(config)
 
     # Keep the upstream CLI import local so tests that only exercise
     # build_headless_namespace() do not pull in vLLM's full CLI import graph.
@@ -70,3 +86,18 @@ def run_dynamo_headless(config: Config) -> None:
 
     args = build_headless_namespace(config)
     run_headless(args)
+
+
+def _maybe_start_vllm_rank_liveness_client(config: Config) -> None:
+    """Start the worker-side ZMQ rank-liveness channel for headless nodes."""
+    from dynamo.common import rank_liveness as rl
+
+    if not rl.liveness_enabled() or not config.gms_shadow_mode:
+        return
+    engine_args = config.engine_args
+    node_rank = int(getattr(engine_args, "node_rank", 0) or 0)
+    leader_host = getattr(engine_args, "master_addr", None)
+    nnodes = int(getattr(engine_args, "nnodes", 1) or 1)
+    if nnodes <= 1 or node_rank < 1 or not leader_host:
+        return
+    rl.RankLivenessClient(leader_host, node_rank).start()

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
 
 import asyncio
 import json
@@ -13,34 +14,102 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from dynamo.vllm.omni.args import OmniConfig
 
-import uvloop
-from huggingface_hub import try_to_load_from_cache
-from huggingface_hub.utils import HFValidationError
-from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
-from vllm.config import VllmConfig
-from vllm.distributed.kv_events import ZmqEventPublisher
-from vllm.usage.usage_lib import UsageContext
-from vllm.v1.engine.async_llm import AsyncLLM
-from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
 
-from dynamo.common.config_dump import dump_config
-from dynamo.common.configuration.groups.router_args import build_router_config
-from dynamo.common.model_fetch import fetch_model
-from dynamo.common.snapshot.lifecycle import elect_and_wake
-from dynamo.common.snapshot.restore_context import (
+def _early_truthy_env(name: str, *, default: bool = False) -> bool:
+    """Local copy of `dynamo.common.utils.env.env_bool`, kept deliberately.
+
+    The JIT/cache isolation below must run before vLLM (and therefore
+    FlashInfer) is imported, which rules out importing `dynamo.common.utils`
+    here. Keep the truth table identical to `env_bool` so one variable never
+    means different things in different parts of this file.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def _maybe_isolate_jit_cache_dirs_by_container() -> dict[str, tuple[str | None, str]]:
+    """Keep runtime JIT/cache locks pod-local and engine-container-local.
+
+    Bulwark primary and shadow containers can compile or materialize FlashInfer
+    artifacts at the same time. Some Kubernetes-mounted filesystems do not
+    reliably support fcntl locks under that contention, so keep these caches in
+    a container-specific tmpfs namespace before vLLM imports FlashInfer.
+    """
+
+    if not _early_truthy_env(
+        "DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER",
+        default=_early_truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"),
+    ):
+        return {}
+
+    container = os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID")
+    if not container:
+        return {}
+
+    base = os.environ.get("DYN_VLLM_JIT_CACHE_BASE", "/dev/shm/dynamo-jit")
+    container_base = os.path.join(base, container)
+    mappings = {
+        "TMPDIR": "tmp",
+        "XDG_CACHE_HOME": "xdg-cache",
+        "VLLM_CACHE_ROOT": "vllm-cache",
+        "TORCHINDUCTOR_CACHE_DIR": "torchinductor-cache",
+        "TRITON_CACHE_DIR": "triton-cache",
+        "CUDA_CACHE_PATH": "cuda-cache",
+        "FLASHINFER_WORKSPACE_BASE": "flashinfer-workspace",
+        "FLASHINFER_CUBIN_DIR": "flashinfer-cubins",
+        "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR": "vllm-flashinfer-autotune",
+        "TILELANG_CACHE_DIR": "tilelang-cache",
+        "TILELANG_TMP_DIR": "tilelang-tmp",
+    }
+
+    changed: dict[str, tuple[str | None, str]] = {}
+    force = _early_truthy_env("DYN_VLLM_FORCE_CONTAINER_JIT_CACHE", default=True)
+    for name, suffix in mappings.items():
+        previous = os.environ.get(name)
+        value = os.path.join(container_base, suffix)
+        if previous == value:
+            continue
+        if previous and not force and not previous.startswith(base):
+            continue
+        os.environ[name] = value
+        changed[name] = (previous, value)
+    return changed
+
+
+_JIT_CACHE_DIR_ENV_CHANGES = _maybe_isolate_jit_cache_dirs_by_container()
+
+import uvloop  # noqa: E402
+from huggingface_hub import try_to_load_from_cache  # noqa: E402
+from huggingface_hub.utils import HFValidationError  # noqa: E402
+from prometheus_client import REGISTRY, CollectorRegistry, multiprocess  # noqa: E402
+from vllm.config import VllmConfig  # noqa: E402
+from vllm.distributed.kv_events import ZmqEventPublisher  # noqa: E402
+from vllm.usage.usage_lib import UsageContext  # noqa: E402
+from vllm.v1.engine.async_llm import AsyncLLM  # noqa: E402
+from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus  # noqa: E402
+
+from dynamo.common.config_dump import dump_config  # noqa: E402
+from dynamo.common.configuration.groups.router_args import (  # noqa: E402
+    build_router_config,
+)
+from dynamo.common.model_fetch import fetch_model  # noqa: E402
+from dynamo.common.snapshot.lifecycle import elect_and_wake  # noqa: E402
+from dynamo.common.snapshot.restore_context import (  # noqa: E402
     parse_snapshot_restore_runtime_config,
     refresh_snapshot_restore_config,
 )
-from dynamo.common.utils.env import env_bool
-from dynamo.common.utils.graceful_shutdown import install_signal_handlers
-from dynamo.common.utils.prometheus import (
+from dynamo.common.utils.env import env_bool  # noqa: E402
+from dynamo.common.utils.graceful_shutdown import install_signal_handlers  # noqa: E402
+from dynamo.common.utils.prometheus import (  # noqa: E402
     EMBEDDING_CACHE_METRIC_PREFIX,
     LLMBackendMetrics,
     register_engine_metrics_callback,
 )
-from dynamo.common.utils.runtime import create_runtime
-from dynamo.common.utils.topology import apply_topology_config
-from dynamo.llm import (
+from dynamo.common.utils.runtime import create_runtime  # noqa: E402
+from dynamo.common.utils.topology import apply_topology_config  # noqa: E402
+from dynamo.llm import (  # noqa: E402
     KvEventPublisher,
     ModelInput,
     ModelRuntimeConfig,
@@ -53,37 +122,47 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.kv_hints import publish_kv_hint_capabilities
 from dynamo.vllm.worker_factory import WorkerFactory
 
-from . import envs
-from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
-from .cache_info import get_configured_kv_event_block_size
-from .capacity import (
+from . import envs  # noqa: E402
+from .args import (  # noqa: E402
+    Config,
+    _uses_dynamo_connector,
+    configure_rl_logprobs_mode,
+    parse_args,
+)
+from .cache_info import get_configured_kv_event_block_size  # noqa: E402
+from .capacity import (  # noqa: E402
     get_metrics_model_name,
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
     publish_vllm_token_budget,
 )
-from .dp_topology import get_dp_range_for_worker
-from .embedding_worker_processes import (
+from .dp_topology import get_dp_range_for_worker  # noqa: E402
+from .embedding_worker_processes import (  # noqa: E402
     EmbeddingEngineCleanupResource,
     create_shared_embedding_engine_client,
     is_embedding_process_child,
     start_embedding_parent_watchdog,
 )
-from .engine_generate import publish_engine_generate_capability
-from .handlers import apply_data_parallel_runtime_config
-from .headless import run_dynamo_headless
-from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
-from .kv_connector_protocols import (
+from .engine_generate import publish_engine_generate_capability  # noqa: E402
+from .handlers import apply_data_parallel_runtime_config  # noqa: E402
+from .headless import run_dynamo_headless  # noqa: E402
+from .instrumented_scheduler import (  # noqa: E402
+    ENV_FPM_BENCHMARK_OUTPUT_PATH,
+    ENV_FPM_WORKER_ID,
+)
+from .kv_connector_protocols import (  # noqa: E402
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
 )
-from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
-from .multimodal_utils.media_config import create_frontend_media_config
-from .multimodal_utils.models.qwen_video_routing import (
+from .multimodal_utils.cache_config import (  # noqa: E402
+    configure_multimodal_embedding_cache,
+)
+from .multimodal_utils.media_config import create_frontend_media_config  # noqa: E402
+from .multimodal_utils.models.qwen_video_routing import (  # noqa: E402
     publish_vllm_qwen_video_processor_contract,
 )
-from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
-from .snapshot import prepare_snapshot_engine
-from .state_agent import (
+from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory  # noqa: E402
+from .snapshot import prepare_snapshot_engine  # noqa: E402
+from .state_agent import (  # noqa: E402
     StateAgentLifecycle,
     start_attachment_owner,
     state_agent_settings,
@@ -91,6 +170,13 @@ from .state_agent import (
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+if _JIT_CACHE_DIR_ENV_CHANGES:
+    logger.info(
+        "[GMS] Isolated vLLM runtime JIT/cache dirs for container=%s: %s",
+        os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID"),
+        {name: value for name, (_, value) in _JIT_CACHE_DIR_ENV_CHANGES.items()},
+    )
+GMS_VLLM_WORKER_CLS = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
 shutdown_endpoints: list = []
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY = (
@@ -155,6 +241,105 @@ def _register_model_source_path(config: Config, vllm_config: VllmConfig) -> str:
     if getattr(vllm_config.model_config, "model_weights", ""):
         return vllm_config.model_config.model
     return config.model
+
+
+def _gms_failover_shadow_member() -> bool:
+    if not (
+        env_bool("DYN_GMS_FAILOVER_SHADOW_MODE") or env_bool("DYN_VLLM_GMS_SHADOW_MODE")
+    ):
+        return False
+    if env_bool("DYN_VLLM_GMS_ACTIVE_LOCK_HELD"):
+        return False
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    primary_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    return engine_id != primary_id
+
+
+def _is_gms_load_format(engine_args: Any) -> bool:
+    return str(getattr(engine_args, "load_format", "")) == "gms"
+
+
+def _configure_gms_vllm_worker(engine_args: Any) -> None:
+    """Force GMS worker setup early enough for spawned vLLM workers."""
+
+    current = getattr(engine_args, "worker_cls", None)
+    if current not in (None, "auto", GMS_VLLM_WORKER_CLS):
+        logger.warning(
+            "[GMS] Overriding user-provided vLLM worker_cls=%s with %s "
+            "because --load-format=gms requires the GMS worker integration",
+            current,
+            GMS_VLLM_WORKER_CLS,
+        )
+
+    engine_args.worker_cls = GMS_VLLM_WORKER_CLS
+
+    # Import eagerly so model-loader/KV patches fail before vLLM starts worker
+    # processes. Worker subprocesses still resolve the class by string.
+    import gpu_memory_service.integrations.vllm.worker  # noqa: F401
+
+    logger.info("[GMS] vLLM worker_cls configured as %s", GMS_VLLM_WORKER_CLS)
+
+
+def _verify_gms_vllm_worker_config(vllm_config: VllmConfig) -> None:
+    worker_cls = getattr(vllm_config.parallel_config, "worker_cls", None)
+    if worker_cls != GMS_VLLM_WORKER_CLS:
+        raise RuntimeError(
+            "GMS load format requires vLLM worker_cls="
+            f"{GMS_VLLM_WORKER_CLS}, got {worker_cls!r}"
+        )
+    logger.info("[GMS] Final vLLM parallel_config.worker_cls=%s", worker_cls)
+
+
+def _gms_shadow_init_geometry_wait_ms() -> int:
+    names = (
+        "DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS",
+        "GMS_VLLM_KV_GEOMETRY_WAIT_MS",
+        "GMS_KV_LEASE_GEOMETRY_WAIT_MS",
+    )
+    wait_ms = 300_000
+    for name in names:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            wait_ms = int(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", name, value)
+            continue
+        break
+    return max(wait_ms, 0)
+
+
+def _maybe_wait_for_gms_primary_kv_before_init(config: Config) -> None:
+    if getattr(config.engine_args, "load_format", None) != "gms":
+        return
+    if not config.gms_shadow_mode:
+        return
+    if not _gms_failover_shadow_member():
+        return
+    if not env_bool("DYN_VLLM_GMS_WAIT_FOR_PRIMARY_KV_BEFORE_INIT", default=True):
+        return
+
+    from gpu_memory_service.integrations.vllm.install_vmm_ipc_kv import (
+        _existing_shared_kv_blocks,
+    )
+
+    wait_ms = _gms_shadow_init_geometry_wait_ms()
+    logger.info(
+        "[GMS] Shadow engine waiting up to %d ms for primary KV geometry "
+        "before vLLM engine initialization",
+        wait_ms,
+    )
+    blocks = _existing_shared_kv_blocks(wait_ms=wait_ms)
+    if blocks is None:
+        raise RuntimeError(
+            "Timed out waiting for primary GMS KV geometry before shadow "
+            "vLLM engine initialization"
+        )
+    logger.info(
+        "[GMS] Shadow engine observed primary KV geometry before init: blocks=%d",
+        blocks,
+    )
 
 
 async def worker(argv: list[str] | None = None) -> None:
@@ -641,8 +826,8 @@ def setup_vllm_engine(
         if "VLLM_LORA_MODULES_LOADING_TIMEOUT" not in os.environ:
             os.environ["VLLM_LORA_MODULES_LOADING_TIMEOUT"] = "600"
 
-    if engine_args.load_format == "gms":
-        engine_args.worker_cls = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+    if _is_gms_load_format(engine_args):
+        _configure_gms_vllm_worker(engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -650,14 +835,24 @@ def setup_vllm_engine(
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
-            logger.info(
-                "[GMS] Failover enabled: will use scratch KV for initialization until engine is primary"
-            )
             # ENGINE_ID=0 writes weights, all others import (RO).
             # Prevents deadlock during TP>1 failover.
             configure_gms_lock_mode(engine_args)
             configure_mx_ports(engine_args)
+
+    if engine_args.load_format in ("mx-source", "mx-target"):
+        try:
+            from modelexpress import register_modelexpress_loaders
+
+            if config.model_express_url:
+                os.environ["MODEL_EXPRESS_URL"] = config.model_express_url
+            register_modelexpress_loaders()
+            engine_args.worker_cls = "modelexpress.vllm_worker.ModelExpressWorker"
+        except ImportError as e:
+            raise ImportError(
+                f"ModelExpress package required for --load-format={engine_args.load_format}. "
+                "Install with: pip install modelexpress"
+            ) from e
 
     # Must happen before create_engine_config() so vLLM sees ec_transfer_config.
     configure_multimodal_embedding_cache(
@@ -674,6 +869,8 @@ def setup_vllm_engine(
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
+    if _is_gms_load_format(engine_args):
+        _verify_gms_vllm_worker_config(vllm_config)
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None
@@ -726,6 +923,8 @@ def setup_vllm_engine(
     factory = []
     if stat_logger:
         factory.append(stat_logger)
+
+    _maybe_wait_for_gms_primary_kv_before_init(config)
 
     # Time engine initialization
     start_time = time.time()

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
@@ -217,3 +217,30 @@ async def test_health_failure_during_worker_shutdown_stops_monitor(
     monitor._shutdown_engine.assert_not_called()
     monitor.runtime.shutdown.assert_not_called()
     exit_process.assert_not_called()
+
+
+async def test_engine_health_ignores_engine_dead_during_shutdown(mock_engine):
+    shutdown_event = asyncio.Event()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+    mock_engine.check_health.side_effect = EngineDeadError(
+        RuntimeError("engine stopped")
+    )
+
+    with patch(
+        "dynamo.vllm.engine_monitor.is_shutdown_in_progress",
+        return_value=True,
+    ):
+        await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    monitor.runtime.shutdown.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_engine_health_exits_when_shutdown_event_set(mock_engine):
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+
+    await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    mock_engine.check_health.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -164,6 +164,45 @@ async def test_snapshot_prepare_failure_leaves_controller_unpaused():
 
 
 @pytest.mark.asyncio
+async def test_quiesce_can_skip_cache_clear():
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+    )
+    controller = VllmEnginePauseController(engine_client)
+
+    changed = await controller.pause(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_client.sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_quiesce_uses_no_clear_sleep_utility_when_available():
+    engine_core = SimpleNamespace(call_utility_async=AsyncMock())
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+        engine_core=engine_core,
+    )
+    controller = VllmEnginePauseController(engine_client)
+
+    changed = await controller.pause(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_core.call_utility_async.assert_awaited_once_with(
+        "gms_sleep_no_clear", 1, "abort"
+    )
+    engine_client.sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._pause_controller.pause(1)
@@ -246,3 +285,19 @@ async def test_wake_up_returns_error_for_register_failure():
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
     assert handler._pause_controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_sleep_with_handoff_releases_failover_lock():
+    handler = _make_handler()
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.sleep({"level": 1, "release_failover_lock": True})
+
+    assert result["status"] == "ok"
+    assert result["failover_lock_released"] is True
+    handler.engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -2157,3 +2157,235 @@ async def test_generate_text_mode_notifies_for_empty_decoded_token():
 
     assert chunks[0]["choices"][0]["delta"]["content"] == ""
     assert context.notifications == 1
+
+@pytest.fixture(autouse=True)
+def _clear_gms_failover_env_leaks(monkeypatch):
+    monkeypatch.delenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", raising=False)
+    yield
+    monkeypatch.delenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", raising=False)
+
+
+def test_gms_shadow_init_geometry_wait_honors_generic_timeout(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.delenv("GMS_VLLM_KV_GEOMETRY_WAIT_MS", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS", raising=False)
+
+    assert vllm_main._gms_shadow_init_geometry_wait_ms() == 300_000
+
+
+def test_gms_shadow_init_geometry_wait_clamps_negative_timeout(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS", "-1")
+
+    assert vllm_main._gms_shadow_init_geometry_wait_ms() == 0
+
+
+def test_vllm_gms_failover_isolates_jit_cache_by_container(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+    monkeypatch.setenv("FLASHINFER_CUBIN_DIR", "/dev/shm/dynamo-jit/flashinfer-cubins")
+
+    changed = vllm_main._maybe_isolate_jit_cache_dirs_by_container()
+
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/engine-1/tmp"
+    assert (
+        os.environ["FLASHINFER_CUBIN_DIR"]
+        == "/dev/shm/dynamo-jit/engine-1/flashinfer-cubins"
+    )
+    assert changed["TMPDIR"] == (
+        "/dev/shm/dynamo-jit/tmp",
+        "/dev/shm/dynamo-jit/engine-1/tmp",
+    )
+
+
+def test_vllm_gms_failover_jit_cache_isolation_can_be_disabled(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER", "0")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+
+    assert vllm_main._maybe_isolate_jit_cache_dirs_by_container() == {}
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/tmp"
+
+
+async def test_gms_reject_removed_private_bootstrap_options(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    for name in WorkerFactory._REMOVED_PRIVATE_BOOTSTRAP_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    # No knobs set -> no error.
+    WorkerFactory._reject_removed_private_bootstrap_options()
+
+    # Each removed knob must fail closed rather than silently run a shadow
+    # against the shared KV pool before it owns the failover lock.
+    for name in WorkerFactory._REMOVED_PRIVATE_BOOTSTRAP_ENV_VARS:
+        monkeypatch.setenv(name, "1")
+        with pytest.raises(RuntimeError, match="private-bootstrap"):
+            WorkerFactory._reject_removed_private_bootstrap_options()
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_gms_primary_acquires_active_lock_before_registration(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("primary must not quiesce before registration")
+
+    class EngineClient:
+        async def collective_rpc(self, *args, **kwargs):
+            raise AssertionError("primary must not wake_up/promote KV before serving")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        "lock",
+        ("fence", "vllm", "active"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_lock_owner_starts_rank_liveness_monitor(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+    handler = SimpleNamespace()
+    runtime = SimpleNamespace()
+    config = SimpleNamespace(gms_shadow_mode=True)
+    monitored = []
+    monkeypatch.setattr(
+        factory,
+        "_maybe_start_rank_liveness_monitor",
+        lambda candidate, candidate_config: monitored.append(
+            (candidate, candidate_config)
+        ),
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        runtime,
+        config,
+        lock_already_acquired=True,
+        post_lock_fence_already_run=True,
+    )
+
+    assert monitored == [(handler, config)]
+
+
+@pytest.mark.asyncio
+async def test_gms_shadow_sleeps_until_lock_then_wakes(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class PauseController:
+        async def pause(self, *args, **kwargs):
+            events.append(("pause", args, kwargs))
+
+        async def resume(self, *args, **kwargs):
+            events.append("resume")
+
+        def mark_resumed(self):
+            events.append("mark_resumed")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(_pause_controller=PauseController())
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(handler, Runtime(), config)
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("pause", (1,), {"clear_cache": False}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "shadow"),
+        "resume",
+        "mark_resumed",
+    ]

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -305,6 +305,7 @@ async def test_custom_encoder_shutdown_engine_on_startup_failure(
         component="backend",
         endpoint="generate",
         enable_rl=False,
+        gms_shadow_mode=False,
         engine_args=SimpleNamespace(enable_lora=False),
         enable_multimodal=True,
         custom_encoder_class="encoder.Backend",

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -21,8 +21,12 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
 from dynamo.common.model_taints import register_model_taint_route
+from dynamo.common.gms_failover import (
+    release_attached_gms_failover_lock,
+    run_gms_failover_post_lock_fence,
+    run_gms_failover_promotion_warmup,
+)
 from dynamo.common.rl import first_endpoint_response, register_rl_routes
-from dynamo.common.snapshot.lifecycle import elect_and_wake
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.prometheus import (
     LLMBackendMetrics,
@@ -1132,28 +1136,193 @@ class WorkerFactory:
         failover_metrics.set_state("init")
         return failover_metrics
 
+    @staticmethod
+    def _truthy_env(name: str, *, default: bool = False) -> bool:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+    # Private-bootstrap/scratch shadow KV is deferred: the isolated scratch pool
+    # that used to back a shadow's pre-lock init/prewarm has been removed. These
+    # knobs are now unsafe -- with them on, a shadow would init or prewarm against
+    # the SHARED GMS KV pool before it owns the failover lock, corrupting the live
+    # primary's KV. Fail closed rather than silently run against shared KV.
+    _REMOVED_PRIVATE_BOOTSTRAP_ENV_VARS = (
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+        "GMS_VLLM_PRIVATE_BOOTSTRAP_KV",
+        "DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP",
+        "GMS_VLLM_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP",
+        "DYN_VLLM_GMS_PREWARM_SHADOW_BEFORE_LOCK",
+        "DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV",
+    )
+
+    @classmethod
+    def _reject_removed_private_bootstrap_options(cls) -> None:
+        enabled = [
+            name
+            for name in cls._REMOVED_PRIVATE_BOOTSTRAP_ENV_VARS
+            if cls._truthy_env(name)
+        ]
+        if enabled:
+            raise RuntimeError(
+                "Refusing to start the vLLM GMS worker: private-bootstrap/scratch "
+                f"shadow KV options are enabled ({', '.join(enabled)}), but the "
+                "isolated scratch KV that made them safe has been removed. With "
+                "these enabled a shadow would initialize or prewarm against the "
+                "SHARED GMS KV pool before it owns the failover lock, which would "
+                "corrupt the live primary's KV. Unset them; shadow prewarm is "
+                "deferred pending a replacement mechanism."
+            )
+
+    async def _acquire_failover_lock(self, *, timeout: float | None = None):
+        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        lock = FlockFailoverLock(lock_path)
+        await lock.acquire(engine_id=f"engine-{engine_id}", timeout=timeout)
+        return lock
+
+    async def _wake_up_kv_fenced(self, handler, tags: list[str]) -> None:
+        """Run collective_rpc('wake_up') with a bounded timeout, fail-closed.
+
+        A promotion remap that wedges (CUDA error, stuck engine core) must not
+        leave this process holding the failover lock while it reports healthy --
+        that is an unrecoverable partial failover that locks out every other
+        standby. On timeout, raise so the process exits and the kernel releases
+        the flock for another standby.
+        """
+        timeout = float(
+            os.environ.get("DYN_GMS_FAILOVER_WAKEUP_TIMEOUT_SECS", "120")
+        )
+        try:
+            await asyncio.wait_for(
+                handler.engine_client.collective_rpc(
+                    "wake_up", kwargs={"tags": tags}
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.critical(
+                "[GMS failover] wake_up/remap did not complete within %.0fs; "
+                "failing closed so the failover lock is released",
+                timeout,
+            )
+            raise
+
+    def _maybe_start_rank_liveness_monitor(self, handler, config: Config):
+        """Leader side of the cross-node ZMQ rank-liveness channel.
+
+        Only the rank-0 leader runs worker_factory (headless workers bypass it),
+        so reaching here means we are the active leader. On a worker node going
+        silent (process death), release the failover lock so the warm shadow
+        promotes in ~one heartbeat-timeout, then signal a graceful shutdown of the
+        now-broken leader — instead of waiting out the NCCL collective timeout.
+        """
+        import signal
+
+        from dynamo.common import rank_liveness as rl
+
+        if not rl.liveness_enabled() or not getattr(config, "gms_shadow_mode", False):
+            return None
+        nnodes = int(getattr(config.engine_args, "nnodes", 1) or 1)
+        if nnodes <= 1:
+            return None
+
+        loop = asyncio.get_running_loop()
+
+        def on_rank_lost(rank: int, reason: str) -> None:
+            logger.warning(
+                "[GMS liveness] vLLM worker rank %d lost (%s); releasing lock + "
+                "shutting down broken leader for fast shadow promotion",
+                rank,
+                reason,
+            )
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    release_attached_gms_failover_lock(handler, backend_name="vllm"),
+                    loop,
+                )
+            except Exception:
+                logger.debug(
+                    "[GMS liveness] lock release on rank loss failed", exc_info=True
+                )
+            # The cohort is broken (a TP rank is gone); bring the leader down so it
+            # stops holding the GPU/KV and the shadow (now lock holder) serves.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        monitor = rl.RankLivenessMonitor(on_rank_lost, expected_ranks=range(1, nnodes))
+        setattr(handler, "_gms_rank_liveness_monitor", monitor)
+        monitor.start()
+        logger.info("[GMS liveness] started vLLM leader rank-liveness monitor")
+        return monitor
+
     async def _maybe_wait_for_failover_lock(
         self,
         handler,
         runtime: DistributedRuntime,
         config: Config,
         failover_metrics=None,
+        *,
+        lock_already_acquired: bool = False,
+        promotion_warmup: Callable[[], Awaitable[None]] | None = None,
+        post_lock_fence_already_run: bool = False,
     ) -> bool:
-        # Shadow mode: sleep → probe → block on lock → wake. True only for a real
-        # (contended) failover, not the initial bootup. The election itself is
-        # shared with the snapshot restore path, which arrives already paused;
-        # a cold-start engine is awake, so it sleeps here first.
-        if config.gms_shadow_mode is not True:
+        """Elect one active GMS writer and prepare it before discovery registration."""
+        if not config.gms_shadow_mode:
             return False
 
-        await handler._pause_controller.pause(1)
-        lock = await elect_and_wake(
-            handler._pause_controller,
-            runtime,
-            lock_path=os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock"),
-            failover_metrics=failover_metrics,
+        if lock_already_acquired:
+            if not post_lock_fence_already_run:
+                await run_gms_failover_post_lock_fence(
+                    backend_name="vllm", role="pre-init"
+                )
+            self._maybe_start_rank_liveness_monitor(handler, config)
+            logger.info(
+                "[Shadow] Failover lock already acquired before engine init; "
+                "registering with discovery"
+            )
+            return False
+
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+        is_shadow = engine_id != primary_engine_id
+        if not is_shadow:
+            logger.info("[Primary] Acquiring active failover lock before discovery")
+            lock = await self._acquire_failover_lock()
+            setattr(handler, "_gms_failover_lock", lock)
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm", role="active"
+            )
+            self._maybe_start_rank_liveness_monitor(handler, config)
+            return False
+
+        # The pre-initialized standby relinquishes its writer role without clearing
+        # prefix metadata, then waits while remaining healthy but undiscoverable.
+        await handler._pause_controller.pause(1, clear_cache=False)
+        if failover_metrics is not None:
+            failover_metrics.set_state("standby")
+        runtime.set_health_status(True)
+        logger.info("[Shadow] Engine sleeping, waiting for failover lock")
+        lock = await self._acquire_failover_lock()
+        setattr(handler, "_gms_failover_lock", lock)
+        was_contended = bool(getattr(lock, "was_contended", False))
+        if failover_metrics is not None:
+            failover_metrics.set_state("waking")
+            if was_contended:
+                failover_metrics.record_switch_attempt()
+        await run_gms_failover_post_lock_fence(
+            backend_name="vllm", role="shadow"
         )
-        return lock is not None and lock.was_contended
+        await handler._pause_controller.resume()
+        handler._pause_controller.mark_resumed()
+        if promotion_warmup is not None:
+            await promotion_warmup()
+        logger.info("[Shadow] Engine awake, registering with discovery")
+        return was_contended
 
     async def _create_decode_worker(
         self,
@@ -1189,6 +1358,7 @@ class WorkerFactory:
         lifecycle: _DecodeWorkerLifecycle,
     ) -> None:
         """Initialize and serve a decode worker."""
+        self._reject_removed_private_bootstrap_options()
 
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
@@ -1233,6 +1403,33 @@ class WorkerFactory:
         failover_metrics = self._maybe_create_failover_metrics(
             config, generate_endpoint
         )
+        early_failover_lock = None
+        early_failover_fence_run = False
+        lock_before_init = os.environ.get("DYN_VLLM_GMS_LOCK_BEFORE_INIT", "1").lower()
+        if config.gms_shadow_mode and lock_before_init not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }:
+            logger.info(
+                "[Shadow] Waiting for failover lock before vLLM engine init "
+                "to protect shared GMS KV warmup"
+            )
+            # Signal startup/liveness health BEFORE blocking on the lock so a
+            # waiting standby's probe passes and the orchestrator does not kill
+            # it (CrashLoopBackOff) while the primary holds the lock. This is
+            # liveness only -- the engine is not registered for serving until
+            # init and discovery registration complete further below.
+            runtime.set_health_status(True)
+            early_failover_lock = await self._acquire_failover_lock()
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role=f"engine-{os.environ.get('ENGINE_ID', '0')}-pre-init",
+            )
+            early_failover_fence_run = True
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "1"
+            logger.info("[Shadow] Failover lock acquired before vLLM engine init")
 
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
@@ -1297,6 +1494,8 @@ class WorkerFactory:
         )
         lifecycle.handler = handler
         handler.add_temp_dir(prometheus_temp_dir)
+        if early_failover_lock is not None:
+            setattr(handler, "_gms_failover_lock", early_failover_lock)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
         consolidator_enabled = False
@@ -1363,10 +1562,25 @@ class WorkerFactory:
                 "The chat template will be loaded but the /v1/chat/completions endpoint will not be available."
             )
 
+        health_check_payload = VllmHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
         was_failover = False
         if snapshot_engine is None:
             was_failover = await self._maybe_wait_for_failover_lock(
-                handler, runtime, config, failover_metrics
+                handler,
+                runtime,
+                config,
+                failover_metrics,
+                lock_already_acquired=early_failover_lock is not None,
+                promotion_warmup=promotion_warmup,
+                post_lock_fence_already_run=early_failover_fence_run,
             )
 
         # Wait for self-benchmark to complete before registering.
@@ -1412,10 +1626,6 @@ class WorkerFactory:
             failover_metrics.set_state("active")
             if was_failover:
                 failover_metrics.record_switch_success()
-
-        health_check_payload = VllmHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"
@@ -1518,6 +1728,7 @@ class WorkerFactory:
         """
         Instantiate and serve
         """
+        self._reject_removed_private_bootstrap_options()
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
@@ -1653,10 +1864,23 @@ class WorkerFactory:
             lora_enabled=config.engine_args.enable_lora,
         )
 
+        health_check_payload = VllmPrefillHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
         was_failover = False
         if snapshot_engine is None:
             was_failover = await self._maybe_wait_for_failover_lock(
-                handler, runtime, config, failover_metrics
+                handler,
+                runtime,
+                config,
+                failover_metrics,
+                promotion_warmup=promotion_warmup,
             )
 
         # Wait for self-benchmark to complete before registering.
@@ -1708,10 +1932,6 @@ class WorkerFactory:
             failover_metrics.set_state("active")
             if was_failover:
                 failover_metrics.record_switch_success()
-
-        health_check_payload = VllmPrefillHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         prefill_metrics_labels = [
             (

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -1222,14 +1222,18 @@ class WorkerFactory:
         promotes in ~one heartbeat-timeout, then signal a graceful shutdown of the
         now-broken leader — instead of waiting out the NCCL collective timeout.
         """
+        if not getattr(config, "gms_shadow_mode", False):
+            return None
+        engine_args = getattr(config, "engine_args", None)
+        nnodes = int(getattr(engine_args, "nnodes", 1) or 1)
+        if nnodes <= 1:
+            return None
+
         import signal
 
         from dynamo.common import rank_liveness as rl
 
-        if not rl.liveness_enabled() or not getattr(config, "gms_shadow_mode", False):
-            return None
-        nnodes = int(getattr(config.engine_args, "nnodes", 1) or 1)
-        if nnodes <= 1:
+        if not rl.liveness_enabled():
             return None
 
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary

- Initialize a vLLM shadow, put it into level-2 sleep, and keep it out of discovery.
- Wake and register it only after it owns the failover fence.
- Keep TP rank-liveness coordination out of this one-GPU MVP checkpoint.

## Why this checkpoint

Pre-initialization removes model startup from the user-visible failover path while preserving a single active writer.

## Validation

- Focused worker-factory, sleep/wake, monitor, and orchestration suites: 243 tests passed.
- Authoritative local GPU failover passed.

## Stack

Checkpoint 15/17 for #12053.

- Previous: #14587
- Next: #12032