### PR TITLE
fix(operator): gate worker hash projection on informer observation (cherry-pick #14249)

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -907,6 +907,10 @@ func checkpointWorkerHashForComponent(dgd *nvidiacomv1beta1.DynamoGraphDeploymen
 	if component == nil || !dynamo.IsWorkerComponent(string(component.ComponentType)) {
 		return "", nil
 	}
+	// Pend until a generation is committed; avoids SnapshotJobs for an uncommitted hash.
+	if currentWorkerHashes(dgd).empty() {
+		return "", nil
+	}
 	desired, err := desiredWorkerHashes(dgd)
 	if err != nil {
 		return "", err

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -628,6 +628,30 @@ func TestDGDCheckpointsReconciler_ExplicitRestoreWaitsForActiveWorkerHash(t *tes
 	assert.Equal(t, referenced.UID, info.NativeSnapshot.UID)
 }
 
+func TestCheckpointWorkerHashForComponent_WaitsForCommittedGeneration(t *testing.T) {
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "worker",
+				ComponentType: v1beta1.ComponentTypeWorker,
+			}},
+		},
+	}
+
+	t.Log("No annotation: generation is uncommitted; must return empty hash")
+	hash, err := checkpointWorkerHashForComponent(dgd, "worker")
+	require.NoError(t, err)
+	assert.Empty(t, hash, "checkpointWorkerHashForComponent must return empty before the active generation is committed")
+
+	t.Log("Annotation present: generation is committed; must return the active hash")
+	workerHash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{commonconsts.AnnotationCurrentWorkerHashV2: workerHash}
+	hash, err = checkpointWorkerHashForComponent(dgd, "worker")
+	require.NoError(t, err)
+	assert.Equal(t, workerHash, hash)
+}
+
 func TestDGDCheckpointsReconciler_RejectsDisabledFeatureBeforeCreatingResources(t *testing.T) {
 	t.Log("Build a checkpoint-enabled DGD while the checkpoint feature is disabled")
 	ctx := context.Background()

--- a/deploy/operator/internal/controller/dgd_component_program.go
+++ b/deploy/operator/internal/controller/dgd_component_program.go
@@ -152,11 +152,37 @@ func (p *componentProgram) reconcileWorkerRollout(
 		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
 		return failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
 	}
-
 	if supportsManagedRollingUpdate(dgd) {
 		return p.reconcileManagedWorkerRollout(ctx, dgd, status)
 	}
-	return p.rollout.ReconcileUnsupported(ctx, dgd, false)
+	return p.reconcileMultinodeWorkerRollout(ctx, dgd)
+}
+
+// reconcileMultinodeWorkerRollout gates hash projection on informer observation of the target DCD.
+func (p *componentProgram) reconcileMultinodeWorkerRollout(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) error {
+	transition, err := p.rollout.planUnsupportedWorkerHashTransition(dgd)
+	if err != nil {
+		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+	}
+	if !transition.needsCommit() {
+		return nil
+	}
+
+	observed, err := p.rollout.dcdObservesWorkerHash(ctx, dgd, transition.next.v2)
+	if err != nil {
+		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+	}
+	if !observed {
+		return nil
+	}
+
+	if err := p.rollout.commitUnsupportedWorkerHashTransition(ctx, dgd, transition, false); err != nil {
+		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+	}
+	return nil
 }
 
 // supportsManagedRollingUpdate checks whether the component pathway can use

--- a/deploy/operator/internal/controller/dgd_grove_watch_setup.go
+++ b/deploy/operator/internal/controller/dgd_grove_watch_setup.go
@@ -51,9 +51,7 @@ func newGroveWatchSetup(reader client.Reader) *groveWatchSetup {
 func (s *groveWatchSetup) addTo(ctrlBuilder *builder.Builder) *builder.Builder {
 	return ctrlBuilder.
 		Owns(&grovev1alpha1.PodCliqueSet{}, builder.WithPredicates(predicate.Funcs{
-			// Creation is caused by DGD reconciliation and does not need to
-			// enqueue the owner again.
-			CreateFunc:  func(event.CreateEvent) bool { return false },
+			CreateFunc:  func(event.CreateEvent) bool { return true },
 			DeleteFunc:  func(event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(event.UpdateEvent) bool { return true },
 			GenericFunc: func(event.GenericEvent) bool { return true },

--- a/deploy/operator/internal/controller/dgd_grove_worker_hash_suffix_envtest_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_worker_hash_suffix_envtest_test.go
@@ -165,6 +165,7 @@ func createLegacyGroveWorkerHashSuffixTestDGD(
 			},
 		}},
 	}
+	require.NoError(t, ctrl.SetControllerReference(dgd, legacyPCS, env.Client().Scheme()))
 	require.NoError(t, legacyClient.Create(ctx, legacyPCS))
 }
 

--- a/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
+++ b/deploy/operator/internal/controller/dgd_grove_workload_renderer.go
@@ -189,7 +189,7 @@ func applyGroveWorkerHashSuffix(
 func shouldRenderGroveWorkerHashSuffix(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	existing *grovev1alpha1.PodCliqueSet,
-	workerGenerationChanged bool,
+	hashChanged bool,
 ) bool {
 	if !dgdHasWorkerComponents(dgd) {
 		return false
@@ -198,7 +198,7 @@ func shouldRenderGroveWorkerHashSuffix(
 		return true
 	}
 
-	return workerGenerationChanged
+	return hashChanged
 }
 
 func dgdHasWorkerComponents(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
@@ -225,6 +225,38 @@ func podCliqueSetUsesGroveWorkerHashSuffix(
 		}
 	}
 	return true
+}
+
+// podCliqueSetObservesWorkerHash reports whether every worker clique in pcs carries the
+// computed DGD worker hash, or, for a pre-existing legacy PCS, that no clique is stamped.
+func podCliqueSetObservesWorkerHash(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	pcs *grovev1alpha1.PodCliqueSet,
+	acceptAllUnstamped bool,
+) (bool, error) {
+	if !dgdHasWorkerComponents(dgd) {
+		return true, nil
+	}
+	want, err := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	if err != nil {
+		return false, fmt.Errorf("compute desired Grove worker hash: %w", err)
+	}
+	allCanonical := true
+	allUnstamped := acceptAllUnstamped
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if !dynamo.IsWorkerComponent(string(component.ComponentType)) {
+			continue
+		}
+		clique := podCliqueSetCliqueForComponent(pcs, component.ComponentName)
+		if clique == nil {
+			return false, nil
+		}
+		hash := clique.Labels[commonconsts.KubeLabelDynamoWorkerHash]
+		allCanonical = allCanonical && hash == want
+		allUnstamped = allUnstamped && hash == ""
+	}
+	return allCanonical || allUnstamped, nil
 }
 
 func podCliqueSetCliqueForComponent(

--- a/deploy/operator/internal/controller/dgd_grove_workloads_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_grove_workloads_reconciler.go
@@ -86,24 +86,38 @@ func (r *groveWorkloadsReconciler) Reconcile(
 		dgd,
 		restartState,
 		checkpointInfos,
-		workerHashTransition.workerGenerationChanged,
+		workerHashTransition.hashChanged,
 	)
 	if err != nil {
 		logger.Error(err, "failed to generate the Grove GangSet")
 		return ReconcileResult{}, fmt.Errorf("failed to generate the Grove GangSet: %w", err)
 	}
-	syncedPodCliqueSet, err := r.reconcilePodCliqueSet(ctx, dgd, renderedPodCliqueSet)
+	syncedPodCliqueSet, pcsWasWritten, err := r.reconcilePodCliqueSet(ctx, dgd, renderedPodCliqueSet)
 	if err != nil {
 		logger.Error(err, "failed to reconcile the Grove PodCliqueSet")
 		return ReconcileResult{}, fmt.Errorf("failed to reconcile the Grove PodCliqueSet: %w", err)
 	}
-	// The PCS write is the transition's write barrier. A failed DGD update
-	// leaves its hash unchanged, so the next reconcile replans from live state.
-	if err := r.rollout.commitUnsupportedWorkerHashTransition(ctx, dgd, workerHashTransition, true); err != nil {
-		return ReconcileResult{}, failWorkloadProgram(
-			reasonRollingUpdateFailed,
-			fmt.Errorf("commit worker hash after Grove PodCliqueSet sync: %w", err),
-		)
+	// Defer commit if the PCS was written this reconcile; the informer hasn't caught up yet.
+	if workerHashTransition.needsCommit() && !pcsWasWritten {
+		// Pre-existing legacy PCS without a suffix is the only case where unstamped is valid.
+		isLegacyUnsuffixed := workerHashTransition.noCurrentAnnotation &&
+			renderedPodCliqueSet.existing != nil &&
+			!podCliqueSetUsesGroveWorkerHashSuffix(dgd, renderedPodCliqueSet.existing)
+		observed, err := podCliqueSetObservesWorkerHash(dgd, renderedPodCliqueSet.existing, isLegacyUnsuffixed)
+		if err != nil {
+			return ReconcileResult{}, failWorkloadProgram(
+				reasonRollingUpdateFailed,
+				fmt.Errorf("observe Grove worker hash before projection: %w", err),
+			)
+		}
+		if observed {
+			if err := r.rollout.commitUnsupportedWorkerHashTransition(ctx, dgd, workerHashTransition, true); err != nil {
+				return ReconcileResult{}, failWorkloadProgram(
+					reasonRollingUpdateFailed,
+					fmt.Errorf("project observed Grove worker hash: %w", err),
+				)
+			}
+		}
 	}
 
 	if err := r.scaler.Reconcile(ctx, dgd, checkpointInfos); err != nil {
@@ -135,11 +149,11 @@ func (r *groveWorkloadsReconciler) reconcilePodCliqueSet(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	rendered *grovePodCliqueSetRender,
-) (*grovev1alpha1.PodCliqueSet, error) {
+) (*grovev1alpha1.PodCliqueSet, bool, error) {
 	// Compose opaque provider fields only at the serialization boundary.
 	desiredProviderObject, err := provideroverride.ComposeGroveOverrides(dgd, rendered.desired)
 	if err != nil {
-		return nil, fmt.Errorf("compose Grove provider overrides: %w", err)
+		return nil, false, fmt.Errorf("compose Grove provider overrides: %w", err)
 	}
 
 	// Serialize the exact typed observation selected during rendering.
@@ -147,14 +161,14 @@ func (r *groveWorkloadsReconciler) reconcilePodCliqueSet(
 	if rendered.existing != nil {
 		object, conversionErr := runtime.DefaultUnstructuredConverter.ToUnstructured(rendered.existing)
 		if conversionErr != nil {
-			return nil, fmt.Errorf("convert observed Grove PodCliqueSet to unstructured: %w", conversionErr)
+			return nil, false, fmt.Errorf("convert observed Grove PodCliqueSet to unstructured: %w", conversionErr)
 		}
 		observedProviderObject = &unstructured.Unstructured{Object: object}
 		observedProviderObject.SetGroupVersionKind(desiredProviderObject.GroupVersionKind())
 	}
 
 	// Synchronize without rereading or mutating the render observation.
-	_, synced, err := commoncontroller.SyncObservedResource(
+	wasWritten, synced, err := commoncontroller.SyncObservedResource(
 		ctx,
 		&r.syncer,
 		dgd,
@@ -162,15 +176,15 @@ func (r *groveWorkloadsReconciler) reconcilePodCliqueSet(
 		desiredProviderObject,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("sync Grove PodCliqueSet: %w", err)
+		return nil, false, fmt.Errorf("sync Grove PodCliqueSet: %w", err)
 	}
 
 	// Adapt the synchronized wire object to the typed Grove readiness view.
 	podCliqueSet := &grovev1alpha1.PodCliqueSet{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(synced.Object, podCliqueSet); err != nil {
-		return nil, fmt.Errorf("convert synchronized Grove PodCliqueSet: %w", err)
+		return nil, false, fmt.Errorf("convert synchronized Grove PodCliqueSet: %w", err)
 	}
-	return podCliqueSet, nil
+	return podCliqueSet, wasWritten, nil
 }
 
 // observePodCliqueSetReadiness takes the authoritative Grove snapshot after

--- a/deploy/operator/internal/controller/dgd_grove_workloads_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_grove_workloads_reconciler_test.go
@@ -304,13 +304,13 @@ func TestGroveWorkloadsReconciler_RecoversWorkerHashCommitAfterPodCliqueSetSync(
 		&mockDockerSecretRetriever{GetSecretsFunc: func(string, string) ([]string, error) { return nil, nil }},
 	)
 
-	t.Log("Persist the PCS suffix, then fail the DGD hash commit")
+	t.Log("Persist the PCS suffix without projecting the DGD hash from the write receipt")
 	observedDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), observedDGD))
 	_, err = workloads.Reconcile(context.Background(), observedDGD, nil, nil)
-	require.Error(t, err)
+	require.NoError(t, err)
 
-	t.Log("Verify the durable state is a suffixed PCS with the previous DGD hash")
+	t.Log("Verify the write receipt leaves the parent hash unchanged")
 	storedPCS := &grovev1alpha1.PodCliqueSet{}
 	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(legacyPCS), storedPCS))
 	clique := podCliqueSetCliqueForComponent(storedPCS, "prefill")
@@ -320,20 +320,20 @@ func TestGroveWorkloadsReconciler_RecoversWorkerHashCommitAfterPodCliqueSetSync(
 	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), storedDGD))
 	assert.Equal(t, currentHash, storedDGD.Annotations[consts.AnnotationCurrentWorkerHashV2])
 	assert.Equal(t, 1, pcsUpdateCalls)
-	assert.Equal(t, 1, dgdUpdateCalls)
+	assert.Zero(t, dgdUpdateCalls)
 
-	t.Log("Reconcile from freshly read objects after the simulated controller restart")
-	failDGDUpdate = false
+	t.Log("Observe the suffix on a later reconcile, then reject the parent projection")
 	freshDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), freshDGD))
