### PR TITLE
fix(llm): keep serving when a worker role is ambiguous

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -461,6 +461,16 @@ impl Model {
                 .collect();
             missing_vec.sort();
 
+            let ambiguous_roles = || {
+                let mut roles = eval
+                    .ambiguous
+                    .iter()
+                    .map(|worker_type| worker_type.as_str())
+                    .collect::<Vec<_>>();
+                roles.sort_unstable();
+                roles.join(", ")
+            };
+
             let reason = if eval.ready {
                 if eval.has_legacy {
                     let legacy_live_workers = eval.legacy_live_workers;
@@ -468,19 +478,25 @@ impl Model {
                         "legacy worker(s) present (no worker_type); readiness gating bypassed \
                          (ready while {legacy_live_workers} worker(s) live) — compat window only"
                     ))
+                } else if !eval.ambiguous.is_empty() {
+                    // Serving, but degraded: the duplicated role can't be
+                    // paired, so requests run aggregated on the decode worker.
+                    Some(format!(
+                        "serving in degraded mode: ambiguous worker types: {} \
+                         (role pairing disabled; requests served aggregated)",
+                        ambiguous_roles()
+                    ))
                 } else {
                     None
                 }
             } else if eval.has_legacy {
                 Some("legacy worker(s) present but no live worker".to_string())
             } else if !eval.ambiguous.is_empty() {
-                let mut roles = eval
-                    .ambiguous
-                    .iter()
-                    .map(|worker_type| worker_type.as_str())
-                    .collect::<Vec<_>>();
-                roles.sort_unstable();
-                Some(format!("ambiguous worker types: {}", roles.join(", ")))
+                Some(format!(
+                    "missing worker types: {}; ambiguous worker types: {}",
+                    missing_vec.join(", "),
+                    ambiguous_roles()
+                ))
             } else {
                 Some(format!("missing worker types: {}", missing_vec.join(", ")))
             };
@@ -1631,6 +1647,172 @@ mod tests {
         );
         // Endpoint must agree with the gate.
         assert_eq!(ns.ready, model.is_workers_ready("ns1"));
