### PR TITLE
test(operator): cover the DGDR hub-only spec annotation and add DGDR to the conversion field tripwire

### DIFF
--- a/deploy/operator/api/v1alpha1/conversion_field_coverage_test.go
+++ b/deploy/operator/api/v1alpha1/conversion_field_coverage_test.go
@@ -92,6 +92,44 @@ DynamoComponentDeploymentStatus.component.scheduledReplicas
 DynamoComponentDeploymentStatus.component.updatedReplicas
 DynamoComponentDeploymentStatus.conditions
 DynamoComponentDeploymentStatus.observedGeneration
+DynamoGraphDeploymentRequestSpec.autoApply
+DynamoGraphDeploymentRequestSpec.backend
+DynamoGraphDeploymentRequestSpec.features.kvRouter.enabled
+DynamoGraphDeploymentRequestSpec.features.mocker.enabled
+DynamoGraphDeploymentRequestSpec.features.planner
+DynamoGraphDeploymentRequestSpec.hardware.gpuSku
+DynamoGraphDeploymentRequestSpec.hardware.interconnect
+DynamoGraphDeploymentRequestSpec.hardware.numGpusPerNode
+DynamoGraphDeploymentRequestSpec.hardware.rdma
+DynamoGraphDeploymentRequestSpec.hardware.totalGpus
+DynamoGraphDeploymentRequestSpec.hardware.vramMb
+DynamoGraphDeploymentRequestSpec.image
+DynamoGraphDeploymentRequestSpec.model
+DynamoGraphDeploymentRequestSpec.modelCache.pvcModelPath
+DynamoGraphDeploymentRequestSpec.modelCache.pvcMountPath
+DynamoGraphDeploymentRequestSpec.modelCache.pvcName
+DynamoGraphDeploymentRequestSpec.overrides.dgd
+DynamoGraphDeploymentRequestSpec.overrides.profilingJob
+DynamoGraphDeploymentRequestSpec.runtimeVersionOverride
+DynamoGraphDeploymentRequestSpec.searchStrategy
+DynamoGraphDeploymentRequestSpec.sla.e2eLatency
+DynamoGraphDeploymentRequestSpec.sla.itl
+DynamoGraphDeploymentRequestSpec.sla.optimizationType
+DynamoGraphDeploymentRequestSpec.sla.ttft
+DynamoGraphDeploymentRequestSpec.workload.concurrency
+DynamoGraphDeploymentRequestSpec.workload.isl
+DynamoGraphDeploymentRequestSpec.workload.osl
+DynamoGraphDeploymentRequestSpec.workload.requestRate
+DynamoGraphDeploymentRequestStatus.conditions
+DynamoGraphDeploymentRequestStatus.deploymentInfo.availableReplicas
+DynamoGraphDeploymentRequestStatus.deploymentInfo.replicas
+DynamoGraphDeploymentRequestStatus.dgdName
+DynamoGraphDeploymentRequestStatus.observedGeneration
+DynamoGraphDeploymentRequestStatus.phase
+DynamoGraphDeploymentRequestStatus.profilingJobName
+DynamoGraphDeploymentRequestStatus.profilingPhase
+DynamoGraphDeploymentRequestStatus.profilingResults.pareto.config
+DynamoGraphDeploymentRequestStatus.profilingResults.selectedConfig
 DynamoGraphDeploymentScalingAdapterSpec.dgdRef.componentName
 DynamoGraphDeploymentScalingAdapterSpec.dgdRef.name
 DynamoGraphDeploymentScalingAdapterSpec.replicas
