### PR TITLE
fix(discovery): stop a duplicated worker role from taking the whole namespace offline

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -2049,8 +2049,6 @@ mod tests {
             "KServe readiness must agree with what routing accepts"
         );
 
-        // The ambiguity is still reported, so an operator can see the pairing is
-        // off even though traffic is being served.
         let readiness = model.namespace_readiness();
         let ns = readiness.namespaces.get("pd").expect("namespace reported");
         assert!(ns.ready);

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -2001,16 +2001,11 @@ mod tests {
         );
     }
 
-    /// Two typed prefill endpoints in one namespace (a rolling upgrade, or a
-    /// stray second prefill deployment) make the prefill role ambiguous. The
-    /// pairing cannot be resolved, so `reconcile_discovery_topology` leaves the
-    /// prefill target unset and `PrefillRouter::generate` forwards to the decode
-    /// backend — aggregated serving. The live decode WorkerSet must therefore
-    /// stay selectable through *both* admission gates, which read the same
-    /// `evaluate_namespace(..).ready`: `has_ready_workers` on the HTTP path and
+    /// Covers both admission gates, which read the same
+    /// `evaluate_namespace(..).ready`: `has_ready_workers` on the HTTP path, and
     /// the readiness filter inside `select_worker_set_with` behind every engine