+    }
+
+    /// A second typed Prefill endpoint in one namespace must not take
+    /// the healthy decode worker down with it. Ambiguity disables the P/D
+    /// pairing (`reconcile_discovery_topology` withholds the prefill target);
+    /// the model keeps serving aggregated instead of returning a blanket 503.
+    #[test]
+    fn readiness_duplicate_prefill_keeps_serving_and_reports_degraded() {
+        let model = Model::new("llama".to_string());
+        let (decode, _td) = ws_with_type(
+            "ns1",
+            "mdc-d",
+            WorkerType::Decode,
+            vec![vec![WorkerType::Prefill]],
+            vec![1],
+        );
+        let (prefill, _tp) = ws_with_type(
+            "ns1",
+            "mdc-p",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![2],
+        );
+        model.add_worker_set("ns1".to_string(), decode);
+        model.add_worker_set("ns1:prefill".to_string(), prefill);
+        assert!(
+            model.is_workers_ready("ns1"),
+            "baseline P/D pair must serve"
+        );
+
+        // Second typed prefill endpoint, same namespace, different component.
+        let (prefill2, _tp2) = ws_with_type(
+            "ns1",
+            "mdc-p2",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![3],
+        );
+        model.add_worker_set("ns1:prefill2".to_string(), prefill2);
+
+        // The serving gate behind check_model_serving_ready() must stay open.
+        assert!(
+            model.is_workers_ready("ns1"),
+            "ambiguous prefill must not make the namespace unservable"
+        );
+        assert!(model.has_ready_workers());
+        assert_eq!(model.first_ready_workers(), Some("ns1".to_string()));
+
+        // ...and the ambiguity is still surfaced on /v1/models/{model}/ready.
+        let topo = model.namespace_readiness();
+        assert!(topo.ready);
+        let ns = &topo.namespaces["ns1"];
+        assert!(ns.ready);
+        assert_eq!(ns.worker_types["decode"].workers, 1);
+        assert_eq!(ns.worker_types["prefill"].workers, 2);
+        let reason = ns.reason.as_deref().expect("degraded reason");
+        assert!(
+            reason.contains("ambiguous worker types: prefill"),
+            "reason must name the duplicated role, got: {reason}"
+        );
+        assert!(
+            reason.contains("degraded"),
+            "reason must flag degradation, got: {reason}"
+        );
+
+        // Removing the duplicate returns the namespace to undegraded serving.
+        model.remove_worker_set("ns1:prefill2");
+        let recovered = model.namespace_readiness();
+        assert!(recovered.ready);
+        assert_eq!(recovered.namespaces["ns1"].reason, None);
+    }
+
+    /// N-2 compat: a rolling upgrade can split one endpoint into two
+    /// WorkerSets of the same role, because `worker_set_key` embeds the card's
+    /// `model_type` surface list verbatim (watcher.rs). A release where a decode
+    /// worker starts advertising one more surface — `ModelType` has grown
+    /// `Realtime`, `Classify` and `Pooling` bits over time — therefore produces an
+    /// old-card bucket and a new-card bucket on the *same* endpoint for the
+    /// duration of the rollout. Prefill is exempt: new prefill workers dual-emit
+    /// `ModelType::Prefill` so they share the legacy bucket
+    /// (`ws_key_new_and_legacy_prefill_share_a_bucket`); decode has no such
+    /// guarantee.
+    ///
+    /// `lib/llm/AGENTS.md` requires that differences caused only by supported wire
+    /// evolution "must not split otherwise compatible workers, fail discovery
+    /// closed, or remove healthy serving state". Splitting the bucket is tolerable;
+    /// 503-ing every request for the length of the rollout is not.
+    #[test]
+    fn readiness_mixed_version_decode_rollout_keeps_serving() {
+        let model = Model::new("llama".to_string());
+        // Old decode pods, still draining.
+        let (old_decode, _to) = ws_with_type(
+            "ns1",
+            "mdc-d-v14",
+            WorkerType::Decode,
+            vec![vec![WorkerType::Prefill]],
+            vec![1, 2],
+        );
+        // New decode pods, already admitted; different surface list => different
+        // WorkerSet bucket for the same endpoint.
+        let (new_decode, _tn) = ws_with_type(
+            "ns1",
+            "mdc-d-v15",
+            WorkerType::Decode,
+            vec![vec![WorkerType::Prefill]],
+            vec![3],
+        );
+        let (prefill, _tp) = ws_with_type(
+            "ns1",
+            "mdc-p",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![4],
+        );
+        model.add_worker_set("ns1:decode:chat|completions".to_string(), old_decode);
+        model.add_worker_set(
+            "ns1:decode:chat|completions|realtime".to_string(),
+            new_decode,
+        );
+        model.add_worker_set("ns1:prefill".to_string(), prefill);
+
+        assert!(
+            model.is_workers_ready("ns1"),
+            "a mixed-version decode rollout must keep serving, not 503 until it drains"
+        );
+        let ns = &model.namespace_readiness().namespaces["ns1"];
+        assert!(ns.ready);
+        // Both buckets are counted, and the degradation is visible.
+        assert_eq!(ns.worker_types["decode"].workers, 3);
+        let reason = ns.reason.as_deref().expect("degraded reason");
+        assert!(
+            reason.contains("ambiguous worker types: decode"),
+            "{reason}"
+        );
+    }
+
+    /// Ambiguity must not mask a genuinely absent peer: two prefill WorkerSets
+    /// with no live decode is still unservable, and the reason names both.
+    #[test]
+    fn readiness_duplicate_prefill_without_decode_is_not_ready() {
+        let model = Model::new("llama".to_string());
+        let (p1, _t1) = ws_with_type(
+            "ns1",
+            "mdc-p",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![1],
+        );
+        let (p2, _t2) = ws_with_type(
+            "ns1",
+            "mdc-p2",
+            WorkerType::Prefill,
+            vec![vec![WorkerType::Decode]],
+            vec![2],
+        );
+        model.add_worker_set("ns1:prefill".to_string(), p1);
+        model.add_worker_set("ns1:prefill2".to_string(), p2);
+
+        assert!(!model.is_workers_ready("ns1"));
+        let ns = &model.namespace_readiness().namespaces["ns1"];
+        let reason = ns.reason.as_deref().expect("reason");
+        assert!(reason.contains("missing worker types: decode"), "{reason}");
+        assert!(
+            reason.contains("ambiguous worker types: prefill"),
+            "{reason}"
+        );
     }
 
     #[test]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3582,8 +3582,11 @@ mod tests {
                         Vec::new(),
                     )
                     .unwrap();
