### PR TITLE
test(vllm): use CPU platform fixture for LoRA CLI tests

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_backend_args.py
@@ -467,6 +467,7 @@ class TestClassifyWorkerExclusivity:
         config._validate_classify_worker_exclusivity()
 
 
+@pytest.mark.usefixtures("vllm_cpu_platform_when_no_accelerator")
 class TestParseArgsLoraExclusivity:
     """The --enable-lora exclusivity rules must fire on the real CLI path.
 


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
  The four `TestParseArgsLoraExclusivity` tests fail on the GPU-less arm64 CI runner before reaching their assertions:

  RuntimeError: Failed to infer device type

  vLLM constructs `DeviceConfig` defaults while building the CLI parser. The amd64 job passes because CUDA is available there, even during the `gpu_0` test stage.

  Apply the existing `vllm_cpu_platform_when_no_accelerator` fixture to this test class. No production code or assertions change.


## Details:

<!-- Describe the changes made in this PR. -->
all four tests failed in [arm64 CI](https://github.com/ai-dynamo/dynamo/actions/runs/34443657606/job/102765497253)

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues


<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->


**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test setup coverage for vLLM CPU platform behavior when no accelerator is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->