### PR TITLE
fix(test): pin CPU platform for vLLM LoRA argument tests

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
@@ -467,6 +467,7 @@ class TestClassifyWorkerExclusivity:
         config._validate_classify_worker_exclusivity()
 
 
+@pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator")
 class TestParseArgsLoraExclusivity:
     """The --enable-lora exclusivity rules must fire on the real CLI path.
 


### PR DESCRIPTION
## Summary

The four `TestParseArgsLoraExclusivity` tests fail on accelerator-less vLLM runners with `RuntimeError: Failed to infer device type` while building the engine argument parser, before reaching their LoRA assertions. This blocks unrelated PRs. The following exact failed jobs retain the evidence independently of subsequent PR updates:

- #14605: [vllm-runtime / Test cuda13.0, arm64 — run 34446776405, job 102775601567](https://github.com/ai-dynamo/dynamo/actions/runs/34446776405/job/102775601567)
- #14602: [vllm-runtime / Test cuda13.0, arm64 — run 34443657606, job 102765497253](https://github.com/ai-dynamo/dynamo/actions/runs/34443657606/job/102765497253)

Both jobs report the same four `TestParseArgsLoraExclusivity` failures with `RuntimeError: Failed to infer device type`.

Apply the existing `vllm_cpu_platform_when_no_accelerator` fixture to this class, as the other parser tests already do. The fixture pins `CpuPlatform` only when vLLM cannot detect an accelerator and restores platform state after each test; recognized accelerator platforms retain their normal behavior.

This implements the test-fixture fix requested in https://github.com/ai-dynamo/dynamo/pull/14446#issuecomment-5601936319.

## Validation

- Passed: `pre-commit run --files components/src/dynamo/vllm/tests/test_vllm_backend_args.py`, including pytest marker validation.
- Passed: `git diff --check`.
- Targeted pytest run attempted locally, but collection is blocked by the macOS environment lacking the Dynamo vLLM backend and vLLM dependencies. Pulling the exact CI test image was also blocked by missing private ECR credentials. The four tests still need execution in the vLLM CPU CI lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated vLLM backend argument tests to cover environments without an accelerator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
