### PR TITLE
fix(container/vllm): patch exaone_moe lm_head prefix + bump vLLM to v0.28.0 for K-EXAONE

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -66,7 +66,7 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.26.0-ubuntu2404
+    runtime_image_tag: v0.28.0-ubuntu2404
     # Baseline is vllm-openai's TRUE base, nvidia/cuda:13.0.2-base-ubuntu24.04
     # (Docker Hub), NOT a self-baseline of the third-party vllm/vllm-openai image.
     # vllm-openai is built FROM nvidia/cuda, so this attributes everything vLLM

--- a/container/deps/vllm/patches/01-exaone-moe-lm-head-prefix.patch
+++ b/container/deps/vllm/patches/01-exaone-moe-lm-head-prefix.patch
@@ -1,0 +1,38 @@
+From: Cheng Wang <chengwa@nvidia.com>
+Subject: [PATCH] fix(k-exaone-2): pass prefix to ParallelLMHead in exaone_moe so quantization exclusions match
+
+K-EXAONE-2.0-750B-A37B-NVFP4 fails to load on vLLM 0.28.0 and 0.29.0:
+
+  vocab_parallel_embedding.py weight_loader
+  RuntimeError: The size of tensor a (3072) must match the size of tensor b
+                (6144) at non-singleton dimension 1
+
+exaone_moe.py constructs ParallelLMHead without a `prefix`, so it defaults to
+"". VocabParallelEmbedding.__init__ then calls
+quant_config.get_quant_method(self, prefix=""), and
+ModelOptNvFp4Config.is_layer_excluded("") cannot match any of the checkpoint's
+223 exclusion patterns. lm_head is therefore quantized and allocated as a
+packed NVFP4 param [vocab, hidden/2] = [.., 3072], which rejects the
+checkpoint's unquantized BF16 lm_head.weight [153600, 6144].
+
+Verified CPU-only against the checkpoint's own quantization config:
+  is_layer_excluded('lm_head') = True   is_layer_excluded('') = False
+  get_quant_method(ParallelLMHead, prefix='lm_head') -> UnquantizedLinearMethod
+  get_quant_method(ParallelLMHead, prefix='')        -> NVFP4 linear method
+
+The file already imports maybe_prefix and already uses it for "model" a few
+lines above. qwen3_moe.py and exaone4.py (same model family) both pass the
+prefix correctly; exaone_moe.py is the outlier.
+
+Only manifests for checkpoints that exclude lm_head from quantization, which is
+why BF16-validated upstream support PRs never hit it.
+
+--- a/vllm/model_executor/models/exaone_moe.py
++++ b/vllm/model_executor/models/exaone_moe.py
+@@ -513,6 +513,7 @@
+                 else lora_config.lora_vocab_padding_size,
+                 quant_config=quant_config,
++                prefix=maybe_prefix(prefix, "lm_head"),
+             )
+             if config.tie_word_embeddings:
+                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -246,6 +246,16 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" %}
+# Apply vLLM hotfixes to the installed package tree. Patches are applied with
+# --fuzz=5 to tolerate minor line-number drift across nightly builds.
+RUN --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
+    SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    for p in $(ls /tmp/vllm_patches/*.patch 2>/dev/null | sort); do \
+        patch --fuzz=5 -p1 -d "${SITE_PACKAGES}" < "$p"; \
+    done
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
Container PR on the `release/1.4.1-k-exaone-2.0-750b-post.1` branch (per request to file container PRs on release branches).

## Problem

`vllm/model_executor/models/exaone_moe.py` constructs `ParallelLMHead` **without a `prefix`**, so it defaults to `""`. `VocabParallelEmbedding.__init__` then calls `quant_config.get_quant_method(self, prefix="")`, and `is_layer_excluded("")` matches none of an NVFP4 checkpoint's exclusion patterns. `lm_head` is therefore quantized and allocated as a **packed NVFP4** param `[vocab, hidden/2]`, which rejects an unquantized BF16 `lm_head.weight`:

```
vocab_parallel_embedding.py  weight_loader
RuntimeError: The size of tensor a (3072) must match the size of tensor b (6144)
              at non-singleton dimension 1
```

Proven CPU-only against the checkpoint's own quantization config:

```
exclude_modules: 223
is_layer_excluded('lm_head') = True      is_layer_excluded('') = False
get_quant_method(ParallelLMHead, prefix='lm_head') -> UnquantizedLinearMethod
get_quant_method(ParallelLMHead, prefix='')        -> NVFP4 linear method
```

Only manifests for checkpoints that exclude `lm_head` from quantization, which is why BF16-validated support PRs never hit it.

## Changes

Three files:

1. **`container/deps/vllm/patches/01-exaone-moe-lm-head-prefix.patch`** (new) — adds `prefix=maybe_prefix(prefix, "lm_head")`.
2. **`container/templates/vllm_runtime.Dockerfile`** — applies `container/deps/vllm/patches/*.patch` into site-packages (`patch --fuzz=5 -p1`, filename order, cuda only).
3. **`container/context.yaml`** — `runtime_image_tag` **`v0.26.0-ubuntu2404` → `v0.28.0-ubuntu2404`**. See "Scope of the base-image bump" below; this is the part most worth a maintainer's attention.

Patch verified to apply to **both** vLLM 0.26.0 and 0.28.0; `maybe_prefix` is already imported in both.

## Scope of the base-image bump

The bump is **not** incidental to the patch — it is required, and it affects every framework user of this branch, so please review it on its own terms.

**Why it is needed:** this branch pinned vLLM `v0.26.0`, whose model-registry key is misspelled — `registry.py` has `"ExaoneMoEForCausalLM"` (capital `E` in `MoE`), while both `LGAI-EXAONE/K-EXAONE-236B-A23B` and `K-EXAONE-2.0-750B-A37B` declare `architectures: ["ExaoneMoeForCausalLM"]`. `_ModelRegistry._normalize_arch` does an exact dict lookup with no case folding, so the architecture never resolves on 0.26.0. v0.28.0 has the corrected key. The `lm_head` patch alone is therefore not sufficient on this branch.

**What that means for review:** this is a two-minor-version jump on a release branch. The test evidence below is K-EXAONE-specific; I have **not** validated other models against 0.28.0 on this branch. If that is a concern, the alternative is cherry-picking the registry-key fix onto 0.26.0 instead of bumping — happy to do that if preferred.

## Test results (K-EXAONE-2.0-750B-A37B-NVFP4, B200 TP4)

| config | patch | result |
|---|---|---|
| Dynamo DGD | no | crash @ shard 53 |
| Dynamo DGD, no `--quantization` | no | crash @ shard 53 |
| raw vLLM 0.29.0 | no | crash @ shard 53 |
| raw `vllm serve` 0.28.0 | **yes** | 53/53 shards, KV 3,475,818 tokens, startup complete |
| Dynamo DGD (vllm-runtime-nightly) | **yes** | worker Ready, serves through the frontend |

**Extended soak on the image built from this PR head.** The CI image for `7ba2828b` (`…:1.4.1-ci-7ba2828b…-vllm-runtime`) has since served K-EXAONE-2.0-750B-A37B-NVFP4 continuously for several days on 4×/8× B200, aggregated and disaggregated, covering:

- full Mooncake chat-trace replay (12 031 requests) and synthetic sweeps across ~20 engine configurations;
- GPQA-Diamond accuracy gates on four serving configurations — **0.8131 ± 0.0278** for the aggregated recipe against a raw-vLLM control of 0.7677 ± 0.0301, with LG's published BF16 82.2 inside every CI;
- 1P1D disaggregated serving with NIXL KV transfer, also accuracy-gated (0.7778 ± 0.0296).

No load-path or numerical issue attributable to the patch or to the 0.28.0 bump appeared in any of it.

## CI status

Checks are red, and I believe **none of it is attributable to this change**. Evidence:

- **`sglang-runtime / Test cuda13.0, amd64` and `trtllm-runtime / Test cuda13.1, amd64` fail with the identical error**, and this PR touches neither. The diff is three files, all vLLM-specific: a new patch, the vLLM Dockerfile's apply step, and the `vllm:` block of `container/context.yaml`.
- The error in every case is a local composite action failing to resolve, *after* the image has built and passed its sanity check:

  ```
  ✅ Sanity check passed        (ai-dynamo 1.4.1, dynamo.vllm imports cleanly)
  ##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
           '/home/runner/_work/dynamo/dynamo/.github/actions/pytest-local'.
           Did you forget to run actions/checkout before running your local action?
  ```

  `.github/actions/pytest-local/action.yml` is present on the base branch, so this is a workspace/checkout problem on the runner, not a missing file.
- **Same commit, same workflow: `sglang-runtime / Test arm64` and `trtllm-runtime / Test arm64` pass while their amd64 counterparts fail.** A defect in the diff would not be arch-selective like that.
- #14569 — the same code change against `main` — fails a similar `dynamo-runtime` + status-check family, which suggests a shared pre-existing condition rather than anything specific to this branch.

I have re-run the failed jobs. If they stay red, I would appreciate a maintainer re-running them from an in-repo branch, since this is a fork PR and that is the most likely difference.

## This patch is a bridge

The real fix belongs upstream in vLLM — `exaone_moe.py` already imports `maybe_prefix` and uses it for `"model"` a few lines above, and `qwen3_moe.py` / `exaone4.py` both pass the prefix correctly. Current vLLM `main` is still unfixed.

Related: #14569 is the same change targeting `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

