### PR TITLE
fix(profiler): stop THOROUGH profiling crashing on its first candidate deployment

### DIFF
--- a/deploy/utils/dynamo_deployment.py
+++ b/deploy/utils/dynamo_deployment.py
@@ -141,6 +141,13 @@ class DynamoDeploymentClient:
         self.model_name = model_name
         self.service_name = service_name or f"{self.deployment_name}-frontend"
         self.components: List[str] = []  # Will store component names from CR
+        self._original_components: List[str] = []
+        # Version segment of the DynamoGraphDeployment apiVersion this client
+        # talks to. `create_deployment` overwrites it with the version the
+        # supplied manifest declares; both nvidia.com/v1alpha1 and
+        # nvidia.com/v1beta1 are served, and the request path has to agree
+        # with the body or the API server rejects it.
+        self.api_version: str = "v1beta1"
         self.deployment_spec: Optional[
             Dict[str, Any]
         ] = None  # Will store the full deployment spec
@@ -261,10 +268,21 @@ class DynamoDeploymentClient:
             self.deployment_spec is not None
         ), "Failed to load deployment specification"
 
-        # Extract component names (original case for label queries, lowercase for directories)
-        self._original_components = list(
-            self.deployment_spec["spec"]["services"].keys()
-        )
+        self.api_version = (
+            self.deployment_spec.get("apiVersion") or "nvidia.com/v1beta1"
+        ).split("/")[-1]
+
+        # Extract component names (original case for label queries, lowercase for directories).
+        # v1beta1 spells this `spec.components`, a list of objects each with a
+        # `name`; v1alpha1 spelled it `spec.services`, a mapping keyed by name.
+        # Both shapes reach this client, so branch on the shape rather than on
+        # the declared version.
+        spec = self.deployment_spec["spec"]
+        components = spec.get("components")
+        if isinstance(components, list):
+            self._original_components = [component["name"] for component in components]
+        else:
+            self._original_components = list(spec["services"].keys())
         self.components = [svc.lower() for svc in self._original_components]
 
         # Ensure name and namespace are set correctly