@@ -208,6 +246,8 @@ func v1beta1ConversionFieldSet() []string {
 	}{
 		{"DynamoGraphDeploymentSpec", reflect.TypeFor[v1beta1.DynamoGraphDeploymentSpec]()},
 		{"DynamoGraphDeploymentStatus", reflect.TypeFor[v1beta1.DynamoGraphDeploymentStatus]()},
+		{"DynamoGraphDeploymentRequestSpec", reflect.TypeFor[v1beta1.DynamoGraphDeploymentRequestSpec]()},
+		{"DynamoGraphDeploymentRequestStatus", reflect.TypeFor[v1beta1.DynamoGraphDeploymentRequestStatus]()},
 		{"DynamoComponentDeploymentSpec", reflect.TypeFor[v1beta1.DynamoComponentDeploymentSpec]()},
 		{"DynamoComponentDeploymentStatus", reflect.TypeFor[v1beta1.DynamoComponentDeploymentStatus]()},
 		{"DynamoGraphDeploymentScalingAdapterSpec", reflect.TypeFor[v1beta1.DynamoGraphDeploymentScalingAdapterSpec]()},

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -648,9 +648,8 @@ func TestBugDGDRLegacyUnnamedKeptDistinctWhenProfilerExists(t *testing.T) {
 	}
 }
 