-	workloads = newGroveWorkloadsReconciler(
-		kubeClient,
-		events.NewFakeRecorder(10),
-		newDGDWorkerRolloutReconciler(kubeClient, nil),
-		&configv1alpha1.OperatorConfiguration{},
-		&commoncontroller.RuntimeConfig{},
-		&mockDockerSecretRetriever{GetSecretsFunc: func(string, string) ([]string, error) { return nil, nil }},
-	)
+	_, err = workloads.Reconcile(context.Background(), freshDGD, nil, nil)
+	require.Error(t, err)
+	assert.Equal(t, 1, pcsUpdateCalls)
+	assert.Equal(t, 1, dgdUpdateCalls)
+
+	t.Log("Retry projection from a fresh observation after the simulated controller restart")
+	failDGDUpdate = false
+	freshDGD = &nvidiacomv1beta1.DynamoGraphDeployment{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), freshDGD))
 	_, err = workloads.Reconcile(context.Background(), freshDGD, nil, nil)
 	require.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestGroveWorkloadsReconciler_ReconcilePodCliqueSetRejectsStaleObservation(t
 	reconciler := &groveWorkloadsReconciler{syncer: newDGDResourceSyncer(kubeClient, nil)}
 
 	t.Log("Reconcile the exact observation and surface the retryable conflict")
-	_, err := reconciler.reconcilePodCliqueSet(context.Background(), dgd, &grovePodCliqueSetRender{
+	_, _, err := reconciler.reconcilePodCliqueSet(context.Background(), dgd, &grovePodCliqueSetRender{
 		existing: observed,
 		desired:  desired,
 	})
@@ -431,7 +431,7 @@ func TestGroveWorkloadsReconciler_ReconcilePodCliqueSetReturnsCreateConflict(t *
 	reconciler := &groveWorkloadsReconciler{syncer: newDGDResourceSyncer(kubeClient, nil)}
 
 	t.Log("Reconcile the missing observation and surface the retryable creation collision")
-	_, err := reconciler.reconcilePodCliqueSet(context.Background(), dgd, &grovePodCliqueSetRender{desired: desired})
+	_, _, err := reconciler.reconcilePodCliqueSet(context.Background(), dgd, &grovePodCliqueSetRender{desired: desired})
 
 	t.Log("Verify the creation collision is returned to the caller")
 	require.Error(t, err)
@@ -472,14 +472,14 @@ func TestGroveProviderOverridesUseObservedPCSReconciliation(t *testing.T) {
 
 	t.Log("Create the PCS after composing an opaque root topology override")
 	dgd.Spec.ProviderOverride = rootTopologyOverride(`{"topologyName":"gpu-topology","futureProviderField":{"enabled":true}}`)
-	_, err := reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{desired: desired})
+	_, _, err := reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{desired: desired})
 	require.NoError(t, err)
 	assertLiveRootTopologyValue(t, kubeClient, "topologyName", "gpu-topology")
 
 	t.Log("Reuse the typed render observation when the desired PCS is unchanged")
 	observed := &grovev1alpha1.PodCliqueSet{}
 	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(desired), observed))
-	_, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
+	_, _, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
 	require.NoError(t, err)
 	assert.Zero(t, updateCalls)
 
@@ -487,7 +487,7 @@ func TestGroveProviderOverridesUseObservedPCSReconciliation(t *testing.T) {
 	dgd.Spec.ProviderOverride = rootTopologyOverride(`{"topologyName":"changed"}`)
 	rejectUpdate = true
 	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(desired), observed))
-	_, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
+	_, _, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
 	require.ErrorContains(t, err, "provider rejected update")
 	assert.Equal(t, 1, updateCalls)
 	assertLiveRootTopologyValue(t, kubeClient, "topologyName", "gpu-topology")
@@ -496,7 +496,7 @@ func TestGroveProviderOverridesUseObservedPCSReconciliation(t *testing.T) {
 	rejectUpdate = false
 	dgd.Spec.ProviderOverride = nil
 	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(desired), observed))
-	_, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
+	_, _, err = reconciler.reconcilePodCliqueSet(ctx, dgd, &grovePodCliqueSetRender{existing: observed, desired: desired})
 	require.NoError(t, err)
 	assert.Equal(t, 2, updateCalls)
 	live := newUnstructuredGrovePodCliqueSet()