+                // The duplicate withholds the prefill target, so P/D
+                // pairing stops — but the namespace keeps serving aggregated
+                // rather than 503-ing the healthy decode worker.
                 assert!(
-                    !manager
+                    manager
                         .get_committed_model("topology-model")
                         .unwrap()
                         .namespace_readiness()

--- a/lib/llm/src/discovery/readiness.rs
+++ b/lib/llm/src/discovery/readiness.rs
@@ -7,6 +7,10 @@
 //! card normalization and the readiness evaluation live here as pure functions over
 //! [`ReadinessUnit`]s; `Model::evaluate_namespace` and the relay topology projection are
 //! adapters that build units from their own liveness sources.
+//!
+//! The shared answer is [`ReadinessEval::ready`]. A consumer may layer an extra
+//! condition on top of it — the relay additionally requires an unambiguous
+//! topology — but never a different notion of "serving".
 
 use std::collections::HashSet;
 
@@ -51,6 +55,14 @@ pub fn normalize_legacy_prefill_topology(card: &mut ModelDeploymentCard) {
 }
 
 /// Whether a namespace's units are ready to serve traffic.
+///
+/// `ready` answers only "can this namespace serve a request". `ambiguous` — a
+/// non-Aggregated role carrying more than one live WorkerSet — is reported
+/// alongside it but does not clear `ready`: ambiguity disables the P/D (or
+/// encode) *pairing* for that role and serving degrades to aggregated, which is
+/// the pre-v1.5 contract. A consumer that genuinely cannot act on an ambiguous
+/// topology, such as the KV DC Relay picking a remote KV source, must compose
+/// `ready && ambiguous.is_empty()` itself.
 pub fn evaluate_readiness(units: &[ReadinessUnit]) -> ReadinessEval {
     let mut present: HashSet<WorkerType> = HashSet::new();
     let mut missing: HashSet<WorkerType> = HashSet::new();
@@ -127,8 +139,13 @@ pub fn evaluate_readiness(units: &[ReadinessUnit]) -> ReadinessEval {
         }
     }
 
+    // `ambiguous` deliberately does not gate `ready`. A duplicated role only
+    // costs us the ability to *pair* that role — `reconcile_discovery_topology`
+    // withholds the prefill/encode target, and both routers then pass the
+    // request through to the decode backend. Failing the whole namespace here
+    // would 503 that healthy backend before it ever reaches the degrade path.
     ReadinessEval {
-        ready: has_live_worker && missing.is_empty() && ambiguous.is_empty(),
+        ready: has_live_worker && missing.is_empty(),
         has_legacy,
         legacy_live_workers,
         present,
@@ -222,14 +239,35 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_live_units_of_one_role_are_ambiguous_and_not_ready() {
+    fn duplicate_live_units_of_one_role_are_ambiguous_but_still_serve() {
+        // Two typed Prefill WorkerSets alongside a healthy Decode. The
+        // duplication is reported so the topology reconciler can withhold the
+        // prefill target, but the namespace keeps serving — the decode worker
+        // falls back to aggregated rather than the model going 503.
         let evaluation = evaluate_readiness(&[
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
             unit(Some(WorkerType::Decode), 1, vec![vec![WorkerType::Prefill]]),
         ]);
-        assert!(!evaluation.ready);
+        assert!(evaluation.ready);
         assert_eq!(evaluation.ambiguous, HashSet::from([WorkerType::Prefill]));
+        assert!(evaluation.missing.is_empty());
+
+        // A duplicated role still can't paper over a genuinely absent peer.
+        let ambiguous_and_missing = evaluate_readiness(&[
+            unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
+            unit(Some(WorkerType::Prefill), 1, vec![vec![WorkerType::Decode]]),
+            unit(Some(WorkerType::Decode), 0, vec![vec![WorkerType::Prefill]]),
+        ]);
+        assert!(!ambiguous_and_missing.ready);
+        assert_eq!(
+            ambiguous_and_missing.ambiguous,
+            HashSet::from([WorkerType::Prefill])
+        );
+        assert_eq!(
+            ambiguous_and_missing.missing,
+            HashSet::from([WorkerType::Decode])
+        );
 
         let scale_out = evaluate_readiness(&[
             unit(Some(WorkerType::Aggregated), 1, vec![]),
@@ -237,6 +275,33 @@ mod tests {
         ]);
         assert!(scale_out.ready);
         assert!(scale_out.ambiguous.is_empty());
+    }
+
+    #[test]
+    fn duplicate_encode_units_are_ambiguous_but_still_serve() {
+        // The `ready` change applies to every non-Aggregated role, not just
+        // Prefill, so pin the Encode case explicitly. `reconcile_discovery_topology`
+        // withholds `unique_encode` when there is more than one encode provider, and
+        // `EncoderRouter::generate` then passes the request through to `next`
+        // (encoder_router.rs) exactly as the prefill router does. The relay keeps
+        // the strict view of this — see
+        // `kv_dc_relay::topology::duplicate_encode_endpoints_stay_unavailable_for_remote_kv_sourcing`.
+        let evaluation = evaluate_readiness(&[
+            unit(
+                Some(WorkerType::Encode),
+                1,
+                vec![vec![WorkerType::Aggregated]],
+            ),
+            unit(
+                Some(WorkerType::Encode),
+                1,
+                vec![vec![WorkerType::Aggregated]],
+            ),
+            unit(Some(WorkerType::Aggregated), 1, vec![]),
+        ]);
+        assert!(evaluation.ready);
+        assert_eq!(evaluation.ambiguous, HashSet::from([WorkerType::Encode]));
+        assert!(evaluation.missing.is_empty());
     }
 
     #[test]

--- a/lib/llm/src/kv_dc_relay/topology.rs
+++ b/lib/llm/src/kv_dc_relay/topology.rs
@@ -332,9 +332,15 @@ fn derive_topology(
             let evaluation = evaluate_readiness(&group.units);
             let state = if !group.availability_authoritative {
                 TopologyReadinessState::Unknown
-            } else if evaluation.ready {
+            } else if evaluation.ready && evaluation.ambiguous.is_empty() {
                 TopologyReadinessState::Ready
             } else {
+                // Stricter than the local serving gate on purpose. Serving
+                // degrades to aggregated under a duplicated role, but a remote
+                // peer choosing a KV source has no such fallback: it cannot
+                // tell which of the duplicate endpoints owns the blocks, so the
+                // pool stays unadvertised. `duplicate_role_endpoints` below
+                // carries the reason.
                 TopologyReadinessState::Unavailable
             };
             let adapters = derive_adapters(&group.adapters);
@@ -464,9 +470,11 @@ fn derive_adapters(
             let evaluation = evaluate_readiness(&aggregate.units);
             let state = if !aggregate.availability_authoritative {
                 TopologyReadinessState::Unknown
-            } else if evaluation.ready {
+            } else if evaluation.ready && evaluation.ambiguous.is_empty() {
                 TopologyReadinessState::Ready
             } else {
+                // See `derive_topology`: remote KV sourcing has no aggregated
+                // fallback, so an ambiguous adapter topology stays unavailable.
                 TopologyReadinessState::Unavailable
             };
             AdapterReadiness {
@@ -672,8 +680,9 @@ mod tests {
             Some(WorkerType::Decode),
             vec![vec![WorkerType::Prefill]],
         );
-        // A second Decode worker set serving a different surface: the request plane
-        // sees two WorkerSets of one role and gates the namespace as ambiguous.
+        // A second Decode worker set serving a different surface: one endpoint yields
+        // two WorkerSets of one role. The core marks this ambiguous but keeps
+        // serving; the relay additionally refuses to advertise the pool.
         decode.worker_topology.insert(
             2,
             DomainWorkerTopology {
@@ -1012,8 +1021,11 @@ mod tests {
         let snapshot = publisher.snapshot();
         let topology = entry(&snapshot, "llama");
 
-        // Parity with the core evaluation: an ambiguous role topology is not ready,
-        // and the duplicated roles explain the gate.
+        // The relay is deliberately stricter than the core serving gate: the core
+        // keeps an ambiguous namespace servable (it degrades to aggregated), but a
+        // remote peer picking a KV source has no such fallback, so the pool stays
+        // unadvertised and the duplicated roles explain the gate. See
+        // `derive_topology`.
         assert_eq!(topology.state, TopologyReadinessState::Unavailable);
         assert_eq!(
             topology.duplicate_role_endpoints,
@@ -1161,7 +1173,7 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_encode_endpoints_are_ambiguous_like_the_core_evaluation() {
+    fn duplicate_encode_endpoints_stay_unavailable_for_remote_kv_sourcing() {
         let view = view(vec![
             endpoint(
                 "production.encode-a.generate",


### PR DESCRIPTION
## Overview:

Two prefill workers in one namespace made the whole model return 503, even though the decode worker was healthy. Ambiguity should only disable prefill/decode pairing, not take the deployment down.

## Details:

Readiness treated a duplicated role as a namespace-wide failure.

The fallback already existed. When a role has more than one provider, the topology reconciler drops the prefill target and requests go straight to the decode worker to be served aggregated. The readiness gate rejected those requests one layer earlier, so the fallback never ran.

This stops readiness from failing on ambiguity. Nothing is hidden: `/ready` now reports the namespace as serving in degraded mode and names the duplicated role. A genuinely missing role still fails readiness as before.

The KV DC Relay stays strict, now stated explicitly instead of inherited. A remote peer picking a KV source has no aggregated fallback and can't tell which duplicate owns the blocks, so an ambiguous pool stays unadvertised.

## Where should the reviewer start?

`lib/llm/src/discovery/readiness.rs` for the change itself.

Then `lib/llm/src/kv_dc_relay/topology.rs`. I deliberately made the relay stricter than local serving, which is the one judgment call here and worth a second opinion.

## Validation

Ran the reported reproduction against a stock and a patched build of the same commit. Stock returns 503 three times and matches the report exactly. Patched returns 200 and recovers identically once the duplicate is removed.

Repeated on Kubernetes with real vLLM workers (Qwen3-0.6B, 1 decode + 2 prefill, one H100 each). Same result, and per-worker metrics confirm the decode worker really does the prefill when pairing is off.

A v1.4.2 frontend on the same topology also serves, so this is a regression against a shipped release.

Tests: `discovery::` 218/218, `kv_dc_relay::` 176/176, router e2e 48 passed / 0 failed. `cargo fmt` and `cargo clippy` clean. Both new regression tests fail with the change reverted.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Tracked internally as DYN-4330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