-// The reported symptom was that a hub DGDR whose only hub-only content is
-// features.kvRouter reaches the v1alpha1 view with no nvidia.com/dgdr-spec
-// annotation at all, so the value has no carrier.
+// Pins the bug where a hub DGDR whose only hub-only content is features.kvRouter
+// reached the v1alpha1 view with no nvidia.com/dgdr-spec annotation.
 func TestBugDGDRHubSpecAnnotationCarriesHubOnlyFields(t *testing.T) {
 	tests := []struct {
 		name string

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -648,6 +648,88 @@ func TestBugDGDRLegacyUnnamedKeptDistinctWhenProfilerExists(t *testing.T) {
 	}
 }
 
+// The reported symptom was that a hub DGDR whose only hub-only content is
+// features.kvRouter reaches the v1alpha1 view with no nvidia.com/dgdr-spec
+// annotation at all, so the value has no carrier.
+func TestBugDGDRHubSpecAnnotationCarriesHubOnlyFields(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1beta1.DynamoGraphDeploymentRequestSpec
+		// wantSaved is the payload the annotation must decode to, or nil when
+		// the object has nothing hub-only and must carry no annotation.
+		wantSaved *v1beta1.DynamoGraphDeploymentRequestSpec
+	}{
+		{
+			name: "kvRouter is the only feature",
+			spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+				Model:          "Qwen/Qwen3-8B",
+				Backend:        v1beta1.BackendTypeVllm,
+				SearchStrategy: v1beta1.SearchStrategyRapid,
+				Features: &v1beta1.FeaturesSpec{
+					KVRouter: &v1beta1.KVRouterSpec{Enabled: true},
+				},
+			},
+			wantSaved: &v1beta1.DynamoGraphDeploymentRequestSpec{
+				SearchStrategy: v1beta1.SearchStrategyRapid,
+				Features: &v1beta1.FeaturesSpec{
+					KVRouter: &v1beta1.KVRouterSpec{Enabled: true},
+				},
+			},
+		},
+		{
+			name: "defaulted searchStrategy without features",
+			spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+				Model:          "Qwen/Qwen3-8B",
+				Backend:        v1beta1.BackendTypeVllm,
+				SearchStrategy: v1beta1.SearchStrategyRapid,
+			},
+			wantSaved: &v1beta1.DynamoGraphDeploymentRequestSpec{
+				SearchStrategy: v1beta1.SearchStrategyRapid,
+			},
+		},
+		{
+			name: "nothing hub-only",
+			spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+				Model:   "Qwen/Qwen3-8B",
+				Backend: v1beta1.BackendTypeVllm,
+			},
+			wantSaved: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Convert the stored hub object into the v1alpha1 view")
+			hub := &v1beta1.DynamoGraphDeploymentRequest{Spec: test.spec}
+			spoke := &DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertFrom(hub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+
+			t.Log("Check the hub-only spec annotation against the expected presence")
+			raw, ok := spoke.Annotations[annDGDRSpec]
+			if test.wantSaved == nil {
+				if ok {
+					t.Fatalf("%s = %q, want no annotation", annDGDRSpec, raw)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("%s is absent, want a payload carrying the hub-only fields", annDGDRSpec)
+			}
+
+			t.Log("Decode the payload and compare it with the hub-only fields")
+			got, ok := restoreDGDRHubSpec(raw)
+			if !ok {
+				t.Fatalf("restoreDGDRHubSpec(%q) failed to decode", raw)
+			}
+			if diff := cmp.Diff(*test.wantSaved, got); diff != "" {
+				t.Fatalf("hub-only payload mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func mustDGDRHubSpecAnnotation(t *testing.T, spec v1beta1.DynamoGraphDeploymentRequestSpec) string {
 	t.Helper()
 	data, err := marshalDGDRHubSpec(&spec)

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -661,15 +661,13 @@ func TestBugDGDRHubSpecAnnotationCarriesHubOnlyFields(t *testing.T) {
 		{
 			name: "kvRouter is the only feature",
 			spec: v1beta1.DynamoGraphDeploymentRequestSpec{
-				Model:          "Qwen/Qwen3-8B",
-				Backend:        v1beta1.BackendTypeVllm,
-				SearchStrategy: v1beta1.SearchStrategyRapid,
+				Model:   "Qwen/Qwen3-8B",
+				Backend: v1beta1.BackendTypeVllm,
 				Features: &v1beta1.FeaturesSpec{
 					KVRouter: &v1beta1.KVRouterSpec{Enabled: true},
 				},
 			},
 			wantSaved: &v1beta1.DynamoGraphDeploymentRequestSpec{
-				SearchStrategy: v1beta1.SearchStrategyRapid,
 				Features: &v1beta1.FeaturesSpec{
 					KVRouter: &v1beta1.KVRouterSpec{Enabled: true},
 				},


### PR DESCRIPTION
Source issue: [DYN-4334](https://linear.app/nvidia/issue/DYN-4334).

## Overview:

DYN-4334 reports that a `DynamoGraphDeploymentRequest` (DGDR) applied as `nvidia.com/v1beta1` with `spec.features.kvRouter.enabled: true` reads back through the `nvidia.com/v1alpha1` view without the `nvidia.com/dgdr-spec` annotation, leaving that hub-only value with no carrier. The conversion code on `main` does not produce that behavior. This PR adds the tests that say so, and that would catch it if it ever became true.

## Details:

`TestBugDGDRHubSpecAnnotationCarriesHubOnlyFields` in `deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go` calls `ConvertFrom` on the reported object shape and checks that the `nvidia.com/dgdr-spec` annotation decodes to a payload carrying `features.kvRouter.enabled: true`. Two more rows cover a spec whose only hub-only field is `searchStrategy` — the annotation must still be written — and a spec with nothing hub-only, which must carry no annotation. That last row is the negative control that stops a later "always write the annotation" shortcut from passing.

`deploy/operator/api/v1alpha1/conversion_field_coverage_test.go` gains `DynamoGraphDeploymentRequestSpec` and `DynamoGraphDeploymentRequestStatus`. That test compares the reflected field set against a checked-in list, so adding a v1beta1 DGDR field now fails the test until someone decides whether conversion carries it. `features.kvRouter.enabled` sat outside that tripwire until now.

## Where should the reviewer start?

`dynamographdeploymentrequest_conversion_bugs_test.go` — the three-row table and its `wantSaved` expectations. Then the added block in `conversion_field_coverage_test.go`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded conversion coverage validation to include all request specification and status fields, reducing the risk of untracked configuration changes.
  - Added regression coverage confirming hub-only search strategy and key-value router settings are preserved during conversion.
  - Verified that annotations are omitted when no hub-only fields are present, keeping converted resources concise and accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->