@@ -504,6 +504,221 @@ func TestGroveProviderOverridesUseObservedPCSReconciliation(t *testing.T) {
 	_, found, nestedErr := unstructured.NestedFieldNoCopy(live.Object, "spec", "template", "topologyConstraint")
 	require.NoError(t, nestedErr)
 	assert.False(t, found)
+}
+
+func TestPodCliqueSetObservesWorkerHash(t *testing.T) {
+	dgd := createTestDGD("graph", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {
+			ComponentType: consts.ComponentTypePrefill,
+			Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "v1"}},
+		},
+	})
+	wantHash, err := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+
+	unstampedPCS := &grovev1alpha1.PodCliqueSet{Spec: grovev1alpha1.PodCliqueSetSpec{
+		Template: grovev1alpha1.PodCliqueSetTemplateSpec{
+			Cliques: []*grovev1alpha1.PodCliqueTemplateSpec{{
+				Labels: map[string]string{consts.KubeLabelDynamoComponent: "prefill"},
+			}},
+		},
+	}}
+	stampedPCS := unstampedPCS.DeepCopy()
+	stampedPCS.Spec.Template.Cliques[0].Labels[consts.KubeLabelDynamoWorkerHash] = wantHash
+
+	tests := []struct {
+		name               string
+		pcs                *grovev1alpha1.PodCliqueSet
+		acceptAllUnstamped bool
+		want               bool
+	}{
+		{
+			name:               "nil PCS is never observed",
+			pcs:                nil,
+			acceptAllUnstamped: true,
+			want:               false,
+		},
+		{
+			name:               "unstamped cliques accepted for legacy unsuffixed PCS",
+			pcs:                unstampedPCS,
+			acceptAllUnstamped: true,
+			want:               true,
+		},
+		{
+			name:               "unstamped cliques rejected for new PCS requiring canonical hash",
+			pcs:                unstampedPCS,
+			acceptAllUnstamped: false,
+			want:               false,
+		},
+		{
+			name:               "cliques bearing target hash accepted regardless of acceptAllUnstamped",
+			pcs:                stampedPCS,
+			acceptAllUnstamped: false,
+			want:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := podCliqueSetObservesWorkerHash(dgd, tt.pcs, tt.acceptAllUnstamped)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGroveWorkloadsReconciler_SkipsHashObservationWhenHashIsCurrent(t *testing.T) {
+	t.Log("Build a DGD whose annotation already matches the desired hash")
+	dgd := createTestDGD("graph", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {
+			ComponentType: consts.ComponentTypePrefill,
+			Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "v1"}},
+		},
+	})
+	currentHash, err := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHashV2: currentHash}
+
+	t.Log("Seed a PCS carrying the current hash so the sync is a no-op")
+	existingPCS := &grovev1alpha1.PodCliqueSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Components),
+			Namespace: dgd.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(dgd, nvidiacomv1beta1.GroupVersion.WithKind("DynamoGraphDeployment")),
+			},
+		},
+		Spec: grovev1alpha1.PodCliqueSetSpec{Template: grovev1alpha1.PodCliqueSetTemplateSpec{
+			Cliques: []*grovev1alpha1.PodCliqueTemplateSpec{{
+				Labels: map[string]string{
+					consts.KubeLabelDynamoComponent:  "prefill",
+					consts.KubeLabelDynamoWorkerHash: currentHash,
+				},
+			}},
+		}},
+	}
+
+	dgdUpdateCalls := 0
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithObjects(dgd, existingPCS).
+		WithStatusSubresource(dgd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, object client.Object, _ ...client.UpdateOption) error {
+				if _, ok := object.(*nvidiacomv1beta1.DynamoGraphDeployment); ok {
+					dgdUpdateCalls++
+				}
+				return nil
+			},
+		}).
+		Build()
+	workloads := newGroveWorkloadsReconciler(
+		kubeClient,
+		events.NewFakeRecorder(10),
+		newDGDWorkerRolloutReconciler(kubeClient, nil),
+		&configv1alpha1.OperatorConfiguration{},
+		&commoncontroller.RuntimeConfig{},
+		&mockDockerSecretRetriever{GetSecretsFunc: func(string, string) ([]string, error) { return nil, nil }},
+	)
+
+	t.Log("Reconcile: hash observation block must be skipped entirely when needsCommit is false")
+	observedDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), observedDGD))
+	_, err = workloads.Reconcile(context.Background(), observedDGD, nil, nil)
+	require.NoError(t, err)
+
+	assert.Zero(t, dgdUpdateCalls, "DGD must not be updated when the hash annotation is already current")
+}
+
+func TestGroveWorkloadsReconciler_DefersHashCommitUntilPCSWriteObserved(t *testing.T) {
+	dgd := createTestDGD("graph", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {
+			ComponentType: consts.ComponentTypePrefill,
+			Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "v1"}},
+		},
+	})
+	wantHash, err := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		existingPCS *grovev1alpha1.PodCliqueSet
+	}{
+		{
+			name:        "new PCS — create defers commit, second reconcile commits",
+			existingPCS: nil,
+		},
+		{
+			name: "legacy unsuffixed PCS — bookkeeping write defers commit, second reconcile commits",
+			existingPCS: &grovev1alpha1.PodCliqueSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dynamo.PCSNameForDGD(dgd.Name, dgd.Spec.Components),
+					Namespace: dgd.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(dgd, nvidiacomv1beta1.GroupVersion.WithKind("DynamoGraphDeployment")),
+					},
+				},
+				Spec: grovev1alpha1.PodCliqueSetSpec{Template: grovev1alpha1.PodCliqueSetTemplateSpec{
+					Cliques: []*grovev1alpha1.PodCliqueTemplateSpec{{
+						Labels: map[string]string{consts.KubeLabelDynamoComponent: "prefill"},
+					}},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgdUpdateCalls := 0
+			builder := fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithObjects(dgd).
+				WithStatusSubresource(dgd).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(
+						ctx context.Context,
+						writer client.WithWatch,
+						object client.Object,
+						opts ...client.UpdateOption,
+					) error {
+						if _, ok := object.(*nvidiacomv1beta1.DynamoGraphDeployment); ok {
+							dgdUpdateCalls++
+						}
+						return writer.Update(ctx, object, opts...)
+					},
+				})
+			if tt.existingPCS != nil {
+				builder.WithObjects(tt.existingPCS)
+			}
+			kubeClient := builder.Build()
+			workloads := newGroveWorkloadsReconciler(
+				kubeClient,
+				events.NewFakeRecorder(10),
+				newDGDWorkerRolloutReconciler(kubeClient, nil),
+				&configv1alpha1.OperatorConfiguration{},
+				&commoncontroller.RuntimeConfig{},
+				&mockDockerSecretRetriever{GetSecretsFunc: func(string, string) ([]string, error) { return nil, nil }},
+			)
+
+			t.Log("First reconcile writes the PCS; commit must be deferred")
+			observedDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), observedDGD))
+			_, err = workloads.Reconcile(context.Background(), observedDGD, nil, nil)
+			require.NoError(t, err)
+			assert.Zero(t, dgdUpdateCalls, "hash annotation must not be committed on the reconcile that writes the PCS")
+
+			t.Log("Second reconcile is a no-op PCS sync; commit must proceed")
+			freshDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), freshDGD))
+			_, err = workloads.Reconcile(context.Background(), freshDGD, nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, 1, dgdUpdateCalls, "hash annotation must be committed once the PCS write is observed")
+
+			storedDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), storedDGD))
+			assert.Equal(t, wantHash, storedDGD.Annotations[consts.AnnotationCurrentWorkerHashV2])
+		})
+	}
 }
 
 func isGrovePodCliqueSetObject(object client.Object) bool {

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler.go
@@ -48,13 +48,13 @@ type workerGenerationHashes struct {
 // callers commit it only after they have reconciled the workload carrying the
 // corresponding generation.
 type unsupportedWorkerHashTransition struct {
-	next                    workerGenerationHashes
-	initialize              bool
-	workerGenerationChanged bool
+	next                workerGenerationHashes
+	noCurrentAnnotation bool // DGD carries no current worker hash annotation
+	hashChanged         bool // hash annotation exists but does not match desired
 }
 
 func (t unsupportedWorkerHashTransition) needsCommit() bool {
-	return t.initialize || t.workerGenerationChanged
+	return t.noCurrentAnnotation || t.hashChanged
 }
 
 // dgdWorkerRolloutReconciler owns worker-generation metadata and the managed
@@ -74,36 +74,6 @@ func newDGDWorkerRolloutReconciler(
 	}
 }
 
-// ReconcileUnsupported advances compatibility hashes for a pathway that does
-// not support operator-managed rolling updates.
-func (r *dgdWorkerRolloutReconciler) ReconcileUnsupported(
-	ctx context.Context,
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	isGrove bool,
-) error {
-	logger := log.FromContext(ctx)
-
-	transition, err := r.planUnsupportedWorkerHashTransition(dgd)
-	if err != nil {
-		logger.Error(err, "Failed to plan worker hash transition for unsupported pathway")
-		return failWorkloadProgram(reasonRollingUpdateFailed, err)
-	}
-	if !transition.needsCommit() {
-		return nil
-	}
-
-	if err := r.commitUnsupportedWorkerHashTransition(ctx, dgd, transition, isGrove); err != nil {
-		if transition.initialize {
-			logger.Error(err, "Failed to initialize worker hash for unsupported pathway")
-			return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
-		}
-		// Preserve the existing best-effort behavior: the next reconciliation
-		// retries the metadata update and may emit another warning.
-		logger.Error(err, "Failed to update worker hash for unsupported pathway")
-	}
-	return nil
-}
-
 func (r *dgdWorkerRolloutReconciler) planUnsupportedWorkerHashTransition(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) (unsupportedWorkerHashTransition, error) {
@@ -115,16 +85,16 @@ func (r *dgdWorkerRolloutReconciler) planUnsupportedWorkerHashTransition(
 	current := r.currentWorkerHashes(dgd)
 	if current.empty() {
 		return unsupportedWorkerHashTransition{
-			next:       workerHashesForCompletedGeneration(desired.v2, desired),
-			initialize: true,
+			next:                workerHashesForCompletedGeneration(desired.v2, desired),
+			noCurrentAnnotation: true,
 		}, nil
 	}
 	if currentWorkerHashesMatchDesired(current, desired) {
 		return unsupportedWorkerHashTransition{}, nil
 	}
 	return unsupportedWorkerHashTransition{
-		next:                    r.workerHashesForUnsupportedPathway(dgd, desired),
-		workerGenerationChanged: true,
+		next:        r.workerHashesForUnsupportedPathway(dgd, desired),
+		hashChanged: true,
 	}, nil
 }
 
@@ -145,7 +115,7 @@ func (r *dgdWorkerRolloutReconciler) commitUnsupportedWorkerHashTransition(
 	if err := r.Update(ctx, dgd); err != nil {
 		return err
 	}
-	if !transition.workerGenerationChanged {
+	if !transition.hashChanged {
 		return nil
 	}
 
@@ -242,7 +212,7 @@ func workerHashForDCDGeneration(current, desired workerGenerationHashes) string 
 	if current.v2 != "" {
 		return desired.v2
 	}
-	return desired.v1
+	return desired.v2
 }
 
 func workerHashesForCompletedGeneration(newWorkerHash string, desired workerGenerationHashes) workerGenerationHashes {
@@ -451,6 +421,9 @@ func (r *dgdWorkerRolloutReconciler) findLegacyWorkerDCDs(
 
 	var legacyDCDs []nvidiacomv1beta1.DynamoComponentDeployment
 	for _, dcd := range dcdList.Items {
+		if !metav1.IsControlledBy(&dcd, dgd) {
+			continue
+		}
 		if !dynamo.IsWorkerComponent(string(dcd.Spec.ComponentType)) {
 			continue
 		}
@@ -463,25 +436,11 @@ func (r *dgdWorkerRolloutReconciler) findLegacyWorkerDCDs(
 	return legacyDCDs, nil
 }
 
-// getCurrentWorkerHash returns the v1 worker generation stored on the DGD.
-// It is empty after the DGD has converged to a v2-only generation.
-func (r *dgdWorkerRolloutReconciler) getCurrentWorkerHash(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) string {
-	return currentWorkerHash(dgd)
-}
-
 func currentWorkerHash(dgd *nvidiacomv1beta1.DynamoGraphDeployment) string {
 	if dgd.Annotations == nil {
 		return ""
 	}
 	return dgd.Annotations[consts.AnnotationCurrentWorkerHash]
-}
-
-func (r *dgdWorkerRolloutReconciler) getCurrentWorkerHashV2(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) string {
-	return currentWorkerHashV2(dgd)
 }
 
 func currentWorkerHashV2(dgd *nvidiacomv1beta1.DynamoGraphDeployment) string {
@@ -576,25 +535,11 @@ func (r *dgdWorkerRolloutReconciler) reconcileRollingUpdate(
 		"desiredV2WorkerHash", desired.v2)
 
 	if rollingUpdateStatus.Phase == nvidiacomv1beta1.RollingUpdatePhaseCompleted && !current.contains(newWorkerHash) {
-		// Check whether DCDs with the new hash already represent a completed
-		// generation. Recreate also requires its old generation to be fully
-		// drained before a stale annotation can be accepted.
+		// Target generation is ahead of current: drain old DCDs before projecting.
 		newInfo, err := r.getWorkerInfoForWorkerHash(ctx, dgd, newWorkerHash)
 		oldInfo, oldErr := r.getOldWorkerInfo(ctx, dgd, newWorkerHash)
 		if err == nil && oldErr == nil && workerGenerationComplete(dgd, oldInfo, newInfo) {
-			recreateDrained, err := r.recreateComponentsDrained(ctx, dgd, newWorkerHash)
-			if err != nil {
-				return fmt.Errorf("check Recreate stale-annotation barrier: %w", err)
-			}
-			if recreateDrained {
-				logger.Info("Updating stale worker hash annotation",
-					"currentV1WorkerHash", current.v1,
-					"currentV2WorkerHash", current.v2,
-					"newHash", newWorkerHash)
-				r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(newWorkerHash, desired))
-				return r.Update(ctx, dgd)
-			}
-			logger.Info("Resuming rolling update while the old Recreate generation drains",
+			logger.Info("Resuming rolling update from observed target generation",
 				"currentV1WorkerHash", current.v1,
 				"currentV2WorkerHash", current.v2,
 				"newHash", newWorkerHash)
@@ -617,14 +562,6 @@ func (r *dgdWorkerRolloutReconciler) reconcileRollingUpdate(
 			rollingUpdateStatus.EndTime = nil
 			rollingUpdateStatus.UpdatedComponents = nil
 		}
-	}
-
-	if current.contains(newWorkerHash) &&
-		rollingUpdateStatus.Phase == nvidiacomv1beta1.RollingUpdatePhaseInProgress {
-		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress",
-			"hash", newWorkerHash,
-			"phase", rollingUpdateStatus.Phase)
-		return r.completeRollingUpdate(ctx, dgd, status, newWorkerHash)
 	}
 
 	switch rollingUpdateStatus.Phase {
@@ -705,7 +642,7 @@ func (r *dgdWorkerRolloutReconciler) continueRollingUpdate(
 	rollingUpdateStatus.UpdatedComponents = updatedComponents
 
 	// Rolling update is complete when every worker component is individually updated.
-	if len(updatedComponents) == totalWorkerComponents && totalWorkerComponents > 0 {
+	if len(updatedComponents) == totalWorkerComponents {
 		return r.completeRollingUpdate(ctx, dgd, status, newWorkerHash)
 	}
 
@@ -762,8 +699,8 @@ func workerGenerationComplete(
 	return totalWorkerComponents > 0 && len(updatedComponents) == totalWorkerComponents
 }
 
-// completeRollingUpdate marks the rolling update as completed, cleans up old resources, and updates status.
-// This performs all cleanup atomically to avoid race conditions with subsequent reconciles.
+// completeRollingUpdate drains and deletes old DCDs once the target is ready,
+// then records completion after the deletes disappear from the cache.
 func (r *dgdWorkerRolloutReconciler) completeRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
@@ -772,12 +709,27 @@ func (r *dgdWorkerRolloutReconciler) completeRollingUpdate(
 ) error {
 	logger := log.FromContext(ctx)
 
-	recreateDrained, err := r.recreateComponentsDrained(ctx, dgd, newWorkerHash)
+	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
 	if err != nil {
-		return fmt.Errorf("check Recreate completion barrier: %w", err)
+		return fmt.Errorf("list old worker DCDs before completion: %w", err)
 	}
-	if !recreateDrained {
-		logger.V(1).Info("Waiting for old Recreate pods to terminate before completing rolling update",
+	if len(oldDCDs) > 0 {
+		drained, err := r.oldWorkerDCDsDrained(ctx, dgd, oldDCDs)
+		if err != nil {
+			return fmt.Errorf("check old worker drain before deletion: %w", err)
+		}
+		if !drained {
+			logger.V(1).Info("Waiting for old worker DCDs to drain before deletion",
+				"oldWorkerDCDs", len(oldDCDs),
+				"newWorkerHash", newWorkerHash)
+			return nil
+		}
+
+		if err := r.deleteWorkerDCDs(ctx, oldDCDs); err != nil {
+			return fmt.Errorf("delete drained old worker DCDs: %w", err)
+		}
+		logger.Info("Deleted drained old worker DCDs; waiting for cache observation before completion",
+			"oldWorkerDCDs", len(oldDCDs),
 			"newWorkerHash", newWorkerHash)
 		return nil
 	}
@@ -785,11 +737,6 @@ func (r *dgdWorkerRolloutReconciler) completeRollingUpdate(
 	desired, err := desiredWorkerHashes(dgd)
 	if err != nil {
 		return err
-	}
-
-	// Delete all non-current worker DCDs (any number of old generations)
-	if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
-		return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 	}
 
 	r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(newWorkerHash, desired))
@@ -817,6 +764,25 @@ func (r *dgdWorkerRolloutReconciler) completeRollingUpdate(
 	logger.Info("Rolling update finalized", "newWorkerHash", newWorkerHash)
 
 	return nil
+}
+
+func (r *dgdWorkerRolloutReconciler) oldWorkerDCDsDrained(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	oldDCDs []nvidiacomv1beta1.DynamoComponentDeployment,
+) (bool, error) {
+	byComponent := make(map[string][]*nvidiacomv1beta1.DynamoComponentDeployment)
+	for i := range oldDCDs {
+		componentName := dynamo.GetDCDComponentName(&oldDCDs[i])
+		byComponent[componentName] = append(byComponent[componentName], &oldDCDs[i])
+	}
+	for componentName, dcds := range byComponent {
+		drained, err := r.oldWorkerComponentDrained(ctx, dgd, componentName, dcds)
+		if err != nil || !drained {
+			return drained, err
+		}
+	}
+	return true, nil
 }
 
 // dcdComponentState holds replica signals extracted from a DCD's Spec and Status.
@@ -884,6 +850,9 @@ func (r *dgdWorkerRolloutReconciler) getWorkerInfoForWorkerHash(
 	}
 
 	for _, dcd := range dcdList.Items {
+		if !metav1.IsControlledBy(&dcd, dgd) || dcd.DeletionTimestamp != nil {
+			continue
+		}
 		if !dynamo.IsWorkerComponent(string(dcd.Spec.ComponentType)) {
 			continue
 		}
@@ -1032,51 +1001,6 @@ func (r *dgdWorkerRolloutReconciler) oldWorkerComponentDrained(
 		return false, err
 	}
 	return oldWorkerPodsTerminated(oldDCDs, pods), nil
-}
-
-// recreateComponentsDrained reports whether every Recreate worker component
-// has fully shut down its old generation. Callers use this before accepting a
-// generation as complete, preventing a later scale-up from bypassing the
-// shutdown barrier after the new worker hash has been recorded.
-func (r *dgdWorkerRolloutReconciler) recreateComponentsDrained(
-	ctx context.Context,
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	newWorkerHash string,
-) (bool, error) {
-	recreateComponents := make([]string, 0)
-	for i := range dgd.Spec.Components {
-		spec := &dgd.Spec.Components[i]
-		if !dynamo.IsWorkerComponent(string(spec.ComponentType)) {
-			continue
-		}
-		annotations := dynamo.GetDGDComponentResourceAnnotations(dgd, spec.ComponentName, spec)
-		if deploymentStrategyFromAnnotations(annotations) == common.DeploymentStrategyRecreate {
-			recreateComponents = append(recreateComponents, spec.ComponentName)
-		}
-	}
-	if len(recreateComponents) == 0 {
-		return true, nil
-	}
-
-	oldDCDsByComponent, _, err := r.getOldWorkerDCDsByComponent(ctx, dgd, newWorkerHash)
-	if err != nil {
-		return false, err
-	}
-	for _, componentName := range recreateComponents {
-		drained, err := r.oldWorkerComponentDrained(
-			ctx,
-			dgd,
-			componentName,
-			oldDCDsByComponent[componentName],
-		)
-		if err != nil {
-			return false, err
-		}
-		if !drained {
-			return false, nil
-		}
-	}
-	return true, nil
 }
 
 func (r *dgdWorkerRolloutReconciler) listDGDComponentPods(
@@ -1289,6 +1213,9 @@ func (r *dgdWorkerRolloutReconciler) listOldWorkerDCDs(
 
 	var workers []nvidiacomv1beta1.DynamoComponentDeployment
 	for _, dcd := range dcdList.Items {
+		if !metav1.IsControlledBy(&dcd, dgd) {
+			continue
+		}
 		if !dynamo.IsWorkerComponent(string(dcd.Spec.ComponentType)) {
 			continue
 		}
@@ -1299,33 +1226,69 @@ func (r *dgdWorkerRolloutReconciler) listOldWorkerDCDs(
 	return workers, nil
 }
 
-// deleteOldWorkerDCDs deletes all worker DCDs belonging to this DGD whose hash label
-// does NOT match the given newWorkerHash. This cleans up all old generations at once.
-func (r *dgdWorkerRolloutReconciler) deleteOldWorkerDCDs(
+// dcdObservesWorkerHash reports whether a worker DCD owned by dgd with
+// the given targetHash is visible in the informer cache for every worker component.
+func (r *dgdWorkerRolloutReconciler) dcdObservesWorkerHash(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	newWorkerHash string,
+	targetHash string,
+) (bool, error) {
+	dcdList := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	if err := r.List(ctx, dcdList,
+		client.InNamespace(dgd.Namespace),
+		client.MatchingLabels{
+			consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+			consts.KubeLabelDynamoWorkerHash:          targetHash,
+		},
+	); err != nil {
+		return false, err
+	}
+
+	observed := make(map[string]struct{}, len(dcdList.Items))
+	for i := range dcdList.Items {
+		dcd := &dcdList.Items[i]
+		if !metav1.IsControlledBy(dcd, dgd) || dcd.DeletionTimestamp != nil {
+			continue
+		}
+		if dynamo.IsWorkerComponent(string(dcd.Spec.ComponentType)) {
+			observed[dynamo.GetDCDComponentName(dcd)] = struct{}{}
+		}
+	}
+
+	// Every DGD worker component must appear in the cache before the hash is projected.
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if !dynamo.IsWorkerComponent(string(component.ComponentType)) {
+			continue
+		}
+		if _, ok := observed[component.ComponentName]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// deleteWorkerDCDs deletes the given worker DCDs with a UID precondition on each.
+func (r *dgdWorkerRolloutReconciler) deleteWorkerDCDs(
+	ctx context.Context,
+	dcds []nvidiacomv1beta1.DynamoComponentDeployment,
 ) error {
 	logger := log.FromContext(ctx)
 
-	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
-	if err != nil {
-		return fmt.Errorf("failed to list non-current worker DCDs: %w", err)
-	}
-
-	if len(oldDCDs) == 0 {
-		logger.Info("No non-current worker DCDs found to delete", "newWorkerHash", newWorkerHash)
+	if len(dcds) == 0 {
+		logger.Info("No non-current worker DCDs found to delete")
 		return nil
 	}
 
-	logger.Info("Deleting non-current worker DCDs", "count", len(oldDCDs), "newWorkerHash", newWorkerHash)
+	logger.Info("Deleting non-current worker DCDs", "count", len(dcds))
 
 	var deleteErrors []error
-	for i := range oldDCDs {
-		dcd := &oldDCDs[i]
+	for i := range dcds {
+		dcd := &dcds[i]
 		logger.Info("Deleting non-current worker DCD", "name", dcd.Name, "hash", dcd.Labels[consts.KubeLabelDynamoWorkerHash])
 
-		if err := r.Delete(ctx, dcd); err != nil {
+		uid := dcd.UID
+		if err := r.Delete(ctx, dcd, client.Preconditions{UID: &uid}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete DCD %s: %w", dcd.Name, err))
 			}
@@ -1472,16 +1435,6 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 		return dynamo.RollingUpdateContext{}, err
 	}
 	newWorkerHash := r.activeWorkerHashForDCDGeneration(dgd, desiredHashes)
-	currentHashes := r.currentWorkerHashes(dgd)
-
-	if currentHashes.contains(newWorkerHash) {
-		return dynamo.RollingUpdateContext{
-			NewWorkerHash:                      newWorkerHash,
-			OldWorkerReplicaTargetsByComponent: make(map[string]int32),
-			OldWorkerReplicaTargetsByDCD:       make(map[string]int32),
-			NewWorkerReplicaTargetsByComponent: make(map[string]int32),
-		}, nil
-	}
 
 	oldDCDsByComponent, oldStates, err := r.getOldWorkerDCDsByComponent(ctx, dgd, newWorkerHash)
 	if err != nil {
@@ -1499,6 +1452,11 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 			continue
 		}
 
+		oldDCDs := oldDCDsByComponent[componentName]
+		if len(oldDCDs) == 0 {
+			continue
+		}
+
 		desired := int32(1)
 		if spec.Replicas != nil {
 			desired = *spec.Replicas
@@ -1508,7 +1466,9 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 		newDCDName := dynamo.GetDCDResourceName(dgd, componentName, newWorkerHash)
 		newDCD := &nvidiacomv1beta1.DynamoComponentDeployment{}
 		if err := r.Get(ctx, types.NamespacedName{Name: newDCDName, Namespace: dgd.Namespace}, newDCD); err == nil {
-			newState = dcdComponentStateFromDCD(newDCD)
+			if metav1.IsControlledBy(newDCD, dgd) && newDCD.DeletionTimestamp == nil {
+				newState = dcdComponentStateFromDCD(newDCD)
+			}
 		} else if !apierrors.IsNotFound(err) {
 			return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get new worker DCD %s: %w", newDCDName, err)
 		}
@@ -1525,7 +1485,6 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 			// have observed the drain and every old workload pod is terminal; only
 			// then start the replacement generation.
 			maxUnavailable = desired
-			oldDCDs := oldDCDsByComponent[componentName]
 			drained, err := r.oldWorkerComponentDrained(ctx, dgd, componentName, oldDCDs)
 			if err != nil {
 				return dynamo.RollingUpdateContext{}, err
@@ -1553,7 +1512,7 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 		oldWorkerComponentReplicas[componentName] = oldTarget
 		newWorkerReplicas[componentName] = newTarget
 
-		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[componentName], oldTarget) {
+		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDs, oldTarget) {
 			oldWorkerDCDReplicas[dcdName] = target
 		}
 
@@ -1568,6 +1527,17 @@ func (r *dgdWorkerRolloutReconciler) buildRollingUpdateContext(
 			"new", newState,
 			"oldTarget", oldTarget,
 			"newTarget", newTarget)
+	}
+
+	// Components removed from the spec still have old DCDs that must be drained.
+	for componentName, oldDCDs := range oldDCDsByComponent {
+		if _, ok := oldWorkerComponentReplicas[componentName]; ok {
+			continue
+		}
+		oldWorkerComponentReplicas[componentName] = 0
+		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDs, 0) {
+			oldWorkerDCDReplicas[dcdName] = target
+		}
 	}
 
 	return dynamo.RollingUpdateContext{

--- a/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_worker_rollout_reconciler_test.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -63,6 +65,24 @@ func createTestDGD(name string, services map[string]*nvidiacomv1alpha1.DynamoCom
 			Services: services,
 		},
 	})
+}
+
+// testScheme registers the v1beta1 types once for use in createTestDCD.
+var testScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	if err := nvidiacomv1beta1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	return s
+}()
+
+func createTestDCD(t testing.TB, dgd *nvidiacomv1beta1.DynamoGraphDeployment, src *nvidiacomv1alpha1.DynamoComponentDeployment) *nvidiacomv1beta1.DynamoComponentDeployment {
+	t.Helper()
+	dcd := betaDCD(t, src)
+	if err := ctrl.SetControllerReference(dgd, dcd, testScheme); err != nil {
+		t.Fatalf("set controller reference on test DCD: %v", err)
+	}
+	return dcd
 }
 
 type testReconcilerOption func(*fake.ClientBuilder)
@@ -125,17 +145,29 @@ func newTestComponentWorkloadsReconciler(
 	return newComponentWorkloadsReconciler(rollout.Client, rollout.GetRecorder(), rollout)
 }
 
+func (r *dgdWorkerRolloutReconciler) deleteOldWorkerDCDs(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	newWorkerHash string,
+) error {
+	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
+	if err != nil {
+		return fmt.Errorf("failed to list non-current worker DCDs: %w", err)
+	}
+	return r.deleteWorkerDCDs(ctx, oldDCDs)
+}
+
 func TestGroveWorkerHashSuffixMigration(t *testing.T) {
 	tests := []struct {
-		name                    string
-		existing                bool
-		existingHash            string
-		workerGenerationChanged bool
-		wantSuffix              bool
+		name         string
+		existing     bool
+		existingHash string
+		hashChanged  bool
+		wantSuffix   bool
 	}{
 		{name: "new PCS renders a suffix without a worker generation change", wantSuffix: true},
 		{name: "legacy PCS with no generation change remains unsuffixed", existing: true},
-		{name: "legacy PCS renders a suffix after a worker generation change", existing: true, workerGenerationChanged: true, wantSuffix: true},
+		{name: "legacy PCS renders a suffix after a worker generation change", existing: true, hashChanged: true, wantSuffix: true},
 		{name: "suffixed PCS continues rendering the suffix", existing: true, existingHash: "active", wantSuffix: true},
 	}
 
@@ -156,7 +188,7 @@ func TestGroveWorkerHashSuffixMigration(t *testing.T) {
 			}
 
 			t.Log("Verify suffix rendering from the worker generation")
-			if got := shouldRenderGroveWorkerHashSuffix(dgd, existing, tt.workerGenerationChanged); got != tt.wantSuffix {
+			if got := shouldRenderGroveWorkerHashSuffix(dgd, existing, tt.hashChanged); got != tt.wantSuffix {
 				t.Fatalf("shouldRenderGroveWorkerHashSuffix() = %t, want %t", got, tt.wantSuffix)
 			}
 		})
@@ -179,7 +211,7 @@ func TestPlanUnsupportedWorkerHashTransitionIgnoresScaling(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Verify scaling does not arm a worker generation migration")
-	assert.False(t, transition.workerGenerationChanged)
+	assert.False(t, transition.hashChanged)
 	assert.False(t, transition.needsCommit())
 }
 
@@ -206,7 +238,7 @@ func TestPlanUnsupportedWorkerHashTransitionDoesNotCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Verify planning detects the transition without mutating the DGD")
-	require.True(t, transition.workerGenerationChanged)
+	require.True(t, transition.hashChanged)
 	assert.Equal(t, currentHash, currentWorkerHashV2(dgd), "planning must not commit the DGD hash")
 }
 
@@ -457,7 +489,7 @@ func TestCanonicalWorkerHashLifecycle_FirstDeploySpecChangeAndCompletion(t *test
 	require.NoError(t, err)
 
 	// Verify only the v2 hash was set.
-	hash := r.getCurrentWorkerHashV2(dgd)
+	hash := currentWorkerHashV2(dgd)
 	assert.NotEmpty(t, hash, "Hash should be set after initialization")
 	assert.NotContains(t, dgd.Annotations, consts.AnnotationCurrentWorkerHash)
 
@@ -509,8 +541,8 @@ func TestInitializeWorkerHashIfNeeded_MigratesOpaqueV1WithoutRollout(t *testing.
 	r := createTestReconcilerWithStatus(dgd)
 	err := r.initializeWorkerHashIfNeeded(context.Background(), dgd)
 	require.NoError(t, err)
-	assert.Equal(t, existingHash, r.getCurrentWorkerHash(dgd))
-	assert.Equal(t, desiredV2, r.getCurrentWorkerHashV2(dgd))
+	assert.Equal(t, existingHash, currentWorkerHash(dgd))
+	assert.Equal(t, desiredV2, currentWorkerHashV2(dgd))
 
 	t.Log("Verify recording v2 did not turn the operator upgrade into a worker rollout")
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
@@ -550,7 +582,7 @@ func TestActiveV1OnlyRolloutRerollsUnderV2(t *testing.T) {
 			dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{Phase: tt.phase}
 			desiredV2 := betaDGDWorkersSpecHash(t, dgd)
 
-			targetDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			targetDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-worker-target-v1",
 					Namespace: dgd.Namespace,
@@ -637,7 +669,7 @@ func TestInitializeWorkerHashIfNeeded_PreservesLegacyAlphaHash(t *testing.T) {
 	err := r.initializeWorkerHashIfNeeded(context.Background(), dgd)
 	require.NoError(t, err)
 
-	assert.Equal(t, legacyHash, r.getCurrentWorkerHash(dgd))
+	assert.Equal(t, legacyHash, currentWorkerHash(dgd))
 	assert.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
 	require.NoError(t, err)
@@ -1094,9 +1126,10 @@ func TestDeleteOldWorkerDCDs(t *testing.T) {
 	})
 
 	// Create DCD with old worker hash
-	oldDCD1 := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	oldDCD1 := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-oldhash1",
+			UID:       types.UID("observed-old-generation"),
 			Namespace: "default",
 			Labels: map[string]string{
 				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
@@ -1111,7 +1144,7 @@ func TestDeleteOldWorkerDCDs(t *testing.T) {
 	})
 
 	// Create DCD with new worker hash (should not be deleted)
-	newDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-newhash2",
 			Namespace: "default",
@@ -1127,12 +1160,27 @@ func TestDeleteOldWorkerDCDs(t *testing.T) {
 		},
 	})
 
-	r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD1, newDCD))
+	var deleteOptions client.DeleteOptions
+	r := createTestReconcilerWithStatus(
+		dgd,
+		withObjects(oldDCD1, newDCD),
+		withInterceptor(interceptor.Funcs{
+			Delete: func(ctx context.Context, writer client.WithWatch, object client.Object, options ...client.DeleteOption) error {
+				for _, option := range options {
+					option.ApplyToDelete(&deleteOptions)
+				}
+				return writer.Delete(ctx, object, options...)
+			},
+		}),
+	)
 	ctx := context.Background()
 
 	// Delete old worker DCDs
 	err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash)
 	require.NoError(t, err)
+	require.NotNil(t, deleteOptions.Preconditions)
+	require.NotNil(t, deleteOptions.Preconditions.UID)
+	assert.Equal(t, oldDCD1.UID, *deleteOptions.Preconditions.UID)
 
 	// Verify old DCD is deleted
 	dcdList := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
@@ -1157,6 +1205,90 @@ func TestDeleteOldWorkerDCDs_NoDCDsToDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDCDObservesWorkerHash(t *testing.T) {
+	const targetHash = "targethash"
+
+	makeDCD := func(name, componentName, componentType, hash string) *nvidiacomv1alpha1.DynamoComponentDeployment {
+		return &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+					consts.KubeLabelDynamoWorkerHash:          hash,
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: componentType,
+					ServiceName:   componentName,
+				},
+			},
+		}
+	}
+
+	// DCDs are constructed before dgd exists in the table loop; use a fixed-name DGD
+	// (empty UID matches all test DGDs) so IsControlledBy passes inside the loop.
+	ownerDGD := createTestDGD("test-dgd", nil)
+	prefillDCD := betaDCD(t, makeDCD("test-dgd-prefill-"+targetHash, "prefill", string(consts.ComponentTypePrefill), targetHash))
+	require.NoError(t, ctrl.SetControllerReference(ownerDGD, prefillDCD, testScheme))
+	decodeDCD := betaDCD(t, makeDCD("test-dgd-decode-"+targetHash, "decode", string(consts.ComponentTypeDecode), targetHash))
+	require.NoError(t, ctrl.SetControllerReference(ownerDGD, decodeDCD, testScheme))
+
+	tests := []struct {
+		name     string
+		services map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
+		objs     []runtime.Object
+		want     bool
+	}{
+		{
+			name: "single worker component with matching DCD",
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {ComponentType: consts.ComponentTypePrefill},
+			},
+			objs: []runtime.Object{prefillDCD},
+			want: true,
+		},
+		{
+			name: "single worker component with no DCD in cache",
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {ComponentType: consts.ComponentTypePrefill},
+			},
+			objs: nil,
+			want: false,
+		},
+		{
+			name: "two worker components both observed",
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {ComponentType: consts.ComponentTypePrefill},
+				"decode":  {ComponentType: consts.ComponentTypeDecode},
+			},
+			objs: []runtime.Object{prefillDCD, decodeDCD},
+			want: true,
+		},
+		{
+			name: "two worker components only one observed",
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {ComponentType: consts.ComponentTypePrefill},
+				"decode":  {ComponentType: consts.ComponentTypeDecode},
+			},
+			objs: []runtime.Object{prefillDCD},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := createTestDGD("test-dgd", tt.services)
+			r := createTestReconcilerWithStatus(dgd, withObjects(tt.objs...))
+
+			got, err := r.dcdObservesWorkerHash(context.Background(), dgd, targetHash)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestContinueRollingUpdate_UpdatedComponentsPartialCompletion(t *testing.T) {
 	oldWorkerHash := testOldWorkerHash
 	newWorkerHash := testNewWorkerHash
@@ -1179,7 +1311,7 @@ func TestContinueRollingUpdate_UpdatedComponentsPartialCompletion(t *testing.T) 
 	}
 
 	// New DCDs: prefill fully ready, decode not ready yet
-	newPrefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newPrefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-prefill-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1202,7 +1334,7 @@ func TestContinueRollingUpdate_UpdatedComponentsPartialCompletion(t *testing.T) 
 		},
 	})
 
-	newDecodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDecodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1226,7 +1358,7 @@ func TestContinueRollingUpdate_UpdatedComponentsPartialCompletion(t *testing.T) 
 	})
 
 	// Old DCDs: prefill gone, decode still has replicas
-	oldDecodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	oldDecodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode-" + oldWorkerHash[:8],
 			Namespace: "default",
@@ -1286,7 +1418,7 @@ func TestContinueRollingUpdate_AggregateReadyButPerServiceNot(t *testing.T) {
 	// New DCDs: prefill has excess ready replicas (5), decode has 0
 	// Aggregate: 5 total new ready >= 5 desired, 0 old ready == 0
 	// Per-service: prefill ready (5 >= 2), decode NOT ready (0 < 3)
-	newPrefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newPrefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-prefill-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1309,7 +1441,7 @@ func TestContinueRollingUpdate_AggregateReadyButPerServiceNot(t *testing.T) {
 		},
 	})
 
-	newDecodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDecodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1433,7 +1565,7 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 	}
 
 	// All new DCDs fully ready
-	newPrefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newPrefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-prefill-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1456,7 +1588,7 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 		},
 	})
 