-    /// accessor. Gating either on ambiguity answers 503 for the whole namespace
-    /// while a healthy decode worker sits idle.
+    /// accessor. Either one refusing is enough to take the namespace out of
+    /// service, so neither is sufficient on its own as regression coverage.
     #[test]
     fn ambiguous_prefill_topology_keeps_decode_serving() {
         let model = Model::new("llama".to_string());

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -2037,12 +2037,8 @@ mod tests {
         model.add_worker_set("pd:prefill2".to_string(), second_prefill);
 
         assert!(
-            model.is_workers_ready("pd"),
-            "a duplicated prefill role must not withdraw the namespace from serving"
-        );
-        assert!(
             model.has_ready_workers(),
-            "the HTTP admission gate must admit"
+            "a duplicated prefill role must not withdraw the namespace from the HTTP admission gate"
         );
         assert!(
             model.get_chat_engine().is_ok(),

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -461,6 +461,24 @@ impl Model {
                 .collect();
             missing_vec.sort();
 
+            // A duplicated role no longer withholds the namespace from serving, so
+            // it has to be reported on the *ready* path: it is still a real
+            // misconfiguration an operator has to clear, and the pairing it
+            // disables is a capability the deployment asked for.
+            let ambiguous_reason = (!eval.ambiguous.is_empty()).then(|| {
+                let mut roles = eval
+                    .ambiguous
+                    .iter()
+                    .map(|worker_type| worker_type.as_str())
+                    .collect::<Vec<_>>();
+                roles.sort_unstable();
+                format!(
+                    "ambiguous worker types: {}; pairing disabled for these roles, \
+                     namespace still serving",
+                    roles.join(", ")
+                )
+            });
+
             let reason = if eval.ready {
                 if eval.has_legacy {
                     let legacy_live_workers = eval.legacy_live_workers;
@@ -469,18 +487,10 @@ impl Model {
                          (ready while {legacy_live_workers} worker(s) live) — compat window only"
                     ))
                 } else {
-                    None
+                    ambiguous_reason
                 }
             } else if eval.has_legacy {
                 Some("legacy worker(s) present but no live worker".to_string())
-            } else if !eval.ambiguous.is_empty() {
-                let mut roles = eval
-                    .ambiguous
-                    .iter()
-                    .map(|worker_type| worker_type.as_str())
-                    .collect::<Vec<_>>();
-                roles.sort_unstable();
-                Some(format!("ambiguous worker types: {}", roles.join(", ")))
             } else {
                 Some(format!("missing worker types: {}", missing_vec.join(", ")))
             };
@@ -1991,5 +2001,88 @@ mod tests {
             !model.is_ready_to_serve(),
             "only an incomplete namespace remains: not ready to serve"
         );
+    }
+
+    /// Two typed prefill endpoints in one namespace (a rolling upgrade, or a
+    /// stray second prefill deployment) make the prefill role ambiguous. The
+    /// pairing cannot be resolved, so `reconcile_discovery_topology` leaves the
+    /// prefill target unset and `PrefillRouter::generate` forwards to the decode
+    /// backend — aggregated serving. The live decode WorkerSet must therefore
+    /// stay selectable through *both* admission gates, which read the same
+    /// `evaluate_namespace(..).ready`: `has_ready_workers` on the HTTP path and
+    /// the readiness filter inside `select_worker_set_with` behind every engine
+    /// accessor. Gating either on ambiguity answers 503 for the whole namespace
+    /// while a healthy decode worker sits idle.
+    #[test]
+    fn ambiguous_prefill_topology_keeps_decode_serving() {
+        let model = Model::new("llama".to_string());
+
+        // Decode is the front door: live worker plus a chat engine.
+        let (decode, _tx_d) = ws_serving_role(
+            "pd",
+            "mdc-d",
+            WorkerType::Decode,
+            vec![vec![WorkerType::Prefill]],
+            vec![1],
+        );
+        let (prefill, _tx_p) = ws_with_type(
+            "pd",
+            "mdc-p",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![2],
+        );
+        let (second_prefill, _tx_p2) = ws_with_type(
+            "pd",
+            "mdc-p2",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![3],
+        );
+        model.add_worker_set("pd".to_string(), decode);
+        model.add_worker_set("pd:prefill".to_string(), prefill);
+        model.add_worker_set("pd:prefill2".to_string(), second_prefill);
+
+        assert!(
+            model.is_workers_ready("pd"),
+            "a duplicated prefill role must not withdraw the namespace from serving"
+        );
+        assert!(
+            model.has_ready_workers(),
+            "the HTTP admission gate must admit"
+        );
+        assert!(
+            model.get_chat_engine().is_ok(),
+            "the engine accessor must still select the live decode WorkerSet"
+        );
+        assert!(
+            model.is_ready_to_serve(),
+            "KServe readiness must agree with what routing accepts"
+        );
+
+        // The ambiguity is still reported, so an operator can see the pairing is
+        // off even though traffic is being served.
+        let readiness = model.namespace_readiness();
+        let ns = readiness.namespaces.get("pd").expect("namespace reported");
+        assert!(ns.ready);
+        let reason = ns.reason.as_deref().unwrap_or_default();
+        assert!(
+            reason.contains("ambiguous worker types: prefill"),
+            "a ready-but-ambiguous namespace must still name the duplicated role, got {reason:?}"
+        );
+
+        // Negative control: drop the decode WorkerSet and the same namespace is
+        // genuinely incomplete (prefill-only, needs unsatisfied). It must stay
+        // unservable — relaxing ambiguity must not relax the missing-role gate.
+        model.remove_worker_set("pd");
+        assert!(
+            !model.is_workers_ready("pd"),
+            "prefill-only namespace is missing decode and must not be ready"
+        );
+        assert!(
+            model.get_chat_engine().is_err(),
+            "prefill-only namespace must not be selectable for serving"
+        );
+        assert!(!model.is_ready_to_serve());
     }
 }

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -2010,7 +2010,6 @@ mod tests {
     fn ambiguous_prefill_topology_keeps_decode_serving() {
         let model = Model::new("llama".to_string());
 
-        // Decode is the front door: live worker plus a chat engine.
         let (decode, _tx_d) = ws_serving_role(
             "pd",
             "mdc-d",
@@ -2065,10 +2064,5 @@ mod tests {
             !model.is_workers_ready("pd"),
             "prefill-only namespace is missing decode and must not be ready"
         );
-        assert!(
-            model.get_chat_engine().is_err(),
-            "prefill-only namespace must not be selectable for serving"
-        );
-        assert!(!model.is_ready_to_serve());
     }
 }

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -461,10 +461,8 @@ impl Model {
                 .collect();
             missing_vec.sort();
 
-            // A duplicated role no longer withholds the namespace from serving, so
-            // it has to be reported on the *ready* path: it is still a real
-            // misconfiguration an operator has to clear, and the pairing it
-            // disables is a capability the deployment asked for.
+            // A duplicated role is a real misconfiguration and disables that role's
+            // pairing, so report it on the ready path too, not only when unready.
             let ambiguous_reason = (!eval.ambiguous.is_empty()).then(|| {
                 let mut roles = eval
                     .ambiguous
@@ -2071,9 +2069,8 @@ mod tests {
             "a ready-but-ambiguous namespace must still name the duplicated role, got {reason:?}"
         );
 
-        // Negative control: drop the decode WorkerSet and the same namespace is
-        // genuinely incomplete (prefill-only, needs unsatisfied). It must stay
-        // unservable — relaxing ambiguity must not relax the missing-role gate.
+        // Negative control: a prefill-only namespace is genuinely incomplete —
+        // relaxing ambiguity must not relax the missing-role gate.
         model.remove_worker_set("pd");
         assert!(
             !model.is_workers_ready("pd"),

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3583,8 +3583,7 @@ mod tests {
                     )
                     .unwrap();
                 // A second prefill endpoint makes the role ambiguous: the router
-                // drops its target, so requests degrade to aggregated serving,
-                // and the namespace stays ready because decode is still live.
+                // drops its target, but decode is live so the namespace stays ready.
                 assert!(
                     manager
                         .get_committed_model("topology-model")

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3582,8 +3582,11 @@ mod tests {
                         Vec::new(),
                     )
                     .unwrap();
+                // A second prefill endpoint makes the role ambiguous: the router
+                // drops its target, so requests degrade to aggregated serving,
+                // and the namespace stays ready because decode is still live.
                 assert!(
-                    !manager
+                    manager
                         .get_committed_model("topology-model")
                         .unwrap()
                         .namespace_readiness()

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3582,8 +3582,6 @@ mod tests {
                         Vec::new(),
                     )
                     .unwrap();
-                // A second prefill endpoint makes the role ambiguous: the router
-                // drops its target, but decode is live so the namespace stays ready.
                 assert!(
                     manager
                         .get_committed_model("topology-model")

--- a/lib/llm/src/discovery/readiness.rs
+++ b/lib/llm/src/discovery/readiness.rs
@@ -245,8 +245,6 @@ mod tests {
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Decode), 1, vec![vec![WorkerType::Prefill]]),
         ]);
-        // The duplicated role is reported, and the live decode worker keeps the
-        // namespace servable: ambiguity suppresses pairing, not serving.
         assert!(evaluation.ready);
         assert_eq!(evaluation.ambiguous, HashSet::from([WorkerType::Prefill]));
 

--- a/lib/llm/src/discovery/readiness.rs
+++ b/lib/llm/src/discovery/readiness.rs
@@ -32,11 +32,7 @@ pub struct ReadinessEval {
     pub missing: HashSet<WorkerType>,
     /// Non-`Aggregated` worker types with more than one live unit in the namespace.
     ///
-    /// Reported, never gated on. A duplicated role means the topology cannot say
-    /// which endpoint of that role to pair with, so `reconcile_discovery_topology`
-    /// declines to pair it and the routers pass requests straight through; it does
-    /// not mean the namespace stopped serving. Consumers surface this as a
-    /// diagnostic, not as a reason to withhold traffic.
+    /// Diagnostic only: it does not gate `ready`.
     pub ambiguous: HashSet<WorkerType>,
 }
 

--- a/lib/llm/src/discovery/readiness.rs
+++ b/lib/llm/src/discovery/readiness.rs
@@ -30,6 +30,13 @@ pub struct ReadinessEval {
     pub legacy_live_workers: usize,
     pub present: HashSet<WorkerType>,
     pub missing: HashSet<WorkerType>,
+    /// Non-`Aggregated` worker types with more than one live unit in the namespace.
+    ///
+    /// Reported, never gated on. A duplicated role means the topology cannot say
+    /// which endpoint of that role to pair with, so `reconcile_discovery_topology`
+    /// declines to pair it and the routers pass requests straight through; it does
+    /// not mean the namespace stopped serving. Consumers surface this as a
+    /// diagnostic, not as a reason to withhold traffic.
     pub ambiguous: HashSet<WorkerType>,
 }
 
@@ -51,6 +58,16 @@ pub fn normalize_legacy_prefill_topology(card: &mut ModelDeploymentCard) {
 }
 
 /// Whether a namespace's units are ready to serve traffic.
+///
+/// Ready means a worker is live and every registered worker type has one. A
+/// duplicated non-`Aggregated` role is an orthogonal fact: it disables the
+/// pairing for that role — `reconcile_discovery_topology` clears the prefill
+/// target, `PrefillRouter::generate` and the encoder router then forward to the
+/// decode backend — and the namespace keeps serving in aggregated mode.
+/// Ambiguity therefore stays out of the `ready` conjunction; gating on it takes a
+/// healthy decode worker's whole namespace offline for the duration of a rolling
+/// upgrade, which is the fail-closed-on-wire-evolution outcome `lib/llm/AGENTS.md`
+/// rules out.
 pub fn evaluate_readiness(units: &[ReadinessUnit]) -> ReadinessEval {
     let mut present: HashSet<WorkerType> = HashSet::new();
     let mut missing: HashSet<WorkerType> = HashSet::new();
@@ -128,7 +145,7 @@ pub fn evaluate_readiness(units: &[ReadinessUnit]) -> ReadinessEval {
     }
 
     ReadinessEval {
-        ready: has_live_worker && missing.is_empty() && ambiguous.is_empty(),
+        ready: has_live_worker && missing.is_empty(),
         has_legacy,
         legacy_live_workers,
         present,
@@ -222,13 +239,16 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_live_units_of_one_role_are_ambiguous_and_not_ready() {
+    fn duplicate_live_units_of_one_role_are_ambiguous_but_still_ready() {
         let evaluation = evaluate_readiness(&[
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Decode), 1, vec![vec![WorkerType::Prefill]]),
         ]);
-        assert!(!evaluation.ready);
+        // The duplicated role is detected and reported, and the live decode
+        // worker keeps the namespace servable: ambiguity suppresses pairing,
+        // not serving.
+        assert!(evaluation.ready);
         assert_eq!(evaluation.ambiguous, HashSet::from([WorkerType::Prefill]));
 
         let scale_out = evaluate_readiness(&[

--- a/lib/llm/src/discovery/readiness.rs
+++ b/lib/llm/src/discovery/readiness.rs
@@ -245,9 +245,8 @@ mod tests {
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Decode), 1, vec![vec![WorkerType::Prefill]]),
         ]);
-        // The duplicated role is detected and reported, and the live decode
-        // worker keeps the namespace servable: ambiguity suppresses pairing,
-        // not serving.
+        // The duplicated role is reported, and the live decode worker keeps the
+        // namespace servable: ambiguity suppresses pairing, not serving.
         assert!(evaluation.ready);
         assert_eq!(evaluation.ambiguous, HashSet::from([WorkerType::Prefill]));
 

--- a/lib/llm/src/kv_dc_relay/topology.rs
+++ b/lib/llm/src/kv_dc_relay/topology.rs
@@ -673,7 +673,7 @@ mod tests {
             vec![vec![WorkerType::Prefill]],
         );
         // A second Decode worker set serving a different surface: the request plane
-        // sees two WorkerSets of one role and gates the namespace as ambiguous.
+        // sees two WorkerSets of one role and reports the role as ambiguous.
         decode.worker_topology.insert(
             2,
             DomainWorkerTopology {
@@ -695,7 +695,9 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
+        // Parity with the core evaluation: the duplicated role is reported as a
+        // fact and the namespace keeps serving.
+        assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Decode]);
     }
 
@@ -1012,9 +1014,10 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        // Parity with the core evaluation: an ambiguous role topology is not ready,
-        // and the duplicated roles explain the gate.
-        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
+        // Parity with the core evaluation: every role has a live endpoint, so the
+        // topology stays ready, and both duplicated roles are reported as the
+        // reason their pairing is suppressed.
+        assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(
             topology.duplicate_role_endpoints,
             [WorkerRole::Prefill, WorkerRole::Decode]
@@ -1197,7 +1200,9 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
+        // Parity with the core evaluation: a duplicated Encode role is reported
+        // like any other, and does not withdraw the namespace from serving.
+        assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Encode]);
     }
 

--- a/lib/llm/src/kv_dc_relay/topology.rs
+++ b/lib/llm/src/kv_dc_relay/topology.rs
@@ -330,9 +330,13 @@ fn derive_topology(
                 left.endpoint.to_string().cmp(&right.endpoint.to_string())
             });
             let evaluation = evaluate_readiness(&group.units);
+            // Stricter than local serving on purpose: a namespace with a duplicated
+            // role degrades to aggregated serving on its own decode worker, but a
+            // remote peer picking a KV source cannot tell which duplicate owns the
+            // blocks, so the pool stays unadvertised.
             let state = if !group.availability_authoritative {
                 TopologyReadinessState::Unknown
-            } else if evaluation.ready {
+            } else if evaluation.ready && evaluation.ambiguous.is_empty() {
                 TopologyReadinessState::Ready
             } else {
                 TopologyReadinessState::Unavailable
@@ -462,9 +466,11 @@ fn derive_adapters(
         .iter()
         .map(|(model, aggregate)| {
             let evaluation = evaluate_readiness(&aggregate.units);
+            // Same stricter rule as `derive_topology`: an ambiguous role is not
+            // advertised to remote peers, which have no aggregated fallback.
             let state = if !aggregate.availability_authoritative {
                 TopologyReadinessState::Unknown
-            } else if evaluation.ready {
+            } else if evaluation.ready && evaluation.ambiguous.is_empty() {
                 TopologyReadinessState::Ready
             } else {
                 TopologyReadinessState::Unavailable
@@ -672,8 +678,8 @@ mod tests {
             Some(WorkerType::Decode),
             vec![vec![WorkerType::Prefill]],
         );
-        // A second Decode worker set serving a different surface: the request plane
-        // sees two WorkerSets of one role and reports the role as ambiguous.
+        // A second Decode worker set serving a different surface: the relay sees two
+        // WorkerSets of one role and declines to advertise the namespace.
         decode.worker_topology.insert(
             2,
             DomainWorkerTopology {
@@ -695,7 +701,7 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        assert_eq!(topology.state, TopologyReadinessState::Ready);
+        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Decode]);
     }
 
@@ -1012,7 +1018,9 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        assert_eq!(topology.state, TopologyReadinessState::Ready);
+        // The relay withholds an ambiguous namespace, and the duplicated roles
+        // explain why.
+        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
         assert_eq!(
             topology.duplicate_role_endpoints,
             [WorkerRole::Prefill, WorkerRole::Decode]
@@ -1195,7 +1203,7 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        assert_eq!(topology.state, TopologyReadinessState::Ready);
+        assert_eq!(topology.state, TopologyReadinessState::Unavailable);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Encode]);
     }
 

--- a/lib/llm/src/kv_dc_relay/topology.rs
+++ b/lib/llm/src/kv_dc_relay/topology.rs
@@ -695,8 +695,6 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        // Parity with the core evaluation: the duplicated role is reported as a
-        // fact and the namespace keeps serving.
         assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Decode]);
     }
@@ -1014,8 +1012,6 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        // Parity with the core evaluation: every role has a live endpoint, so the
-        // topology stays ready and both duplicated roles are reported.
         assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(
             topology.duplicate_role_endpoints,
@@ -1199,8 +1195,6 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        // Parity with the core evaluation: a duplicated Encode role is reported
-        // like any other, and does not withdraw the namespace from serving.
         assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(topology.duplicate_role_endpoints, [WorkerRole::Encode]);
     }

--- a/lib/llm/src/kv_dc_relay/topology.rs
+++ b/lib/llm/src/kv_dc_relay/topology.rs
@@ -1015,8 +1015,7 @@ mod tests {
         let topology = entry(&snapshot, "llama");
 
         // Parity with the core evaluation: every role has a live endpoint, so the
-        // topology stays ready, and both duplicated roles are reported as the
-        // reason their pairing is suppressed.
+        // topology stays ready and both duplicated roles are reported.
         assert_eq!(topology.state, TopologyReadinessState::Ready);
         assert_eq!(
             topology.duplicate_role_endpoints,


### PR DESCRIPTION
Source issue: [DYN-4330](https://linear.app/nvidia/issue/DYN-4330).

## Overview:

When one namespace held two live workers of the same non-`Aggregated` role — a second prefill endpoint during a rolling upgrade, for example — every request to that namespace answered `503` while a healthy decode worker sat idle. A duplicated role now disables only that role's pairing, and the namespace keeps serving locally. The KV DC Relay stays strict and still declines to advertise an ambiguous namespace to remote peers.

## Details:

`evaluate_readiness` in `lib/llm/src/discovery/readiness.rs` computed `ready: has_live_worker && missing.is_empty() && ambiguous.is_empty()`. The `ambiguous` set is namespace-scoped, so one duplicated role zeroed `ready` for every role in the namespace, and both admission gates that read it — `check_model_serving_ready` on the HTTP path, and the readiness filter in `select_worker_set_with` behind every engine accessor — refused traffic.

Dropping `&& ambiguous.is_empty()` reaches degraded behaviour that was already implemented but unreachable: `reconcile_discovery_topology` leaves the prefill target unset, so `PrefillRouter::generate` forwards straight to the decode backend and the namespace serves in aggregated mode. `ambiguous` is still computed and returned — a reported fact, not a gate. To keep the operator signal, `namespace_readiness` in `lib/llm/src/discovery/model.rs` emits its `ambiguous worker types: ` reason on the ready path as well, with the sorted role list unchanged and `; pairing disabled for these roles, namespace still serving` appended so the reason says what the state means.

Ambiguity gating belongs at the consumer that cannot degrade, not in the shared conjunction. `derive_topology` and `derive_adapters` in `lib/llm/src/kv_dc_relay/topology.rs` compose the condition themselves:

```rust
let state = if !group.availability_authoritative {
    TopologyReadinessState::Unknown
} else if evaluation.ready && evaluation.ambiguous.is_empty() {
    TopologyReadinessState::Ready
} else {
    TopologyReadinessState::Unavailable
};
```

A local namespace with a duplicated role degrades to aggregated serving on its own decode worker. A remote peer selecting a KV source has no such fallback and cannot tell which duplicate endpoint owns the blocks, so the pool stays unadvertised. The relay's duplicate-decode, duplicate-prefill/decode and duplicate-encode cases assert `TopologyReadinessState::Unavailable`.

## Validation:

```bash
cargo fmt --all -- --check
cargo test -p dynamo-llm --no-default-features --lib discovery::
cargo test -p dynamo-llm --no-default-features --lib kv_dc_relay::
cargo clippy -p dynamo-llm --no-default-features --all-targets --no-deps -- -D warnings
```

All pass: `216 passed; 0 failed` for `discovery::`, `176 passed; 0 failed` for `kv_dc_relay::`, and clean formatting and clippy runs. The two suites are the load-bearing ones and they check opposite halves of the boundary. `ambiguous_prefill_topology_keeps_decode_serving` builds one live decode WorkerSet plus two live prefill WorkerSets and asserts both local admission gates admit, with a prefill-only negative control that must stay unready; the three duplicate-role relay tests assert the relay withholds the same topology.

## Where should the reviewer start?

`lib/llm/src/discovery/readiness.rs` — the one-term production change, with the contract written into the `evaluate_readiness` doc comment so it is not reinstated. Then the two relay sites in `kv_dc_relay/topology.rs`, which are where the local and remote answers deliberately diverge. Then the new test and the reason-string move in `model.rs`.

## Related Issues

This work is tracked in Linear as [DYN-4330](https://linear.app/nvidia/issue/DYN-4330); there is no corresponding `ai-dynamo/dynamo` issue to link.

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Namespaces remain ready and continue serving traffic when duplicate worker roles are detected, provided required live workers are available.
  - Readiness reporting identifies ambiguous worker roles and lists the affected roles.
  - Topology pairing is disabled when worker roles are ambiguous, while aggregated traffic serving continues.
  - Ambiguous topologies are withheld from remote relay advertisement.
  - Prefill-only namespaces remain unready and unroutable when no suitable decode worker is available.
  - Duplicate prefill workers no longer prevent decode-backed serving or readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->