@@ -281,7 +299,7 @@ class DynamoDeploymentClient:
             if self.namespace == dgdr_namespace:
                 self.deployment_spec["metadata"]["ownerReferences"] = [
                     {
-                        "apiVersion": "nvidia.com/v1alpha1",
+                        "apiVersion": "nvidia.com/v1beta1",
                         "kind": "DynamoGraphDeploymentRequest",
                         "name": dgdr_name,
                         "uid": dgdr_uid,
@@ -294,7 +312,7 @@ class DynamoDeploymentClient:
         try:
             await self.custom_api.create_namespaced_custom_object(
                 group="nvidia.com",
-                version="v1alpha1",
+                version=self.api_version,
                 namespace=self.namespace,
                 plural="dynamographdeployments",
                 body=self.deployment_spec,
@@ -404,7 +422,7 @@ class DynamoDeploymentClient:
             try:
                 status = await self.custom_api.get_namespaced_custom_object(
                     group="nvidia.com",
-                    version="v1alpha1",
+                    version=self.api_version,
                     namespace=self.namespace,
                     plural="dynamographdeployments",
                     name=self.deployment_name,
@@ -622,7 +640,7 @@ class DynamoDeploymentClient:
         try:
             await self.custom_api.delete_namespaced_custom_object(
                 group="nvidia.com",
-                version="v1alpha1",
+                version=self.api_version,
                 namespace=self.namespace,
                 plural="dynamographdeployments",
                 name=self.deployment_name,

--- a/deploy/utils/dynamo_deployment.py
+++ b/deploy/utils/dynamo_deployment.py
@@ -142,11 +142,8 @@ class DynamoDeploymentClient:
         self.service_name = service_name or f"{self.deployment_name}-frontend"
         self.components: List[str] = []  # Will store component names from CR
         self._original_components: List[str] = []
-        # Version segment of the DynamoGraphDeployment apiVersion this client
-        # talks to. `create_deployment` overwrites it with the version the
-        # supplied manifest declares; both nvidia.com/v1alpha1 and
-        # nvidia.com/v1beta1 are served, and the request path has to agree
-        # with the body or the API server rejects it.
+        # Version segment of the DynamoGraphDeployment apiVersion, reset from the
+        # manifest in create_deployment: the request path must match the body.
         self.api_version: str = "v1beta1"
         self.deployment_spec: Optional[
             Dict[str, Any]
@@ -272,11 +269,9 @@ class DynamoDeploymentClient:
             self.deployment_spec.get("apiVersion") or "nvidia.com/v1beta1"
         ).split("/")[-1]
 
-        # Extract component names (original case for label queries, lowercase for directories).
+        # Extract component names (original case for label queries, lowercase for directories)
         # v1beta1 spells this `spec.components`, a list of objects each with a
         # `name`; v1alpha1 spelled it `spec.services`, a mapping keyed by name.
-        # Both shapes reach this client, so branch on the shape rather than on
-        # the declared version.
         spec = self.deployment_spec["spec"]
         components = spec.get("components")
         if isinstance(components, list):

--- a/deploy/utils/tests/test_dynamo_deployment.py
+++ b/deploy/utils/tests/test_dynamo_deployment.py
@@ -62,3 +62,73 @@ async def test_wait_for_deployment_ready_raises_deployment_failed_on_crashloop(
     # Confirm we didn't run out the timeout — there should have been at
     # most one DGD status check before the raise.
     assert client.custom_api.get_namespaced_custom_object.await_count == 1
+
+
+def _mocked_client() -> DynamoDeploymentClient:
+    """A client whose Kubernetes API calls are recorded instead of sent."""
+    client = DynamoDeploymentClient(namespace="ns", deployment_name="dgd-test")
+    client._init_kubernetes = AsyncMock()  # type: ignore[method-assign]
+    client.custom_api = MagicMock()
+    client.custom_api.create_namespaced_custom_object = AsyncMock()
+    client.custom_api.delete_namespaced_custom_object = AsyncMock()
+    return client
+
+
+async def test_create_deployment_reads_v1beta1_components():
+    """A v1beta1 candidate (DYN-4332) must deploy without a KeyError.
+
+    ``materialize_dgd`` has produced ``spec.components`` — a list of objects
+    each carrying a ``name`` — since DGD generation moved to v1beta1, while
+    this client still read the v1alpha1 ``spec.services`` mapping.
+    """
+    client = _mocked_client()
+
+    await client.create_deployment(
+        {
+            "apiVersion": "nvidia.com/v1beta1",
+            "kind": "DynamoGraphDeployment",
+            "metadata": {"name": "candidate", "namespace": "ns"},
+            "spec": {
+                "components": [
+                    {"name": "Frontend"},
+                    {"name": "VllmPrefillWorker"},
+                ]
+            },
+        }
+    )
+
+    # Original case drives the nvidia.com/dynamo-component label selector;
+    # the lowercase projection names the per-component log directory.
+    assert client._original_components == ["Frontend", "VllmPrefillWorker"]
+    assert client.components == ["frontend", "vllmprefillworker"]
+
+    create_kwargs = client.custom_api.create_namespaced_custom_object.await_args.kwargs
+    assert create_kwargs["version"] == "v1beta1"
+
+    await client.delete_deployment()
+    delete_kwargs = client.custom_api.delete_namespaced_custom_object.await_args.kwargs
+    assert delete_kwargs["version"] == "v1beta1"
+
+
+async def test_create_deployment_reads_v1alpha1_services():
+    """Negative control: v1alpha1 manifests still work.
+
+    ``create_deployment`` accepts any DynamoGraphDeployment YAML, and the
+    repository still carries v1alpha1 manifests using ``spec.services``.
+    """
+    client = _mocked_client()
+
+    await client.create_deployment(
+        {
+            "apiVersion": "nvidia.com/v1alpha1",
+            "kind": "DynamoGraphDeployment",
+            "metadata": {"name": "candidate", "namespace": "ns"},
+            "spec": {"services": {"Frontend": {}, "VllmPrefillWorker": {}}},
+        }
+    )
+
+    assert client._original_components == ["Frontend", "VllmPrefillWorker"]
+    assert client.components == ["frontend", "vllmprefillworker"]
+
+    create_kwargs = client.custom_api.create_namespaced_custom_object.await_args.kwargs
+    assert create_kwargs["version"] == "v1alpha1"

--- a/deploy/utils/tests/test_dynamo_deployment.py
+++ b/deploy/utils/tests/test_dynamo_deployment.py
@@ -65,7 +65,6 @@ async def test_wait_for_deployment_ready_raises_deployment_failed_on_crashloop(
 
 
 def _mocked_client() -> DynamoDeploymentClient:
-    """A client whose Kubernetes API calls are recorded instead of sent."""
     client = DynamoDeploymentClient(namespace="ns", deployment_name="dgd-test")
     client._init_kubernetes = AsyncMock()  # type: ignore[method-assign]
     client.custom_api = MagicMock()
@@ -75,7 +74,7 @@ def _mocked_client() -> DynamoDeploymentClient:
 
 
 async def test_create_deployment_reads_v1beta1_components():
-    """A v1beta1 candidate (DYN-4332) must deploy without a KeyError.
+    """A v1beta1 candidate must deploy without a KeyError.
 
     ``materialize_dgd`` has produced ``spec.components`` — a list of objects
     each carrying a ``name`` — since DGD generation moved to v1beta1, while

--- a/deploy/utils/tests/test_dynamo_deployment.py
+++ b/deploy/utils/tests/test_dynamo_deployment.py
@@ -110,25 +110,31 @@ async def test_create_deployment_reads_v1beta1_components():
     assert delete_kwargs["version"] == "v1beta1"
 
 
-async def test_create_deployment_reads_v1alpha1_services():
-    """Negative control: v1alpha1 manifests still work.
+async def test_create_deployment_owner_reference_targets_v1beta1_dgdr(monkeypatch):
+    """The owner reference must name a DGDR version the API server serves.
 
-    ``create_deployment`` accepts any DynamoGraphDeployment YAML, and the
-    repository still carries v1alpha1 manifests using ``spec.services``.
+    Profiling DGDs are garbage-collected through this reference when the
+    owning DynamoGraphDeploymentRequest is deleted. The DGDR CRD stores
+    v1beta1, so a reference declaring v1alpha1 would leak every profiling
+    deployment once v1alpha1 stops being served.
     """
+    monkeypatch.setenv("DGDR_NAME", "dgdr-test")
+    monkeypatch.setenv("DGDR_NAMESPACE", "ns")
+    monkeypatch.setenv("DGDR_UID", "8f0b0f4e-0000-4000-8000-000000000000")
+
     client = _mocked_client()
 
     await client.create_deployment(
         {
-            "apiVersion": "nvidia.com/v1alpha1",
+            "apiVersion": "nvidia.com/v1beta1",
             "kind": "DynamoGraphDeployment",
             "metadata": {"name": "candidate", "namespace": "ns"},
-            "spec": {"services": {"Frontend": {}, "VllmPrefillWorker": {}}},
+            "spec": {"components": [{"name": "Frontend"}]},
         }
     )
 
-    assert client._original_components == ["Frontend", "VllmPrefillWorker"]
-    assert client.components == ["frontend", "vllmprefillworker"]
-
     create_kwargs = client.custom_api.create_namespaced_custom_object.await_args.kwargs
-    assert create_kwargs["version"] == "v1alpha1"
+    owner_references = create_kwargs["body"]["metadata"]["ownerReferences"]
+    assert owner_references[0]["apiVersion"] == "nvidia.com/v1beta1"
+    assert owner_references[0]["kind"] == "DynamoGraphDeploymentRequest"
+    assert owner_references[0]["name"] == "dgdr-test"


### PR DESCRIPTION
Source issue: [DYN-4332](https://linear.app/nvidia/issue/DYN-4332).

## Overview:

A `DynamoGraphDeploymentRequest` with `spec.searchStrategy: thorough` failed on its very first candidate with `KeyError: 'services'`, so THOROUGH profiling deployed nothing at all. `DynamoDeploymentClient` in `deploy/utils/dynamo_deployment.py` still read the `nvidia.com/v1alpha1` shape of the manifests it is handed, while profiler DGD generation now emits `nvidia.com/v1beta1`.

## Details:

`create_deployment` now picks component names by shape. v1beta1 spells them `spec.components`, a list of objects that each carry a `name`; v1alpha1 spelled them `spec.services`, a mapping keyed by name. Branching on the shape keeps older manifests working.

The same code path also sent every request to a hardcoded `version="v1alpha1"` while posting a body that declared v1beta1, which the API server rejects because the body's API version must match the request path. The client now derives the version from the manifest's own `apiVersion` field and uses it for the create, the readiness poll, and the delete. The `ownerReferences` entry — how Kubernetes garbage-collects a profiling deployment together with its owning `DynamoGraphDeploymentRequest` — now names `nvidia.com/v1beta1`, the version the DGDR CRD stores.

## Where should the reviewer start?

`deploy/utils/dynamo_deployment.py`, in `DynamoDeploymentClient.create_deployment`: the shape branch and the `self.api_version` derivation that replaces the three hardcoded versions.

## Validation

`pytest deploy/utils/tests/test_dynamo_deployment.py` passes. Its two new tests deploy a v1beta1 candidate against a mocked Kubernetes client and assert the component names, the `version=` used on create and delete, and the owner reference; both fail against the unfixed source. `pre-commit run --files deploy/utils/dynamo_deployment.py deploy/utils/tests/test_dynamo_deployment.py` passes. The end-to-end THOROUGH run needs a 16-GPU cluster and was not run here.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for both v1beta1 and v1alpha1 deployment resources.
  - Deployment operations now automatically use the API version specified in the manifest.
  - Component information is supported from both `spec.components` and `spec.services`.
  - Improved compatibility across supported deployment resource versions.

- **Tests**
  - Added coverage for v1beta1 component handling, deployment lifecycle operations, and owner references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->