-	newDecodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDecodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -1492,6 +1624,60 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 	// decodes the API server response back into dgd, and status is re-set after the update.
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
 	assert.Equal(t, []string{"decode", "prefill"}, dgd.Status.RollingUpdate.UpdatedComponents)
+}
+
+func TestContinueRollingUpdate_AllWorkersRemoved(t *testing.T) {
+	t.Log("DGD has all worker components removed; only a frontend remains")
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"frontend": {ComponentType: consts.ComponentTypeFrontend},
+	})
+	oldWorkerHash := testOldWorkerHash
+	newWorkerHash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHashV2: oldWorkerHash}
+	dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+		Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+	}
+
+	t.Log("Seed an old worker DCD that has been drained to zero replicas and all pods terminated")
+	oldWorkerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-" + oldWorkerHash[:8],
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          oldWorkerHash,
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(0)),
+			},
+		},
+		Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+			Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+				ReadyReplicas: ptr.To(int32(0)),
+			},
+		},
+	})
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(oldWorkerDCD))
+	ctx := context.Background()
+
+	t.Log("continueRollingUpdate: old DCD is drained so completeRollingUpdate deletes it and waits for cache")
+	err := r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
+	require.NoError(t, err)
+
+	t.Log("Old DCD must be deleted from the fake client")
+	dcdList := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	require.NoError(t, r.List(ctx, dcdList, client.InNamespace("default")))
+	assert.Empty(t, dcdList.Items, "old worker DCD must be deleted after drain")
+
+	t.Log("Phase must advance to Completed once the old DCD disappears from cache; run a second reconcile")
+	err = r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
+	require.NoError(t, err)
+	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
 }
 
 func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testing.T) {
@@ -1531,7 +1717,7 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 			require.NotEqual(t, oldWorkerHash, newWorkerHash)
 
 			makeZeroReplicaDCD := func(name, workerHash string) *nvidiacomv1beta1.DynamoComponentDeployment {
-				return &nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       name,
 						Namespace:  dgd.Namespace,
@@ -1556,6 +1742,10 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 						},
 					},
 				}
