### PR TITLE
fix(recipes): pin the GLM-5.3-Flash image by digest

### DIFF
--- a/docs/fern/pages/recipes/_catalog/recipes/glm-5-3-flash.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/glm-5-3-flash.yaml
@@ -18,7 +18,7 @@ targets:
     count: 4
   runtime:
     framework: vllm
-    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+    image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: aggregated
   techniques:
   - fp8
@@ -40,7 +40,7 @@ targets:
     count: 8
   runtime:
     framework: vllm
-    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+    image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: disaggregated
   techniques:
   - disaggregated-prefill-decode
@@ -63,7 +63,7 @@ targets:
     count: 8
   runtime:
     framework: vllm
-    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+    image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: aggregated
   techniques:
   - fp8
@@ -86,7 +86,7 @@ targets:
     count: 16
   runtime:
     framework: vllm
-    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+    image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: disaggregated
   techniques:
   - disaggregated-prefill-decode

--- a/docs/fern/pages/recipes/_catalog/recipes/glm-5-3-flash.yaml
+++ b/docs/fern/pages/recipes/_catalog/recipes/glm-5-3-flash.yaml
@@ -18,7 +18,7 @@ targets:
     count: 4
   runtime:
     framework: vllm
-    image: vllm/vllm-openai:glm53-flash
+    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: aggregated
   techniques:
   - fp8
@@ -40,7 +40,7 @@ targets:
     count: 8
   runtime:
     framework: vllm
-    image: vllm/vllm-openai:glm53-flash
+    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: disaggregated
   techniques:
   - disaggregated-prefill-decode
@@ -63,7 +63,7 @@ targets:
     count: 8
   runtime:
     framework: vllm
-    image: vllm/vllm-openai:glm53-flash
+    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: aggregated
   techniques:
   - fp8
@@ -86,7 +86,7 @@ targets:
     count: 16
   runtime:
     framework: vllm
-    image: vllm/vllm-openai:glm53-flash
+    image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
   topology: disaggregated
   techniques:
   - disaggregated-prefill-decode

--- a/docs/fern/pages/recipes/model-recipes/glm-5-3-flash.mdx
+++ b/docs/fern/pages/recipes/model-recipes/glm-5-3-flash.mdx
@@ -70,7 +70,7 @@ Each target below is an NVIDIA Dynamo + vLLM deployment of Z.AI's GLM-5.3-Flash,
 
 - A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available: 4x on one ARM64 node for aggregated, or 8x across two ARM64 nodes for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed. Both GB200 targets require a ComputeDomain spanning the full NVL72 rack.
-- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai` image, which the manifests pin by digest.
+- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai:glm53-flash` image, which the manifests pin by digest.
 - A ReadWriteMany PVC named `model-cache`, populated with the checkpoint in the standard Hugging Face cache layout.
 
 </div>
@@ -79,7 +79,7 @@ Each target below is an NVIDIA Dynamo + vLLM deployment of Z.AI's GLM-5.3-Flash,
 
 - A Kubernetes cluster with the Dynamo platform installed and H200 GPUs available: 8x on one node for aggregated, or 16x across two nodes for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - Eight RDMA resource claims on each GPU node for disaggregated serving. Update `rdma/ib` if your device plugin advertises a different resource name.
-- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai` image, which the manifests pin by digest.
+- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai:glm53-flash` image, which the manifests pin by digest.
 - A ReadWriteMany PVC named `model-cache`, populated with the checkpoint in the standard Hugging Face cache layout.
 
 </div>

--- a/docs/fern/pages/recipes/model-recipes/glm-5-3-flash.mdx
+++ b/docs/fern/pages/recipes/model-recipes/glm-5-3-flash.mdx
@@ -70,7 +70,7 @@ Each target below is an NVIDIA Dynamo + vLLM deployment of Z.AI's GLM-5.3-Flash,
 
 - A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available: 4x on one ARM64 node for aggregated, or 8x across two ARM64 nodes for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - The NVIDIA DRA driver with ComputeDomain support installed. Both GB200 targets require a ComputeDomain spanning the full NVL72 rack.
-- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai:glm53-flash` image.
+- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai` image, which the manifests pin by digest.
 - A ReadWriteMany PVC named `model-cache`, populated with the checkpoint in the standard Hugging Face cache layout.
 
 </div>
@@ -79,7 +79,7 @@ Each target below is an NVIDIA Dynamo + vLLM deployment of Z.AI's GLM-5.3-Flash,
 
 - A Kubernetes cluster with the Dynamo platform installed and H200 GPUs available: 8x on one node for aggregated, or 16x across two nodes for disaggregated. See the [Kubernetes Deployment Guide](../../kubernetes/getting-started/quickstart.mdx).
 - Eight RDMA resource claims on each GPU node for disaggregated serving. Update `rdma/ib` if your device plugin advertises a different resource name.
-- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai:glm53-flash` image.
+- Access to `zai-org/GLM-5.3-Flash` and the `vllm/vllm-openai` image, which the manifests pin by digest.
 - A ReadWriteMany PVC named `model-cache`, populated with the checkpoint in the standard Hugging Face cache layout.
 
 </div>

--- a/recipes/glm-5.3-flash/README.md
+++ b/recipes/glm-5.3-flash/README.md
@@ -36,8 +36,11 @@ Dynamo + vLLM deployment profiles for the GB200 and H200 agentic workload:
 ## Prerequisites
 
 1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/fern/pages/kubernetes/getting-started/quickstart.mdx).
-2. **GLM-5.3-Flash image**: `vllm/vllm-openai:glm53-flash` — a GLM-specific vLLM build with
-   GLA/KDA attention kernels. `ai-dynamo` is pip-installed at pod startup.
+2. **GLM-5.3-Flash image**: pinned by digest in the manifests as
+   `vllm/vllm-openai@sha256:2c6da6c6…` — a GLM-specific vLLM build with GLA/KDA attention
+   kernels. `ai-dynamo` is pip-installed at pod startup. The `:glm53-flash` tag is mutable and
+   was re-pushed upstream on 2026-09-09 to an incompatible vLLM nightly, so the manifests
+   reference the validated digest rather than the tag.
 3. **Hugging Face access** to `zai-org/GLM-5.3-Flash`.
 
 ## Quick Start

--- a/recipes/glm-5.3-flash/README.md
+++ b/recipes/glm-5.3-flash/README.md
@@ -37,10 +37,10 @@ Dynamo + vLLM deployment profiles for the GB200 and H200 agentic workload:
 
 1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/fern/pages/kubernetes/getting-started/quickstart.mdx).
 2. **GLM-5.3-Flash image**: pinned by digest in the manifests as
-   `vllm/vllm-openai@sha256:2c6da6c6…` — a GLM-specific vLLM build with GLA/KDA attention
-   kernels. `ai-dynamo` is pip-installed at pod startup. The `:glm53-flash` tag is mutable and
-   was re-pushed upstream on 2026-09-09 to an incompatible vLLM nightly, so the manifests
-   reference the validated digest rather than the tag.
+   `vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4` —
+   a GLM-specific vLLM build with GLA/KDA attention kernels. `ai-dynamo` is pip-installed at pod
+   startup. Do not substitute the `:glm53-flash` tag: it is mutable and was re-pushed upstream on
+   2026-09-09 to an incompatible vLLM nightly.
 3. **Hugging Face access** to `zai-org/GLM-5.3-Flash`.
 
 ## Quick Start

--- a/recipes/glm-5.3-flash/README.md
+++ b/recipes/glm-5.3-flash/README.md
@@ -36,11 +36,10 @@ Dynamo + vLLM deployment profiles for the GB200 and H200 agentic workload:
 ## Prerequisites
 
 1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/fern/pages/kubernetes/getting-started/quickstart.mdx).
-2. **GLM-5.3-Flash image**: pinned by digest in the manifests as
-   `vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4` —
-   a GLM-specific vLLM build with GLA/KDA attention kernels. `ai-dynamo` is pip-installed at pod
-   startup. Do not substitute the `:glm53-flash` tag: it is mutable and was re-pushed upstream on
-   2026-09-09 to an incompatible vLLM nightly.
+2. **GLM-5.3-Flash image**: `vllm/vllm-openai:glm53-flash` — a GLM-specific vLLM build with
+   GLA/KDA attention kernels. `ai-dynamo` is pip-installed at pod startup. The manifests pin this
+   image by digest; do not drop the digest, because the tag is mutable and was re-pushed upstream
+   on 2026-09-09 to an incompatible vLLM nightly.
 3. **Hugging Face access** to `zai-org/GLM-5.3-Flash`.
 
 ## Quick Start
@@ -83,6 +82,12 @@ kubectl apply -f vllm/${MODE}-${SKU}-agentic/deploy.yaml -n ${NAMESPACE}
 
 ## Limitations
 
+- **Image pinned by digest.** The worker image is
+  `vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4`.
+  The `:glm53-flash` tag alone is not reproducible: it was re-pushed upstream on 2026-09-09 to a
+  re-tagged vLLM nightly whose FlashMLA-sparse backend rejects this model's head size, which breaks
+  the recipe's `--attention-backend FLASHMLA_SPARSE`. The validated image is currently reachable
+  only as an untagged digest, so it remains exposed to registry garbage collection.
 - **GB200 disaggregated:** KV transport uses `cuda_copy+tcp` with the `glm53-flash` image. The
   image's UCX build does not support MNNVL IPC, so `^cuda_ipc` prevents a C-level crash at
   `uct_cuda_ipc_ep_get_zcopy`. To enable MNNVL NVLink KV transfer, rebuild the image on the

--- a/recipes/glm-5.3-flash/vllm/agg-gb200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/agg-gb200-agentic/deploy.yaml
@@ -90,7 +90,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache

--- a/recipes/glm-5.3-flash/vllm/agg-gb200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/agg-gb200-agentic/deploy.yaml
@@ -90,7 +90,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache

--- a/recipes/glm-5.3-flash/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/agg-h200-agentic/deploy.yaml
@@ -94,7 +94,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash

--- a/recipes/glm-5.3-flash/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/agg-h200-agentic/deploy.yaml
@@ -94,7 +94,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash

--- a/recipes/glm-5.3-flash/vllm/disagg-gb200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/disagg-gb200-agentic/deploy.yaml
@@ -93,7 +93,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache
@@ -253,7 +253,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache

--- a/recipes/glm-5.3-flash/vllm/disagg-gb200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/disagg-gb200-agentic/deploy.yaml
@@ -93,7 +93,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache
@@ -253,7 +253,7 @@ spec:
                 sizeLimit: 200Gi
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: model-cache

--- a/recipes/glm-5.3-flash/vllm/disagg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/disagg-h200-agentic/deploy.yaml
@@ -93,7 +93,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -271,7 +271,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai:glm53-flash
+              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash

--- a/recipes/glm-5.3-flash/vllm/disagg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.3-flash/vllm/disagg-h200-agentic/deploy.yaml
@@ -93,7 +93,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -271,7 +271,7 @@ spec:
               effect: NoSchedule
           containers:
             - name: main
-              image: vllm/vllm-openai@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
+              image: vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash


### PR DESCRIPTION
## Overview:

The four GLM-5.3-Flash manifests reference the mutable tag `vllm/vllm-openai:glm53-flash`, which was re-pushed upstream on 2026-09-09 and now resolves to an image incompatible with the recipes' own arguments. This pins the validated image by digest instead.

## Details:

Every fresh deployment of these recipes now fails at engine startup, because the recipes hard-pin `--attention-backend FLASHMLA_SPARSE` and the image the tag currently resolves to rejects this model's head size for that backend.

Changing the six `image:` lines across the four manifests (plus the four in the recipe catalog entry) to a digest reference makes the pin immutable:

```
vllm/vllm-openai:glm53-flash@sha256:2c6da6c6f16ed15c91e412d896dba13701f25fe1861eaec9ddaa4db34d1d21c4
```

The tag is kept and the digest appended, matching how every existing digest pin under `recipes/` is written — 33 references to `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0@sha256:…` and 12 to `vllm/vllm-openai:qwen38-flash-next@sha256:…`. That second one is the closest precedent available: a model-specific vLLM build from this same Docker Hub repository, pinned the same way. The digest decides resolution; the tag stays as readable provenance, and the DGD operator can still inspect it (the `qwen3.8-flash-next` README notes the operator reads the tag for API compatibility, which is why `runtimeVersionOverride` accompanies non-semver tags — these manifests already set it).

I verified the two claims in #14573 against Docker Hub's registry API rather than taking them from the issue:

- **The tag moved.** `:glm53-flash` currently resolves to `sha256:819ec9c0…c52374`; the digest pinned here is `sha256:2c6da6c6…1d21c4`. Different images, matching what the issue reported.
- **The pinned digest is a multi-arch manifest list** (`application/vnd.docker.distribution.manifest.list.v2+json`) carrying both `linux/arm64` and `linux/amd64`. That matters here: one digest covers the GB200 (ARM64) and H200 (AMD64) targets, so no per-target reference is needed.

I have not run these recipes. @marckarp confirmed in #14573 that the pinned digest boots and serves on 8xH100 with a cold pull, and that the current tag reproduces the `FLASHMLA_SPARSE … head_size not supported` failure.

### Scope

This is deliberately only the short-term half of the fix the issue proposes. The durable part — republishing the validated image under `nvcr.io/nvidia/ai-dynamo/`, as was done for GLM-5.2 — needs registry access this change cannot reach. Worth flagging that the validated image is presently reachable **only** as an untagged digest, so it is exposed to garbage collection; a digest pin removes the immediate breakage but does not remove that risk.

I also left the recipe flags alone. Re-validating them against the new nightly-based image (the issue's optional item 3) needs hardware.

Documentation follows the same precedent: the prerequisites keep naming the plain tag (readable, and what a person looks for), and a Limitations entry records that the manifests pin it by digest and why. The `sitecustomize.py` comment in `agg-h200-agentic` names the image family as context for the cuDNN workaround, which is still accurate, so it is unchanged. Service names like `glm53-flash-agg-frontend` are unrelated and untouched.

## Validation

- **Digest reachable and correct shape.** Registry API returns HTTP 200 for the pinned digest; it is a manifest list with `linux/arm64` and `linux/amd64` entries. The reference matches `sha256:[0-9a-f]{64}`.
- **All references consistent.** Parsing the four manifests and the catalog entry, all 10 `vllm-openai` image references are the identical `:glm53-flash@sha256:2c6da6c6…` string; no bare-tag reference remains in any `image:` field.
- **YAML intact.** All five files still parse; document counts unchanged (2 per manifest, 1 for the catalog).
- **Not performed.** No cluster deploy and no inference run. The functional confirmation is @marckarp's on 8xH100, not mine.

## Where should the reviewer start?

The six `image:` lines in `recipes/glm-5.3-flash/vllm/*/deploy.yaml`. Everything else follows from those.

## Related Issues

- Closes #14573