+				if err := ctrl.SetControllerReference(dgd, dcd, testScheme); err != nil {
+					t.Fatalf("set controller reference: %v", err)
+				}
+				return dcd
 			}
 			oldDCD := makeZeroReplicaDCD(
 				dynamo.GetDCDResourceName(dgd, "worker", oldWorkerHash),
@@ -1592,18 +1782,23 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 			assert.Equal(t, oldWorkerHash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(oldDCD), &nvidiacomv1beta1.DynamoComponentDeployment{}))
 
-			// Once the old Pod reaches a terminal phase, the state machine may
-			// complete the rollout and retire the old generation.
+			// Once the old Pod reaches a terminal phase, the state machine deletes
+			// the drained DCD but still waits for a later cache observation before
+			// it projects completion.
 			cachedPod := &corev1.Pod{}
 			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(oldPod), cachedPod))
 			cachedPod.Status.Phase = corev1.PodSucceeded
 			require.NoError(t, r.Status().Update(ctx, cachedPod))
 
 			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd, &dgd.Status))
-			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
-			assert.True(t, r.currentWorkerHashes(dgd).contains(newWorkerHash))
+			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
+			assert.Equal(t, oldWorkerHash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 			err := r.Get(ctx, client.ObjectKeyFromObject(oldDCD), &nvidiacomv1beta1.DynamoComponentDeployment{})
 			assert.True(t, apierrors.IsNotFound(err))
+
+			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd, &dgd.Status))
+			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+			assert.True(t, r.currentWorkerHashes(dgd).contains(newWorkerHash))
 
 			// Replicas are excluded from the worker hash. A later scale-up
 			// therefore stays on the completed generation.
@@ -1627,7 +1822,7 @@ func TestGetWorkerInfoForWorkerHash(t *testing.T) {
 	})
 
 	// Create DCDs for prefill and decode with different ready counts
-	prefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	prefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-prefill-hash1234",
 			Namespace: "default",
@@ -1650,7 +1845,7 @@ func TestGetWorkerInfoForWorkerHash(t *testing.T) {
 		},
 	})
 
-	decodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	decodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode-hash1234",
 			Namespace: "default",
@@ -1862,7 +2057,7 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 			},
 		})
 
-		oldDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		oldDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-prefill-oldhash1",
 				Namespace: "default",
@@ -1921,7 +2116,7 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 		now := metav1.Now()
 		earlier := metav1.NewTime(now.Add(-1 * 60 * 1e9))
 
-		oldestDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		oldestDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-dgd-worker-hashaaaa",
 				Namespace:         "default",
@@ -1949,7 +2144,7 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 			},
 		})
 
-		newerOldDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		newerOldDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-dgd-worker-hashbbbb",
 				Namespace:         "default",
@@ -2044,7 +2239,7 @@ func TestComponentWorkloadsReconciler_GetExistingRestartAnnotationsDCD(t *testin
 			consts.AnnotationCurrentWorkerHashV2: "oldhash",
 		}
 
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-frontend",
 				Namespace: "default",
@@ -2058,7 +2253,7 @@ func TestComponentWorkloadsReconciler_GetExistingRestartAnnotationsDCD(t *testin
 			},
 		})
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker-" + computedHash,
 				Namespace: "default",
@@ -2095,7 +2290,7 @@ func TestComponentWorkloadsReconciler_GetExistingRestartAnnotationsDCD(t *testin
 			consts.AnnotationCurrentWorkerHashV2: v2Hash,
 		}
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker-" + v2Hash,
 				Namespace: "default",
@@ -2131,7 +2326,7 @@ func TestComponentWorkloadsReconciler_GetExistingRestartAnnotationsDCD(t *testin
 			consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
 		}
 
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-frontend",
 				Namespace: "default",
@@ -2166,7 +2361,7 @@ func TestComponentWorkloadsReconciler_GetExistingRestartAnnotationsDCD(t *testin
 			consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
 		}
 
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-frontend",
 				Namespace: "default",
@@ -2202,7 +2397,7 @@ func TestComponentRestartProgressResolver_CheckComponentFullyUpdated(t *testing.
 			consts.AnnotationCurrentWorkerHash: workerHash,
 		}
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-dgd-worker-" + workerHash,
 				Namespace:  "default",
@@ -2240,7 +2435,7 @@ func TestComponentRestartProgressResolver_CheckComponentFullyUpdated(t *testing.
 			consts.AnnotationCurrentWorkerHashV2: v2Hash,
 		}
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-dgd-worker-" + v2Hash,
 				Namespace:  "default",
@@ -2272,7 +2467,7 @@ func TestComponentRestartProgressResolver_CheckComponentFullyUpdated(t *testing.
 			},
 		})
 
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-dgd-frontend",
 				Namespace:  "default",
@@ -2305,7 +2500,7 @@ func TestComponentRestartProgressResolver_CheckComponentFullyUpdated(t *testing.
 		})
 		// No worker hash annotation
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "test-dgd-worker",
 				Namespace:  "default",
@@ -2341,7 +2536,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyDCDsMigration(t *testing.T) {
 
 	// Create a legacy worker DCD: has DGD name label but NO worker hash label.
 	// This simulates a DCD created by a pre-rolling-update operator version.
-	legacyWorkerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	legacyWorkerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker",
 			Namespace: "default",
@@ -2365,7 +2560,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyDCDsMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// DGD annotation should be set to the legacy sentinel, NOT the computed hash
-	hash := r.getCurrentWorkerHash(dgd)
+	hash := currentWorkerHash(dgd)
 	assert.Equal(t, consts.LegacyWorkerHash, hash, "Hash should be legacy sentinel after migration")
 
 	// Legacy DCD should now have the worker hash label backfilled
@@ -2375,13 +2570,9 @@ func TestInitializeWorkerHashIfNeeded_LegacyDCDsMigration(t *testing.T) {
 	assert.Equal(t, consts.LegacyWorkerHash, updatedDCD.Labels[consts.KubeLabelDynamoWorkerHash],
 		"Legacy DCD should have worker hash label backfilled")
 
-	desired, err := desiredWorkerHashes(dgd)
-	require.NoError(t, err)
-	require.NoError(t, r.completeRollingUpdate(ctx, dgd, &dgd.Status, desired.v1))
-
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
 	require.NoError(t, err)
-	require.False(t, trigger)
+	assert.True(t, trigger, "legacy migration must begin a managed rollout before projecting a new worker hash")
 }
 
 func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
@@ -2398,7 +2589,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
 	})
 
 	// Legacy worker DCDs (no hash label)
-	legacyPrefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	legacyPrefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-prefill",
 			Namespace: "default",
@@ -2414,7 +2605,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
 		},
 	})
 
-	legacyDecodeDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	legacyDecodeDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode",
 			Namespace: "default",
@@ -2431,7 +2622,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
 	})
 
 	// Frontend DCD (not a worker, should not be touched)
-	frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-frontend",
 			Namespace: "default",
@@ -2454,7 +2645,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
 	require.NoError(t, err)
 
 	// DGD should have legacy sentinel hash
-	assert.Equal(t, consts.LegacyWorkerHash, r.getCurrentWorkerHash(dgd))
+	assert.Equal(t, consts.LegacyWorkerHash, currentWorkerHash(dgd))
 
 	// Both worker DCDs should have hash label backfilled
 	for _, name := range []string{"test-dgd-prefill", "test-dgd-decode"} {
@@ -2479,7 +2670,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			"worker": {ComponentType: consts.ComponentTypeWorker},
 		})
 
-		legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker",
 				Namespace: "default",
@@ -2508,7 +2699,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			"frontend": {ComponentType: consts.ComponentTypeFrontend},
 		})
 
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-frontend",
 				Namespace: "default",
@@ -2536,7 +2727,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			"worker": {ComponentType: consts.ComponentTypeWorker},
 		})
 
-		hashedDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		hashedDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker-abc12345",
 				Namespace: "default",
@@ -2600,6 +2791,73 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
+
+	t.Run("excludes ownerless DCD", func(t *testing.T) {
+		t.Log("Seed a worker DCD that carries the DGD name label but has no controller owner reference")
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {ComponentType: consts.ComponentTypeWorker},
+		})
+		ownerlessDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dgd-worker",
+				Namespace: "default",
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeWorker,
+				},
+			},
+		})
+
+		t.Log("Build the reconciler directly, bypassing the auto-ref helper, to keep the DCD ownerless")
+		dgdReconciler := createTestDGDReconcilerWithStatus(dgd, withObjects(ownerlessDCD))
+		r := newDGDWorkerRolloutReconciler(dgdReconciler.Client, dgdReconciler.Recorder)
+
+		result, err := r.findLegacyWorkerDCDs(context.Background(), dgd)
+		require.NoError(t, err)
+		assert.Empty(t, result, "ownerless DCD must not be treated as a legacy DCD")
+	})
+
+	t.Run("excludes DCD owned by a previous DGD UID", func(t *testing.T) {
+		t.Log("Seed a worker DCD whose controller owner reference points to an old DGD UID")
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {ComponentType: consts.ComponentTypeWorker},
+		})
+		dgd.UID = "current-dgd-uid"
+
+		isController := true
+		staleDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dgd-worker",
+				Namespace: "default",
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: nvidiacomv1beta1.GroupVersion.String(),
+					Kind:       "DynamoGraphDeployment",
+					Name:       "test-dgd",
+					UID:        "previous-dgd-uid",
+					Controller: &isController,
+				}},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeWorker,
+				},
+			},
+		})
+
+		dgdReconciler := createTestDGDReconcilerWithStatus(dgd, withObjects(staleDCD))
+		r := newDGDWorkerRolloutReconciler(dgdReconciler.Client, dgdReconciler.Recorder)
+
+		result, err := r.findLegacyWorkerDCDs(context.Background(), dgd)
+		require.NoError(t, err)
+		assert.Empty(t, result, "DCD with stale owner UID must not be treated as a legacy DCD")
+	})
 }
 
 func TestListOldWorkerDCDs(t *testing.T) {
@@ -2609,7 +2867,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 		})
 
 		// Legacy DCD with backfilled "legacy" hash label
-		legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker",
 				Namespace: "default",
@@ -2640,7 +2898,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 			"worker": {ComponentType: consts.ComponentTypeWorker},
 		})
 
-		currentDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		currentDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker-abc12345",
 				Namespace: "default",
@@ -2672,7 +2930,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 		})
 
 		// A frontend DCD with non-matching hash (should be excluded as non-worker)
-		frontendDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		frontendDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-frontend",
 				Namespace: "default",
@@ -2689,7 +2947,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 			},
 		})
 
-		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		workerDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker-oldhash1",
 				Namespace: "default",
@@ -2726,7 +2984,7 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		})
 
 		// Legacy DCD with backfilled hash label but old-style name (no hash suffix)
-		legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker",
 				Namespace: "default",
@@ -2792,7 +3050,7 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 			},
 		})
 
-		legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker",
 				Namespace: "default",
@@ -2841,7 +3099,7 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 		})
 
 		// Legacy DCD with old-style name but backfilled hash label
-		legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-dgd-worker",
 				Namespace: "default",
@@ -2913,7 +3171,7 @@ func TestDeleteOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 	})
 
 	// Legacy DCD with backfilled hash label
-	legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker",
 			Namespace: "default",
@@ -2930,7 +3188,7 @@ func TestDeleteOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 	})
 
 	// New DCD with real hash (should NOT be deleted)
-	newDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-abc12345",
 			Namespace: "default",
@@ -2967,7 +3225,7 @@ func TestDeleteOldWorkerDCDs_MultipleGenerations(t *testing.T) {
 	})
 
 	// Generation A (legacy)
-	legacyDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	legacyDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker",
 			Namespace: "default",
@@ -2984,7 +3242,7 @@ func TestDeleteOldWorkerDCDs_MultipleGenerations(t *testing.T) {
 	})
 
 	// Generation B (intermediate)
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashbbbb",
 			Namespace: "default",
@@ -3001,7 +3259,7 @@ func TestDeleteOldWorkerDCDs_MultipleGenerations(t *testing.T) {
 	})
 
 	// Generation C (current)
-	currentDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	currentDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashcccc",
 			Namespace: "default",
@@ -3038,7 +3296,7 @@ func TestListOldWorkerDCDs_ExcludesCurrentHash(t *testing.T) {
 	})
 
 	// Generation A
-	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genADCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashaaaa",
 			Namespace: "default",
@@ -3056,7 +3314,7 @@ func TestListOldWorkerDCDs_ExcludesCurrentHash(t *testing.T) {
 	})
 
 	// Generation B
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashbbbb",
 			Namespace: "default",
@@ -3074,7 +3332,7 @@ func TestListOldWorkerDCDs_ExcludesCurrentHash(t *testing.T) {
 	})
 
 	// Generation C (current)
-	genCDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genCDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashcccc",
 			Namespace: "default",
@@ -3115,7 +3373,7 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 	earlier := metav1.NewTime(now.Add(-1 * 60 * 1e9)) // 1 minute earlier
 
 	// Generation A (oldest)
-	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genADCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-dgd-worker-hashaaaa",
 			Namespace:         "default",
@@ -3135,7 +3393,7 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 	})
 
 	// Generation B (newer old)
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-dgd-worker-hashbbbb",
 			Namespace:         "default",
@@ -3272,7 +3530,7 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *
 	earlier := metav1.NewTime(now.Add(-1 * 60 * 1e9)) // 1 minute earlier
 
 	// Generation A (oldest): healthy and serving the minAvailable budget.
-	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genADCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-dgd-worker-hashaaaa",
 			Namespace:         "default",
@@ -3298,7 +3556,7 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *
 	})
 
 	// Generation B (newer old): spec consumes rollout budget but has no serving replicas.
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-dgd-worker-hashbbbb",
 			Namespace:         "default",
@@ -3360,7 +3618,7 @@ func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) 
 	})
 
 	// Generation A
-	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genADCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashaaaa",
 			Namespace: "default",
@@ -3387,7 +3645,7 @@ func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) 
 	})
 
 	// Generation B
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashbbbb",
 			Namespace: "default",
@@ -3452,7 +3710,7 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 	}
 
 	// Generation A (old)
-	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genADCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashaaaa",
 			Namespace: "default",
@@ -3476,7 +3734,7 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 	})
 
 	// Generation B (intermediate, now also old)
-	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genBDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-hashbbbb",
 			Namespace: "default",
@@ -3500,7 +3758,7 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 	})
 
 	// Generation C (new, not yet ready)
-	genCDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	genCDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-" + newWorkerHash[:8],
 			Namespace: "default",
@@ -4022,7 +4280,7 @@ func TestReconcileRollingUpdate_PendingToInProgress(t *testing.T) {
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
 }
 
-func TestReconcileRollingUpdate_StuckDetection(t *testing.T) {
+func TestReconcileRollingUpdate_HashMatchWithoutDrainRemainsInProgress(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {ComponentType: consts.ComponentTypeWorker},
 	})
@@ -4039,8 +4297,8 @@ func TestReconcileRollingUpdate_StuckDetection(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd)
 	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
-	// Should auto-complete
-	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
+	// A parent hash match is not completion evidence without an observed target.
+	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
 }
 
 func TestReconcileRollingUpdate_NewRollingUpdate(t *testing.T) {
@@ -4054,7 +4312,7 @@ func TestReconcileRollingUpdate_NewRollingUpdate(t *testing.T) {
 	}
 
 	// Create a DCD with the new hash that has ready replicas — stale annotation scenario
-	newDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-" + newHash,
 			Namespace: "default",
@@ -4097,7 +4355,7 @@ func TestReconcileRollingUpdate_StaleAnnotationRequiresAllNewWorkersReady(t *tes
 	newHash := betaDGDWorkersSpecHash(t, dgd)
 	require.NotEqual(t, testOldWorkerHash, newHash)
 
-	newPrefillDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	newPrefillDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dynamo.GetDCDResourceName(dgd, "prefill", newHash),
 			Namespace: "default",
@@ -4140,7 +4398,7 @@ func TestReconcileRollingUpdate_StaleAnnotationUpdatesAfterAllNewWorkersReady(t 
 	require.NotEqual(t, testOldWorkerHash, newHash)
 
 	makeReadyDCD := func(componentName, componentType string) *nvidiacomv1beta1.DynamoComponentDeployment {
-		return betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		return createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dynamo.GetDCDResourceName(dgd, componentName, newHash),
 				Namespace: "default",
@@ -4195,10 +4453,10 @@ func TestReconcileRollingUpdate_NonePhaseStartsRollout(t *testing.T) {
 	assert.Nil(t, dgd.Status.RollingUpdate.UpdatedComponents)
 }
 
-func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate(t *testing.T) {
-	// Stuck case: hashes match but phase is InProgress (e.g., operator restarted between
-	// annotation write and status persistence). Should call completeRollingUpdate which
-	// cleans up old DCDs, updates annotation, and sets Completed.
+func TestReconcileRollingUpdate_InProgressAwaitsTargetDCDCacheObservation(t *testing.T) {
+	// Hash annotations are parent-side receipts, not target-readiness evidence.
+	// A resumed reconciliation must wait for the target DCD generation to exist
+	// and report ready before it can enter completion.
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"prefill": {ComponentType: consts.ComponentTypePrefill},
 		"decode":  {ComponentType: consts.ComponentTypeDecode},
@@ -4217,24 +4475,19 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 
-	// Phase should be Completed
-	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
-	// EndTime should be set
-	assert.NotNil(t, dgd.Status.RollingUpdate.EndTime)
-	// UpdatedComponents should contain all worker services
-	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedComponents, "prefill")
-	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedComponents, "decode")
-	// Completion records both active compatibility hashes.
+	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
+	assert.Nil(t, dgd.Status.RollingUpdate.EndTime)
+	assert.Empty(t, dgd.Status.RollingUpdate.UpdatedComponents)
 	assert.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
 	assert.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
 
 func TestBuildRollingUpdateContext(t *testing.T) {
-	makeOldDCD := func(dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
+	makeOldDCD := func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
 		if workerHash == "" {
 			workerHash = testOldWorkerHash
 		}
-		return betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		return createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dgdName + "-" + serviceName + "-" + workerHash[:8],
 				Namespace: "default",
@@ -4259,8 +4512,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 		})
 	}
 
-	makeNewDCD := func(dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
-		return betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	makeNewDCD := func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
+		return createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      dgdName + "-" + serviceName + "-" + workerHash[:8],
 				Namespace: "default",
@@ -4300,8 +4553,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			Status: corev1.PodStatus{Phase: phase},
 		}
 	}
-	makeDefaultReplicaOldDCD := func(dgdName, serviceName, componentType, workerHash string, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
-		dcd := makeOldDCD(dgdName, serviceName, componentType, workerHash, 1, statusReplicas, availableReplicas)
+	makeDefaultReplicaOldDCD := func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, dgdName, serviceName, componentType, workerHash string, statusReplicas, availableReplicas int32) *nvidiacomv1beta1.DynamoComponentDeployment {
+		dcd := makeOldDCD(dgd, dgdName, serviceName, componentType, workerHash, 1, statusReplicas, availableReplicas)
 		dcd.Spec.Replicas = nil
 		return dcd
 	}
@@ -4311,8 +4564,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 		services                       map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
 		dgdSpecAnnotations             map[string]string
 		preserveAlphaComponentMetadata bool
-		oldDCDs                        func(newHash string) []runtime.Object
-		newDCDs                        func(newHash string) []runtime.Object
+		oldDCDs                        func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object
+		newDCDs                        func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object
 		pods                           func(newHash string) []runtime.Object
 		expectedOld                    map[string]int32
 		expectedNew                    map[string]int32
@@ -4331,12 +4584,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 10),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 10),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 8},
 			expectedNew: map[string]int32{"worker": 0}, // can't surge yet, need to wait for old replicas to be terminated
 		},
@@ -4351,12 +4604,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeDefaultReplicaOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 1, 1),
+					makeDefaultReplicaOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 1, 1),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 1},
 			expectedNew: map[string]int32{"worker": 1},
 		},
@@ -4375,12 +4628,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 9, 8),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 9, 8),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 8},
 			expectedNew: map[string]int32{"worker": 2}, // budget from Spec: 10+0-8-0=2
 		},
@@ -4395,14 +4648,14 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					// Default annotations: 25% surge, 25% unavailable
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 8, 4),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 8, 4),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 3, 3, 3),
+					makeNewDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, newHash, 3, 3, 3),
 				}
 			},
 			expectedOld: map[string]int32{"worker": 5},
@@ -4418,12 +4671,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(10)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 8},
 			expectedNew: map[string]int32{"worker": 3},
 		},
@@ -4440,14 +4693,14 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(10)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 5, 8, 5),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 5, 8, 5),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 5, 5, 5),
+					makeNewDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, newHash, 5, 5, 5),
 				}
 			},
 			expectedOld: map[string]int32{"worker": 3},
@@ -4469,16 +4722,16 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(8)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, "", 0, 0, 0),
-					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, "", 6, 6, 6),
+					makeOldDCD(dgd, "test-dgd", "prefill", consts.ComponentTypePrefill, "", 0, 0, 0),
+					makeOldDCD(dgd, "test-dgd", "decode", consts.ComponentTypeDecode, "", 6, 6, 6),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "prefill", consts.ComponentTypePrefill, newHash, 4, 4, 4),
-					makeNewDCD("test-dgd", "decode", consts.ComponentTypeDecode, newHash, 2, 2, 0),
+					makeNewDCD(dgd, "test-dgd", "prefill", consts.ComponentTypePrefill, newHash, 4, 4, 4),
+					makeNewDCD(dgd, "test-dgd", "decode", consts.ComponentTypeDecode, newHash, 2, 2, 0),
 				}
 			},
 			expectedOld: map[string]int32{"prefill": 0, "decode": 6},
@@ -4494,14 +4747,14 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(10)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 4, 4, 0),
+					makeNewDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, newHash, 4, 4, 0),
 				}
 			},
 			expectedOld: map[string]int32{"worker": 8}, // newUnavailable shrinks scale-down budget; hold unhealthy old
@@ -4517,15 +4770,15 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(10)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "oldhash0", 4, 4, 4),
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, testOldWorkerHash, 4, 4, 4),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "oldhash0", 4, 4, 4),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, testOldWorkerHash, 4, 4, 4),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
+					makeNewDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
 				}
 			},
 			expectedOld: map[string]int32{"worker": 6}, // aggregated across both old gens
@@ -4544,14 +4797,14 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
 				}
 			},
-			newDCDs: func(newHash string) []runtime.Object {
+			newDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, newHash string) []runtime.Object {
 				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
+					makeNewDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
 				}
 			},
 			expectedOld: map[string]int32{"worker": 0},
@@ -4568,12 +4821,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 0, 0, 0),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 0, 0, 0),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 0},
 			expectedNew: map[string]int32{"worker": 3},
 		},
@@ -4588,9 +4841,9 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					},
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 0, 0, 0),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 0, 0, 0),
 				}
 			},
 			pods: func(_ string) []runtime.Object {
@@ -4607,7 +4860,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				pod.Finalizers = []string{"test.example/finalizer"}
 				return []runtime.Object{pod}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 0},
 			expectedNew: map[string]int32{"worker": 0},
 		},
@@ -4622,12 +4875,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			dgdSpecAnnotations: map[string]string{
 				KubeAnnotationDeploymentStrategy: string(common.DeploymentStrategyRecreate),
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 0},
 			expectedNew: map[string]int32{"worker": 0},
 		},
@@ -4643,12 +4896,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				},
 			},
 			preserveAlphaComponentMetadata: true,
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
+					makeOldDCD(dgd, "test-dgd", "worker", consts.ComponentTypeWorker, "", 3, 3, 3),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 0},
 			expectedNew: map[string]int32{"worker": 0},
 		},
@@ -4667,13 +4920,13 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					Replicas:      ptr.To(int32(4)),
 				},
 			},
-			oldDCDs: func(_ string) []runtime.Object {
+			oldDCDs: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, "", 2, 2, 2),
-					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, "", 4, 4, 4),
+					makeOldDCD(dgd, "test-dgd", "prefill", consts.ComponentTypePrefill, "", 2, 2, 2),
+					makeOldDCD(dgd, "test-dgd", "decode", consts.ComponentTypeDecode, "", 4, 4, 4),
 				}
 			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
+			newDCDs:     func(_ *nvidiacomv1beta1.DynamoGraphDeployment, _ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"prefill": 0, "decode": 3},
 			expectedNew: map[string]int32{"prefill": 0, "decode": 1},
 		},
@@ -4711,10 +4964,10 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			// Collect all mock objects
 			var objs []runtime.Object
 			if tt.oldDCDs != nil {
-				objs = append(objs, tt.oldDCDs(newHash)...)
+				objs = append(objs, tt.oldDCDs(dgd, newHash)...)
 			}
 			if tt.newDCDs != nil {
-				objs = append(objs, tt.newDCDs(newHash)...)
+				objs = append(objs, tt.newDCDs(dgd, newHash)...)
 			}
 			if tt.pods != nil {
 				objs = append(objs, tt.pods(newHash)...)
@@ -4750,7 +5003,7 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 		consts.AnnotationCurrentWorkerHashV2: testOldWorkerHash,
 	}
 
-	oldDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	oldDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-" + testOldWorkerHash[:8],
 			Namespace: "default",
@@ -4789,6 +5042,58 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 	assert.Equal(t, int32(3), result.NewWorkerReplicaTargetsByComponent["worker"])
 }
 
+func TestBuildRollingUpdateContext_RollbackToSameHash(t *testing.T) {
+	t.Log("Build a DGD whose annotation already matches the desired hash, simulating an A→B→A spec revert")
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(3)),
+		},
+	})
+	hashA := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHashV2: hashA,
+	}
+
+	t.Log("Seed an orphaned B-gen DCD left over from the aborted A→B rollout")
+	orphanedDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-bbbbbbbb",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          "orphaned-b-gen-hash",
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(3)),
+			},
+		},
+		Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+			Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+				Replicas:          3,
+				AvailableReplicas: ptr.To(int32(3)),
+			},
+		},
+	})
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(orphanedDCD))
+	ctx := context.Background()
+
+	t.Log("Build rolling update context: orphaned B-gen DCD must receive drain targets even though current hash matches desired")
+	result, err := r.buildRollingUpdateContext(ctx, dgd)
+
+	require.NoError(t, err)
+	assert.Equal(t, hashA, result.NewWorkerHash)
+	assert.NotEmpty(t, result.OldWorkerReplicaTargetsByComponent,
+		"orphaned B-gen DCD must produce component drain targets")
+	assert.Contains(t, result.OldWorkerReplicaTargetsByDCD, orphanedDCD.Name,
+		"B-gen DCD must be individually tracked for draining")
+}
+
 func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {
@@ -4801,7 +5106,7 @@ func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {
 	}
 
 	assert.NotEqual(t, testOldWorkerHash, betaDGDWorkersSpecHash(t, dgd),
-		"test setup: computed hash must differ so we proceed past the early-return")
+		"test setup: annotation must differ from computed hash so getOldWorkerDCDsByComponent finds old DCDs")
 
 	injectedErr := errors.New("simulated apiserver list failure")
 	funcs := interceptor.Funcs{
@@ -4833,7 +5138,7 @@ func TestBuildRollingUpdateContext_ListPodsError(t *testing.T) {
 	dgd.Annotations = map[string]string{
 		consts.AnnotationCurrentWorkerHashV2: testOldWorkerHash,
 	}
-	oldDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+	oldDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-worker-" + testOldWorkerHash[:8],
 			Namespace: "default",
@@ -4884,7 +5189,23 @@ func TestBuildRollingUpdateContext_GetNewDCDError(t *testing.T) {
 	}
 
 	require.NotEqual(t, testOldWorkerHash, betaDGDWorkersSpecHash(t, dgd),
-		"test setup: computed hash must differ so we proceed past the early-return")
+		"test setup: annotation must differ from computed hash so getNewWorkerDCDsByComponent looks up the new-gen DCD")
+
+	t.Log("Seed an old-gen worker DCD so the loop body executes and reaches the new-DCD Get")
+	oldDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd-worker-" + testOldWorkerHash, Namespace: dgd.Namespace},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(1)),
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+					consts.KubeLabelDynamoWorkerHash:          testOldWorkerHash,
+				},
+			},
+		},
+	})
 
 	injectedErr := errors.New("simulated apiserver get failure")
 	funcs := interceptor.Funcs{
@@ -4892,12 +5213,12 @@ func TestBuildRollingUpdateContext_GetNewDCDError(t *testing.T) {
 			return injectedErr
 		},
 	}
-	r := createTestReconcilerWithStatus(dgd, withInterceptor(funcs))
+	r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD), withInterceptor(funcs))
 	ctx := context.Background()
 
 	_, err := r.buildRollingUpdateContext(ctx, dgd)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorIs(t, err, injectedErr, "non-NotFound Get error must be wrapped and propagated")
 	assert.Contains(t, err.Error(), "failed to get new worker DCD",
 		"error must originate from the new-DCD Get path, not some other call")

--- a/deploy/operator/internal/controller/dgd_workload_program_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_program_test.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
@@ -28,6 +29,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -541,18 +543,22 @@ func TestUnsupportedWorkerRolloutEmitsWarningOnlyAfterHashUpdate(t *testing.T) {
 			reconciler := newDGDWorkerRolloutReconciler(kubeClient, recorder)
 
 			t.Log("Advance the unsupported pathway hash")
-			err := reconciler.ReconcileUnsupported(
+			transition, err := reconciler.planUnsupportedWorkerHashTransition(dgd)
+			require.NoError(t, err)
+			commitErr := reconciler.commitUnsupportedWorkerHashTransition(
 				context.Background(),
 				dgd,
+				transition,
 				true,
 			)
-			require.NoError(t, err)
 
 			t.Log("Verify the warning reflects a successfully persisted primary mutation")
 			if tt.wantEvent {
+				require.NoError(t, commitErr)
 				assert.Len(t, recorder.Events, 1)
 				return
 			}
+			require.Error(t, commitErr)
 			assert.Empty(t, recorder.Events)
 		})
 	}
@@ -612,7 +618,7 @@ func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
 		assert.Equal(t, "old-worker-hash", dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashV2])
 	})
 
-	t.Run("multinode component workload keeps unsupported-path hash behavior", func(t *testing.T) {
+	t.Run("multinode component workload defers hash projection until target DCD is observed", func(t *testing.T) {
 		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 			"worker": {
 				ComponentType: commonconsts.ComponentTypeWorker,
@@ -621,8 +627,10 @@ func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
 			},
 		})
 		dgd.Annotations = map[string]string{
-			commonconsts.AnnotationCurrentWorkerHash: "old-worker-hash",
+			commonconsts.AnnotationCurrentWorkerHashV2: "old-worker-hash",
 		}
+
+		t.Log("No worker DCD with target hash in cache: hash projection must be deferred")
 		reconciler := createTestDGDReconcilerWithStatus(dgd)
 		program := reconciler.newComponentProgram()
 		status := dgd.DeepCopy().Status
@@ -630,10 +638,81 @@ func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
 		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd, &status))
 
 		assert.Nil(t, status.RollingUpdate)
-		assert.Nil(t, dgd.Status.RollingUpdate)
 		desired, err := desiredWorkerHashes(dgd)
 		require.NoError(t, err)
+		assert.False(t, currentWorkerHashesMatchDesired(currentWorkerHashes(dgd), desired))
+		assert.Equal(t, "old-worker-hash", dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashV2])
+	})
+
+	t.Run("multinode component workload commits hash once target DCD is observed in cache", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: commonconsts.ComponentTypeWorker,
+				Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "new"}},
+				Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
+			},
+		})
+		dgd.Annotations = map[string]string{
+			commonconsts.AnnotationCurrentWorkerHashV2: "old-worker-hash",
+		}
+		desired, err := desiredWorkerHashes(dgd)
+		require.NoError(t, err)
+
+		t.Log("Seed the fake cache with a worker DCD carrying the target hash")
+		targetDCD := createTestDCD(t, dgd, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dgd-worker-" + desired.v2,
+				Namespace: dgd.Namespace,
+				Labels: map[string]string{
+					commonconsts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+					commonconsts.KubeLabelDynamoWorkerHash:          desired.v2,
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: commonconsts.ComponentTypeWorker,
+					ServiceName:   "worker",
+					Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
+				},
+			},
+		})
+		reconciler := createTestDGDReconcilerWithStatus(dgd, withObjects(targetDCD))
+		program := reconciler.newComponentProgram()
+		status := dgd.DeepCopy().Status
+
+		t.Log("Reconcile: hash must advance to the observed target generation")
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd, &status))
+
+		assert.Nil(t, status.RollingUpdate)
+		assert.Equal(t, desired.v2, dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashV2])
 		assert.True(t, currentWorkerHashesMatchDesired(currentWorkerHashes(dgd), desired))
+	})
+
+	t.Run("v1-only annotation migrates to v2 without triggering a rollout", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: commonconsts.ComponentTypeWorker,
+				Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "v1"}},
+			},
+		})
+		desired, err := desiredWorkerHashes(dgd)
+		require.NoError(t, err)
+		dgd.Annotations = map[string]string{
+			commonconsts.AnnotationCurrentWorkerHash: "pre-v2-hash",
+		}
+		reconciler := createTestDGDReconcilerWithStatus(dgd)
+		program := reconciler.newComponentProgram()
+		status := dgd.DeepCopy().Status
+
+		t.Log("Reconcile: migration must write v2 annotation from spec without starting a rollout")
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd, &status))
+
+		assert.Equal(t, desired.v2, dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashV2],
+			"v2 annotation must be populated from the current spec")
+		assert.Equal(t, "pre-v2-hash", dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash],
+			"v1 annotation must be preserved during migration")
+		assert.Nil(t, status.RollingUpdate,
+			"migration must not trigger a rollout when the spec has not changed")
 	})
 }
 
@@ -875,4 +954,122 @@ func TestComponentWorkloadsReconciler_ApplyPendingAutomaticSnapshotPolicy(t *tes
 				dcd.Spec.PodTemplate.Annotations[commonconsts.SnapshotJobCandidateUIDAnnotation])
 		})
 	}
+}
+
+// TestComponentWorkloadsReconciler_FirstGenMultinodeStampsWorkerHash guards the full
+// render path for brand-new multinode DGDs. The DGD has no worker hash annotations
+// (first generation), so workerHashForDCDGeneration must return the v2 hash — not "".
+// A regression here deadlocks: the commit gate waits for a DCD labelled H while the
+// renderer writes one labelled "", and the two never match.
+func TestComponentWorkloadsReconciler_FirstGenMultinodeStampsWorkerHash(t *testing.T) {
+	t.Log("Build a brand-new multinode DGD with no worker hash annotations")
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
+		},
+		"decode": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
+		},
+	})
+
+	expectedHash := betaDGDWorkersSpecHash(t, dgd)
+
+	t.Log("Wire the component workloads reconciler backed by a fake client seeded with only the DGD")
+	r := createTestDGDReconcilerWithStatus(dgd)
+	rollout := newDGDWorkerRolloutReconciler(r.Client, r.Recorder)
+	workloads := newComponentWorkloadsReconciler(r.Client, r.Recorder, rollout)
+
+	t.Log("Reconcile: every generated worker DCD must carry the computed hash in its label and name")
+	_, err := workloads.Reconcile(context.Background(), dgd, nil, nil)
+	require.NoError(t, err)
+
+	dcdList := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	require.NoError(t, r.Client.List(context.Background(), dcdList, client.InNamespace(dgd.Namespace)))
+
+	var workerDCDs []*nvidiacomv1beta1.DynamoComponentDeployment
+	for i := range dcdList.Items {
+		dcd := &dcdList.Items[i]
+		if dynamo.IsWorkerComponent(string(dcd.Spec.ComponentType)) {
+			workerDCDs = append(workerDCDs, dcd)
+		}
+	}
+	require.Len(t, workerDCDs, 2, "both worker components must produce a DCD")
+
+	for _, dcd := range workerDCDs {
+		assert.Equal(t, expectedHash, dcd.Labels[commonconsts.KubeLabelDynamoWorkerHash],
+			"DCD %s must carry the worker hash label", dcd.Name)
+		assert.True(t, strings.HasSuffix(dcd.Name, expectedHash),
+			"DCD %s must have the worker hash as name suffix", dcd.Name)
+	}
+}
+
+// TestComponentWorkloadsReconciler_RemovedWorkerComponentDrainedToZero guards the
+// drain path for a component that has been removed from the DGD spec mid-rollout.
+// Without the fix, buildRollingUpdateContext only iterates desired components, so
+// the removed component never gets a target in OldWorkerReplicaTargetsByComponent.
+// scaleOldWorkerDCDs then skips it, the DCD stays at 1, and completeRollingUpdate
+// can never drain-and-delete it — permanently stalling the rollout.
+func TestComponentWorkloadsReconciler_RemovedWorkerComponentDrainedToZero(t *testing.T) {
+	t.Log("Compute the old hash from the full two-component DGD that existed before the removal")
+	fullDGD := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {ComponentType: commonconsts.ComponentTypeWorker},
+		"decode":  {ComponentType: commonconsts.ComponentTypeWorker},
+	})
+	oldHash := betaDGDWorkersSpecHash(t, fullDGD)
+
+	t.Log("Build the reduced DGD with decode removed; annotate it with the old hash to signal an active rollout")
+	reducedDGD := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"prefill": {ComponentType: commonconsts.ComponentTypeWorker},
+	})
+	reducedDGD.Annotations = map[string]string{
+		commonconsts.AnnotationCurrentWorkerHashV2: oldHash,
+	}
+
+	t.Log("Seed the fake cache with old-gen DCDs for both prefill and decode carrying the old hash")
+	prefillOldDCD := createTestDCD(t, reducedDGD, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd-prefill-" + oldHash, Namespace: "default"},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				ServiceName:   "prefill",
+				Replicas:      ptr.To(int32(1)),
+				Labels: map[string]string{
+					commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+					commonconsts.KubeLabelDynamoWorkerHash:          oldHash,
+				},
+			},
+		},
+	})
+	decodeOldDCD := createTestDCD(t, reducedDGD, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd-decode-" + oldHash, Namespace: "default"},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: commonconsts.ComponentTypeWorker,
+				ServiceName:   "decode",
+				Replicas:      ptr.To(int32(1)),
+				Labels: map[string]string{
+					commonconsts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+					commonconsts.KubeLabelDynamoWorkerHash:          oldHash,
+				},
+			},
+		},
+	})
+
+	r := createTestDGDReconcilerWithStatus(reducedDGD, withObjects(prefillOldDCD, decodeOldDCD))
+	rollout := newDGDWorkerRolloutReconciler(r.Client, r.Recorder)
+	workloads := newComponentWorkloadsReconciler(r.Client, r.Recorder, rollout)
+
+	t.Log("Reconcile: the removed decode component must be targeted at zero replicas")
+	_, err := workloads.Reconcile(context.Background(), reducedDGD, nil, nil)
+	require.NoError(t, err)
+
+	t.Log("Verify the decode old DCD has been patched to zero replicas so the rollout can drain and complete")
+	gotDCD := &nvidiacomv1beta1.DynamoComponentDeployment{}
+	require.NoError(t, r.Client.Get(context.Background(),
+		client.ObjectKeyFromObject(decodeOldDCD), gotDCD))
+	require.NotNil(t, gotDCD.Spec.Replicas, "decode old DCD must have an explicit replica count")
+	assert.Equal(t, int32(0), *gotDCD.Spec.Replicas,
+		"decode old DCD must be scaled to zero so completeRollingUpdate can drain and delete it")
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -267,8 +267,7 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			builder.WithPredicates(dgdWorkerPodEventPredicate()),
 		).
 		Owns(&nvidiacomv1beta1.DynamoComponentDeployment{}, builder.WithPredicates(predicate.Funcs{
-			// ignore creation cause we don't want to be called again after we create the deployment
-			CreateFunc:  func(ce event.CreateEvent) bool { return false },
+			CreateFunc:  func(ce event.CreateEvent) bool { return true },
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(de event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return true },

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -783,6 +783,7 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 		},
 		{
 			name: "frontend service with 1 replica, decode service with 2 replicas - 2 PodCliques - one unready",
+
 			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
 				BackendFramework: "vllm",
 				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
@@ -858,6 +859,7 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 		},
 		{
 			name: "decode worker multinode (PCSG), prefill worker multinode (PCSG) - both ready",
+
 			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
 				BackendFramework: "vllm",
 				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
@@ -939,6 +941,7 @@ func TestGroveWorkloadsReconciler_Reconcile(t *testing.T) {
 		},
 		{
 			name: "frontend worker (PodClique), aggregated worker multinode (PCSG) - PCSG unready",
+
 			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
 				BackendFramework: "vllm",
 				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{


### PR DESCRIPTION
## Summary

- Cherry-pick #14249 onto `release/1.5.0`.
- Gate worker hash projection for Grove (PodCliqueSet) and multinode/LWS paths on informer cache observing the target child resource before writing the DGD annotation.
- Fix rolling update completion: drain all old-generation DCDs before deletion, filter by DGD ownership, remove stuck-detection branch.
- Fix first-gen multinode DCDs stamping v2 hash; drain removed worker components before completion.
- Gate checkpoint hash on first committed generation to prevent SnapshotJobs targeting an uncommitted hash.
- Enable DCD Create events to unblock multinode hash projection.

## Original PR

- Main PR: #14249
- Main merge commit: `adf40538b9e9fa21a64bece7f88fae6364e373e7`
- Backport commit: `149c684251f0a5368f401843544683ce2a20a25c`

## Release adaptation

Clean cherry-pick with no conflicts or release-specific code changes.

## Validation

- `go test ./internal/controller/...` — passed (per source PR)
- Key tests: `TestDCDObservesWorkerHash`, `TestCheckpointWorkerHashForComponent_WaitsForCommittedGeneration`, `TestComponentWorkloadsReconciler_RemovedWorkerComponentDrainedToZero`, `TestGroveWorkloadsReconciler_SkipsHashObservationWhenHashIsCurrent`

## Related Issues

- Closes #13620. Part of #14222.