### PR TITLE
test(trtllm): enable fault tolerance coverage

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -208,7 +208,7 @@ class _DeferredAbort:
         """Abort immediately if first token received, otherwise defer."""
         if self._first_token_received:
             self._generation_result.abort()
-            logging.debug("Deferred abort: first token already received, aborting now")
+            logging.debug("Deferred abort: engine abort fired")
         else:
             logging.debug(
                 "Deferred abort: first token not received, spawning background task"
@@ -223,7 +223,7 @@ class _DeferredAbort:
         except Exception:
             pass
         self._generation_result.abort()
-        logging.debug("Deferred abort: background task completed, abort fired")
+        logging.debug("Deferred abort: engine abort fired")
 
 
 @dataclass

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -906,12 +906,15 @@ class HandlerBase(BaseGenerativeHandler):
                         return True
         return False
 
-    def _normalize_request_format(self, request: dict) -> None:
+    @staticmethod
+    def _normalize_request_format(request: dict) -> None:
         """
         Convert OpenAI request format to TRT-LLM internal format.
 
         Moves fields from OpenAI locations to where TRT-LLM expects them:
         - max_tokens: top-level → stop_conditions.max_tokens
+        - min_tokens: top-level → stop_conditions.min_tokens
+        - ignore_eos: top-level → stop_conditions.ignore_eos
         - temperature: top-level → sampling_options.temperature
 
         Note: The Rust frontend's PrefillRouter handles the *value* of max_tokens
@@ -924,17 +927,17 @@ class HandlerBase(BaseGenerativeHandler):
         # Ensure stop_conditions exists
         if "stop_conditions" not in request:
             request["stop_conditions"] = {}
-        if "max_tokens" in request and "max_tokens" not in request["stop_conditions"]:
-            request["stop_conditions"]["max_tokens"] = request.pop("max_tokens")
+        for field in ("max_tokens", "min_tokens", "ignore_eos"):
+            if field in request:
+                value = request.pop(field)
+                request["stop_conditions"].setdefault(field, value)
 
         # Ensure sampling_options exists
         if "sampling_options" not in request:
             request["sampling_options"] = {}
-        if (
-            "temperature" in request
-            and "temperature" not in request["sampling_options"]
-        ):
-            request["sampling_options"]["temperature"] = request.pop("temperature")
+        if "temperature" in request:
+            temperature = request.pop("temperature")
+            request["sampling_options"].setdefault("temperature", temperature)
 
     async def _initiate_shutdown(self, error: Exception):
         """Initiate graceful shutdown after fatal error"""

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -211,6 +211,31 @@ class TestOverrideSamplingParams:
         mock_post_init.assert_called_once()
 
 
+class TestNormalizeRequestFormat:
+    def test_moves_openai_stop_fields_without_overwriting_internal_values(self):
+        request = {
+            "max_tokens": 64,
+            "min_tokens": 32,
+            "ignore_eos": True,
+            "temperature": 0.5,
+            "stop_conditions": {"min_tokens": 16},
+            "sampling_options": {"temperature": 0.25},
+        }
+
+        HandlerBase._normalize_request_format(request)
+
+        assert request["stop_conditions"] == {
+            "max_tokens": 64,
+            "min_tokens": 16,
+            "ignore_eos": True,
+        }
+        assert "max_tokens" not in request
+        assert "min_tokens" not in request
+        assert "ignore_eos" not in request
+        assert request["sampling_options"] == {"temperature": 0.25}
+        assert "temperature" not in request
+
+
 class TestGuidedDecodingFromToolChoice:
     """Tests that guided_decoding dicts from Rust are converted to GuidedDecodingParams.
 

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -456,7 +456,7 @@ def test_request_cancellation_trtllm_decode_handoff_cancel(
 
     The decode-entry log is emitted before KV transfer begins, so this test does not prove that
     TRT-LLM supports an engine abort during transfer. It verifies Dynamo's deferred-abort behavior:
-    cancellation completes after the handoff, resources are cleaned up, and both workers remain usable.
+    the engine abort fires after the handoff and both workers remain usable.
 
     Timing (Last Run: 2025-12-09): ~115s total (2 workers at 45% GPU each)
     - Engine initialization: ~92s (frontend: 2s, prefill worker: 45s, decode worker: 45s sequential)
@@ -515,11 +515,21 @@ def test_request_cancellation_trtllm_decode_handoff_cancel(
                 logger.info(f"Cancelled request ID: {request_id} after decode handoff")
 
                 # Poll for "Aborted Request ID" in decode worker
-                _, decode_log_offset = poll_for_pattern(
+                poll_for_pattern(
                     process=decode_worker,
                     pattern=f"Aborted Request ID: {request_id}",
                     log_offset=decode_log_offset,
                     max_wait_ms=10_000,
+                )
+
+                # The request-level abort log above is emitted when the wrapper is
+                # invoked. Require the later engine-abort signal so a stuck deferred
+                # task cannot masquerade as successful cancellation.
+                _, decode_log_offset = poll_for_pattern(
+                    process=decode_worker,
+                    pattern="Deferred abort: engine abort fired",
+                    log_offset=decode_log_offset,
+                    max_wait_ms=30_000,
                 )
 
                 # Verify frontend log has kill message
@@ -543,7 +553,9 @@ def test_request_cancellation_trtllm_decode_handoff_cancel(
                     process=decode_worker,
                     pattern="Decode Request ID: ",
                     log_offset=decode_log_offset,
+                    max_wait_ms=30_000,
                     match_type="contains",
+                    cancellable_request=cancellable_req,
                 )
                 read_streaming_responses(
                     cancellable_req,

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -12,7 +12,6 @@ Test Execution Times (Last Run: 2025-12-13):
 
 import logging
 import os
-import shutil
 import time
 
 import pytest
@@ -65,6 +64,7 @@ class DynamoWorkerProcess(ManagedProcess):
         request.addfinalizer(lambda port=system_port: deallocate_port(port))
         self.system_port = system_port
         self.frontend_port = frontend_port
+        tmp_path = request.getfixturevalue("tmp_path")
 
         command = [
             "python3",
@@ -80,16 +80,14 @@ class DynamoWorkerProcess(ManagedProcess):
             "16384",
         ]
         if mode != "agg":
-            with open("test_request_cancellation_trtllm_config.yaml", "w") as f:
+            config_file = tmp_path / f"trtllm_cancel_config_{system_port}.yaml"
+            with config_file.open("w") as f:
                 f.write(
                     "cache_transceiver_config:\n  backend: DEFAULT\n  max_tokens_in_buffer: 16384\n"
                 )
                 f.write("disable_overlap_scheduler: true\n")
                 f.write("kv_cache_config:\n  max_tokens: 16384\n")
-            command += [
-                "--extra-engine-args",
-                "test_request_cancellation_trtllm_config.yaml",
-            ]
+            command += ["--extra-engine-args", str(config_file)]
 
         health_check_urls = [
             (f"http://localhost:{frontend_port}/v1/models", check_models_api),
@@ -115,16 +113,7 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
         env["DYN_SYSTEM_PORT"] = str(system_port)
 
-        # Set log directory based on worker type
-        log_dir = f"{request.node.name}_{mode}_worker"
-
-        # Clean up any existing log directory from previous runs
-        try:
-            shutil.rmtree(log_dir)
-            logger.info(f"Cleaned up existing log directory: {log_dir}")
-        except FileNotFoundError:
-            # Directory doesn't exist, which is fine
-            pass
+        log_dir = tmp_path / f"{mode}_worker"
 
         super().__init__(
             command=command,
@@ -133,7 +122,7 @@ class DynamoWorkerProcess(ManagedProcess):
             timeout=300,
             display_output=True,
             terminate_all_matching_process_names=False,
-            log_dir=log_dir,
+            log_dir=str(log_dir),
         )
 
         self.mode = mode
@@ -346,7 +335,9 @@ def test_request_cancellation_trtllm_decode_cancel(
                 )
 
 
-@pytest.mark.skip(reason="TRT-LLM prefill cancellation is disabled due to reliability")
+@pytest.mark.skip(
+    reason="Cancellation does not reach TRT-LLM before prefill completes (1.3.0rc25)"
+)
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_prefill_cancel(
     request, runtime_services_dynamic_ports, predownload_models
@@ -456,7 +447,6 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 )
 
 
-@pytest.mark.skip(reason="Test fails only on CI")
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_kv_transfer_cancel(
     request, runtime_services_dynamic_ports, predownload_models
@@ -527,6 +517,7 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                     process=decode_worker,
                     pattern=f"Aborted Request ID: {request_id}",
                     log_offset=decode_log_offset,
+                    max_wait_ms=10_000,
                 )
 
                 # Verify frontend log has kill message
@@ -541,7 +532,10 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
 
                 # Verify the workers are still functional
                 cancellable_req = send_cancellable_request(
-                    frontend.frontend_port, "chat_completion_stream"
+                    frontend.frontend_port,
+                    "chat_completion_stream",
+                    max_tokens=8,
+                    timeout_s=30,
                 )
                 _, decode_log_offset = poll_for_pattern(
                     process=decode_worker,
@@ -549,7 +543,12 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                     log_offset=decode_log_offset,
                     match_type="contains",
                 )
-                read_streaming_responses(cancellable_req, expected_count=5)
+                read_streaming_responses(
+                    cancellable_req,
+                    expected_count=1,
+                    deadline_s=30,
+                    drain=True,
+                )
 
                 logger.info(
                     "Workers are functional after cancellation during KV transfer"

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -6,7 +6,7 @@ Test Execution Times (Last Run: 2025-12-13):
 - test_request_cancellation_trtllm_aggregated: ~45s (gpu_1)
 - test_request_cancellation_trtllm_decode_cancel: ~65s (gpu_1)
 - test_request_cancellation_trtllm_prefill_cancel: ~65s (gpu_1)
-- test_request_cancellation_trtllm_kv_transfer_cancel: ~65s (gpu_1)
+- test_request_cancellation_trtllm_decode_handoff_cancel: ~65s (gpu_1)
 - Total: ~240s x2 request planes = ~480s (0:08:00)
 """
 
@@ -447,19 +447,20 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 )
 
 
-@pytest.mark.timeout(195)  # 3x average
-def test_request_cancellation_trtllm_kv_transfer_cancel(
+@pytest.mark.timeout(350)  # 3x average
+def test_request_cancellation_trtllm_decode_handoff_cancel(
     request, runtime_services_dynamic_ports, predownload_models
 ):
     """
-    End-to-end test for request cancellation during prefill to decode KV transfer phase.
+    End-to-end test for request cancellation after the decode worker accepts it.
 
-    This test verifies that when a request is cancelled by the client during the KV transfer phase,
-    the system properly handles the cancellation and cleans up resources on the workers.
+    The decode-entry log is emitted before KV transfer begins, so this test does not prove that
+    TRT-LLM supports an engine abort during transfer. It verifies Dynamo's deferred-abort behavior:
+    cancellation completes after the handoff, resources are cleaned up, and both workers remain usable.
 
     Timing (Last Run: 2025-12-09): ~115s total (2 workers at 45% GPU each)
     - Engine initialization: ~92s (frontend: 2s, prefill worker: 45s, decode worker: 45s sequential)
-    - Testing KV transfer cancellation: ~20s
+    - Testing decode handoff cancellation: ~20s
     - Teardown: ~3s
     """
 
@@ -482,9 +483,9 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
                 time.sleep(2)
 
-                # Step 4: Test request cancellation during KV transfer phase
+                # Step 4: Test request cancellation after decode handoff
                 logger.info(
-                    "Testing completion request cancellation during KV transfer phase..."
+                    "Testing completion request cancellation after decode handoff..."
                 )
 
                 # Send request with long prompt
@@ -499,18 +500,19 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                     match_type="contains",
                 )
 
-                # Poll for decode worker entry signaling start of KV transfer phase
+                # Wait for decode admission. This log precedes KV transfer, and normal
+                # handoff can take longer than poll_for_pattern's 500 ms default.
                 _, decode_log_offset = poll_for_pattern(
                     process=decode_worker,
                     pattern=f"Decode Request ID: {request_id}",
+                    max_wait_ms=30_000,
                     poll_interval_ms=2,
+                    cancellable_request=cancellable_req,
                 )
 
-                # Cancel during KV transfer phase in decode worker
+                # Dynamo defers the engine abort until the first result completes.
                 cancellable_req.cancel()
-                logger.info(
-                    f"Cancelled request ID: {request_id} at beginning of decode"
-                )
+                logger.info(f"Cancelled request ID: {request_id} after decode handoff")
 
                 # Poll for "Aborted Request ID" in decode worker
                 _, decode_log_offset = poll_for_pattern(
@@ -527,7 +529,7 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                 )
 
                 logger.info(
-                    "Completion request cancellation at beginning of decode detected successfully"
+                    "Completion request cancellation after decode handoff detected successfully"
                 )
 
                 # Verify the workers are still functional
@@ -551,7 +553,7 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(
                 )
 
                 logger.info(
-                    "Workers are functional after cancellation during KV transfer"
+                    "Workers are functional after cancellation following decode handoff"
                 )
 
                 # Verify cancellation metrics

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -483,7 +483,6 @@ def test_request_cancellation_trtllm_decode_handoff_cancel(
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
                 time.sleep(2)
 
-                # Step 4: Test request cancellation after decode handoff
                 logger.info(
                     "Testing completion request cancellation after decode handoff..."
                 )

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -51,9 +51,8 @@ XPU_CANCELLATION_MAX_TOKENS = 2096
 DECODE_CANCEL_TEST_TIMEOUT_S = 900
 
 # The streaming read had no bound. STREAM_READ is the per-read socket timeout
-# between chunks; BEHAVIORAL bounds the wait for the next chunk while the
-# chunk-count goal is unmet. Neither caps total read time -- a late final chunk
-# that completes the count still counts. See read_streaming_responses.
+# between chunks; BEHAVIORAL caps total time spent reaching the chunk-count goal.
+# See read_streaming_responses.
 DECODE_CANCEL_STREAM_READ_TIMEOUT_S = 30
 DECODE_CANCEL_BEHAVIORAL_ALLOWANCE_S = 90
 

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import re
 import socket
@@ -281,17 +282,16 @@ def read_streaming_responses(
     cancellable_req: CancellableRequest,
     expected_count: int = 5,
     deadline_s: float | None = None,
+    drain: bool = False,
 ) -> None:
     """Read a specific number of responses from a streaming request.
 
     Args:
         cancellable_req: The CancellableRequest object with an active stream
         expected_count: Number of responses to read before returning
-        deadline_s: Budget for waiting on the next chunk, checked after each
-            arrival while the goal is unmet. A late chunk that completes
-            expected_count still counts, so this does not cap total read
-            time. The `timeout` passed to requests bounds a single read; this
-            bounds the sequence of them.
+        deadline_s: Absolute wall-clock budget for reading the required stream.
+        drain: Continue reading after expected_count until a successful terminal
+            response and ``[DONE]`` marker are received.
 
     Raises:
         pytest.fail if stream ends before expected_count responses
@@ -305,29 +305,100 @@ def read_streaming_responses(
         )
 
     response = cast(requests.Response, response_raw)  # Type narrowing after checks
-    deadline = None if deadline_s is None else time.monotonic() + deadline_s
     response_count = 0
-    for line in response.iter_lines():
-        response_count += 1
-        logger.info(
-            f"Received streaming response {response_count}: {line.decode()[:100]}"
-        )
-        if response_count >= expected_count:
-            logger.info(f"Successfully read {response_count} responses")
-            return
-        # Checked only while the goal is unmet. Moving this above the return
-        # would fail runs that received every chunk they needed.
-        if deadline is not None and time.monotonic() > deadline:
+    saw_finish_reason = False
+    saw_done = False
+    deadline = None if deadline_s is None else time.monotonic() + deadline_s
+    deadline_expired = threading.Event()
+    deadline_timer = None
+
+    if deadline_s is not None:
+
+        def expire_stream() -> None:
+            deadline_expired.set()
+            cancellable_req.cancel()
+
+        deadline_timer = threading.Timer(deadline_s, expire_stream)
+        deadline_timer.daemon = True
+        deadline_timer.start()
+
+    def fail_if_deadline_expired() -> None:
+        if deadline_expired.is_set() or (
+            deadline is not None and time.monotonic() >= deadline
+        ):
             cancellable_req.cancel()
             pytest.fail(
-                f"Read only {response_count} of {expected_count} streaming responses "
-                f"within {deadline_s}s"
+                "Streaming response did not reach the required count and terminal "
+                f"state within {deadline_s}s; count={response_count}, "
+                f"expected={expected_count}"
             )
 
-    # If we get here, stream ended too early
-    pytest.fail(
-        f"Stream ended after only {response_count} lines - expected to read at least {expected_count}"
-    )
+    try:
+        try:
+            for line in response.iter_lines():
+                fail_if_deadline_expired()
+                if not line:
+                    continue
+                if not line.startswith(b"data:"):
+                    logger.debug("Ignoring non-data SSE line: %s", line[:100])
+                    continue
+
+                payload = line.removeprefix(b"data:").strip()
+                if payload == b"[DONE]":
+                    saw_done = True
+                    break
+
+                try:
+                    event = json.loads(payload)
+                except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                    cancellable_req.cancel()
+                    pytest.fail(f"Invalid JSON in streaming response: {error}")
+
+                if not isinstance(event, dict):
+                    cancellable_req.cancel()
+                    pytest.fail(
+                        "Streaming response event must be a JSON object, "
+                        f"got {type(event).__name__}"
+                    )
+
+                if event.get("error") is not None:
+                    cancellable_req.cancel()
+                    pytest.fail(
+                        f"Streaming response ended with an error: {event['error']}"
+                    )
+
+                response_count += 1
+                saw_finish_reason = saw_finish_reason or any(
+                    choice.get("finish_reason") is not None
+                    for choice in event.get("choices", [])
+                )
+                logger.info(
+                    "Received streaming response %s: %.100s", response_count, event
+                )
+                if response_count >= expected_count and not drain:
+                    fail_if_deadline_expired()
+                    logger.info(f"Successfully read {response_count} responses")
+                    return
+        except Exception:
+            fail_if_deadline_expired()
+            raise
+
+        fail_if_deadline_expired()
+        if drain and not saw_done:
+            pytest.fail("Streaming response ended without a [DONE] marker")
+        if drain and not saw_finish_reason:
+            pytest.fail("Streaming response ended without a successful finish reason")
+        if response_count >= expected_count:
+            logger.info(f"Successfully drained {response_count} responses")
+            return
+
+        pytest.fail(
+            "Stream ended after only "
+            f"{response_count} lines - expected to read at least {expected_count}"
+        )
+    finally:
+        if deadline_timer is not None:
+            deadline_timer.cancel()
 
 
 def _parse_frontend_cancellation_metric(

--- a/tests/fault_tolerance/migration/request_utils.py
+++ b/tests/fault_tolerance/migration/request_utils.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request driving and response validation for migration tests."""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+
+import pytest
+from openai import OpenAI
+
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MigrationResponse:
+    """Client-visible response state collected by the request thread."""
+
+    observations: list[tuple[str | None | Exception, float]] = field(
+        default_factory=list
+    )
+    finish_reason: str | None = None
+    completion_tokens: int | None = None
+
+
+def _make_client(frontend_port: int) -> OpenAI:
+    """Build a non-retrying client pointed at the test frontend."""
+    return OpenAI(
+        base_url=f"http://localhost:{frontend_port}/v1",
+        api_key="not-needed",
+        max_retries=0,
+        timeout=240,
+    )
+
+
+def _request_args(
+    *,
+    prompt: str,
+    use_chat_completion: bool,
+    stream: bool,
+    max_tokens: int | None,
+    force_max_output_tokens: bool,
+) -> dict:
+    args = {
+        "model": FAULT_TOLERANCE_MODEL_NAME,
+        "stream": stream,
+        "temperature": 0,
+        "seed": 0,
+    }
+    if use_chat_completion:
+        args["messages"] = [{"role": "user", "content": prompt}]
+    else:
+        args["prompt"] = prompt
+    if max_tokens is not None:
+        args["max_tokens"] = max_tokens
+    if force_max_output_tokens:
+        if max_tokens is None:
+            raise ValueError("force_max_output_tokens requires max_tokens")
+        args["extra_body"] = {"ignore_eos": True, "min_tokens": max_tokens}
+        if stream:
+            args["stream_options"] = {"include_usage": True}
+    return args
+
+
+def start_request(
+    frontend_port: int,
+    *,
+    use_chat_completion: bool,
+    stream: bool,
+    use_long_prompt: bool = False,
+    max_tokens: int | None = None,
+    long_prompt_repetitions: int = 8_000,
+    force_max_output_tokens: bool = False,
+) -> tuple[threading.Thread, MigrationResponse]:
+    """Start one completion or chat-completion request in a background thread."""
+    response = MigrationResponse()
+
+    def send_request() -> None:
+        prompt = "Tell me a long long long story about yourself?"
+        if use_long_prompt:
+            prompt += " Make sure it is" + " long" * long_prompt_repetitions + "!"
+
+        request_api = "chat completion" if use_chat_completion else "completion"
+        logger.info(
+            "Sending %s request (stream=%s) with prompt: '%s...'",
+            request_api,
+            stream,
+            prompt[:50],
+        )
+        response.observations.append((None, time.monotonic()))
+
+        try:
+            client = _make_client(frontend_port)
+            args = _request_args(
+                prompt=prompt,
+                use_chat_completion=use_chat_completion,
+                stream=stream,
+                max_tokens=max_tokens,
+                force_max_output_tokens=force_max_output_tokens,
+            )
+            if stream:
+                chunks = (
+                    client.chat.completions.create(**args)
+                    if use_chat_completion
+                    else client.completions.create(**args)
+                )
+                for chunk in chunks:
+                    if chunk.usage is not None:
+                        response.completion_tokens = chunk.usage.completion_tokens
+                    choice = chunk.choices[0] if chunk.choices else None
+                    if choice is None:
+                        continue
+                    if choice.finish_reason is not None:
+                        response.finish_reason = choice.finish_reason
+                    content = (
+                        choice.delta.content if use_chat_completion else choice.text
+                    )
+                    if content is not None:
+                        response.observations.append((content, time.monotonic()))
+            elif use_chat_completion:
+                result = client.chat.completions.create(**args)
+                choice = result.choices[0]
+                response.finish_reason = choice.finish_reason
+                if result.usage is not None:
+                    response.completion_tokens = result.usage.completion_tokens
+                response.observations.append((choice.message.content, time.monotonic()))
+            else:
+                result = client.completions.create(**args)
+                choice = result.choices[0]
+                response.finish_reason = choice.finish_reason
+                if result.usage is not None:
+                    response.completion_tokens = result.usage.completion_tokens
+                response.observations.append((choice.text, time.monotonic()))
+        except Exception as error:
+            logger.error("Request failed with error: %s", error)
+            response.observations.append((error, time.monotonic()))
+
+    request_thread = threading.Thread(target=send_request, daemon=True)
+    request_thread.start()
+    return request_thread, response
+
+
+def wait_for_response(
+    response: MigrationResponse,
+    num_responses: int = 5,
+    max_wait_time: float = 10.0,
+) -> None:
+    """Block until the request has produced enough non-empty payload chunks."""
+    deadline = time.monotonic() + max_wait_time
+    while time.monotonic() < deadline:
+        content_count = sum(
+            1
+            for content, _ in response.observations
+            if isinstance(content, str) and content
+        )
+        if content_count >= num_responses:
+            return
+        time.sleep(0.001)
+
+    content_count = sum(
+        1
+        for content, _ in response.observations
+        if isinstance(content, str) and content
+    )
+    pytest.fail(
+        f"Only observed {content_count}/{num_responses} non-empty response chunks "
+        f"within {max_wait_time}s"
+    )
+
+
+def validate_response(
+    request_thread: threading.Thread,
+    response: MigrationResponse,
+    expected_completion_tokens: int | None = None,
+    expected_output_prefix: str | None = None,
+) -> str:
+    """Wait for a terminal response and validate its client-visible contract."""
+    request_thread.join(timeout=240)
+    assert not request_thread.is_alive(), "Request did not complete within 240 seconds"
+
+    observations = response.observations
+    assert observations, "Missing first entry with start timestamp"
+    assert observations[0][0] is None, "First entry should be start timestamp only"
+    prev_timestamp = observations[0][1]
+    response_parts: list[str] = []
+
+    for result, timestamp in observations[1:]:
+        delay = timestamp - prev_timestamp
+        if delay > 2.0:
+            logger.info("Observed %.3fs before the next response chunk", delay)
+        prev_timestamp = timestamp
+
+        assert result is not None, "Response entry should not be None"
+        if isinstance(result, Exception):
+            raise result
+        response_parts.append(result)
+
+    assert any(response_parts), "Request completed without non-empty response content"
+    assert (
+        response.finish_reason is not None
+    ), "Request completed without a terminal finish reason"
+    if expected_completion_tokens is not None:
+        assert response.finish_reason == "length", (
+            "Forced-length request terminated unexpectedly: "
+            f"finish_reason={response.finish_reason!r}"
+        )
+        assert response.completion_tokens == expected_completion_tokens, (
+            "Forced-length request returned the wrong completion-token count: "
+            f"expected={expected_completion_tokens}, "
+            f"actual={response.completion_tokens}"
+        )
+
+    output = "".join(response_parts)
+    if expected_output_prefix is not None:
+        assert output.startswith(expected_output_prefix), (
+            "Migrated output diverged from the deterministic fault-free prefix: "
+            f"expected={expected_output_prefix[:100]!r}, actual={output[:100]!r}"
+        )
+    logger.info("Received %s response(s): %s...", len(response_parts), output[:100])
+    return output
+
+
+def request_to_completion(frontend_port: int, **request_options) -> str:
+    """Run one request synchronously through the shared migration request path."""
+    thread, response = start_request(frontend_port, **request_options)
+    expected_tokens = (
+        request_options.get("max_tokens")
+        if request_options.get("force_max_output_tokens")
+        else None
+    )
+    return validate_response(
+        thread, response, expected_completion_tokens=expected_tokens
+    )

--- a/tests/fault_tolerance/migration/request_utils.py
+++ b/tests/fault_tolerance/migration/request_utils.py
@@ -215,10 +215,26 @@ def validate_response(
         )
 
     output = "".join(response_parts)
-    if expected_output_prefix is not None:
-        assert output.startswith(expected_output_prefix), (
-            "Migrated output diverged from the deterministic fault-free prefix: "
-            f"expected={expected_output_prefix[:100]!r}, actual={output[:100]!r}"
+    if expected_output_prefix is not None and not output.startswith(
+        expected_output_prefix
+    ):
+        mismatch_index = next(
+            (
+                index
+                for index, (expected, actual) in enumerate(
+                    zip(expected_output_prefix, output)
+                )
+                if expected != actual
+            ),
+            min(len(expected_output_prefix), len(output)),
+        )
+        context_start = max(0, mismatch_index - 40)
+        context_end = mismatch_index + 80
+        pytest.fail(
+            "Migrated output diverged from the deterministic fault-free prefix "
+            f"at character {mismatch_index}: "
+            f"expected={expected_output_prefix[context_start:context_end]!r}, "
+            f"actual={output[context_start:context_end]!r}"
         )
     logger.info("Received %s response(s): %s...", len(response_parts), output[:100])
     return output

--- a/tests/fault_tolerance/migration/request_utils.py
+++ b/tests/fault_tolerance/migration/request_utils.py
@@ -176,7 +176,6 @@ def validate_response(
     request_thread: threading.Thread,
     response: MigrationResponse,
     expected_completion_tokens: int | None = None,
-    expected_output_prefix: str | None = None,
 ) -> str:
     """Wait for a terminal response and validate its client-visible contract."""
     request_thread.join(timeout=240)
@@ -215,29 +214,31 @@ def validate_response(
         )
 
     output = "".join(response_parts)
-    if expected_output_prefix is not None and not output.startswith(
-        expected_output_prefix
-    ):
-        mismatch_index = next(
-            (
-                index
-                for index, (expected, actual) in enumerate(
-                    zip(expected_output_prefix, output)
-                )
-                if expected != actual
-            ),
-            min(len(expected_output_prefix), len(output)),
-        )
-        context_start = max(0, mismatch_index - 40)
-        context_end = mismatch_index + 80
-        pytest.fail(
-            "Migrated output diverged from the deterministic fault-free prefix "
-            f"at character {mismatch_index}: "
-            f"expected={expected_output_prefix[context_start:context_end]!r}, "
-            f"actual={output[context_start:context_end]!r}"
-        )
     logger.info("Received %s response(s): %s...", len(response_parts), output[:100])
     return output
+
+
+def assert_output_prefix(output: str, expected_prefix: str) -> None:
+    """Require output to preserve a fault-free prefix with useful diagnostics."""
+    if output.startswith(expected_prefix):
+        return
+
+    mismatch_index = next(
+        (
+            index
+            for index, (expected, actual) in enumerate(zip(expected_prefix, output))
+            if expected != actual
+        ),
+        min(len(expected_prefix), len(output)),
+    )
+    context_start = max(0, mismatch_index - 40)
+    context_end = mismatch_index + 80
+    pytest.fail(
+        "Migrated output diverged from the stable fault-free prefix "
+        f"at character {mismatch_index}: "
+        f"expected={expected_prefix[context_start:context_end]!r}, "
+        f"actual={output[context_start:context_end]!r}"
+    )
 
 
 def request_to_completion(frontend_port: int, **request_options) -> str:

--- a/tests/fault_tolerance/migration/request_utils.py
+++ b/tests/fault_tolerance/migration/request_utils.py
@@ -16,6 +16,10 @@ from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 logger = logging.getLogger(__name__)
 
 
+class OutputContinuityError(AssertionError):
+    """A migrated response diverged from its stable fault-free prefix."""
+
+
 @dataclass
 class MigrationResponse:
     """Client-visible response state collected by the request thread."""
@@ -233,7 +237,7 @@ def assert_output_prefix(output: str, expected_prefix: str) -> None:
     )
     context_start = max(0, mismatch_index - 40)
     context_end = mismatch_index + 80
-    pytest.fail(
+    raise OutputContinuityError(
         "Migrated output diverged from the stable fault-free prefix "
         f"at character {mismatch_index}: "
         f"expected={expected_prefix[context_start:context_end]!r}, "

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -1,29 +1,273 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Test Execution Times (Last Run: 2026-01-12):
-- test_request_migration_trtllm_aggregated: ~95s
-- test_request_migration_trtllm_prefill: N/A
-- test_request_migration_trtllm_kv_transfer: N/A
-- test_request_migration_trtllm_decode: N/A
-"""
+"""TensorRT-LLM request-migration fault-tolerance tests."""
 
 import logging
 import os
-import shutil
+import time
+from pathlib import Path
 
 import pytest
+import requests
 
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
+from tests.utils.gpu_args import build_trtllm_override_args
 from tests.utils.managed_process import ManagedProcess, check_health_ready
 from tests.utils.payloads import check_models_api
-from tests.utils.port_utils import allocate_port, deallocate_port
+from tests.utils.port_utils import allocate_port, deallocate_ports
+from tests.utils.prometheus import sum_metric_samples
 
 # Customized utils for migration tests
-from .utils import DynamoFrontendProcess, run_migration_test
+from .utils import (
+    DynamoFrontendProcess,
+    managed_processes_concurrently,
+    run_migration_test,
+    start_chat_completion_request,
+    start_completion_request,
+    validate_response,
+    wait_for_endpoint_instances,
+)
 
 logger = logging.getLogger(__name__)
+
+AGGREGATED_MAX_SEQ_LEN = 4096
+AGGREGATED_MAX_TOKENS = 3072
+AGGREGATED_PROMPT_REPETITIONS = 128
+DECODE_MAX_SEQ_LEN = 4096
+DECODE_MAX_TOKENS = 3072
+KV_TRANSFER_MAX_SEQ_LEN = 2048
+KV_TRANSFER_MAX_TOKENS = 1536
+KV_TRANSFER_PROMPT_REPETITIONS = 128
+
+GRACEFUL_MIGRATION_SKIP = pytest.mark.skip(
+    reason=(
+        "TRT-LLM aggregate/decode graceful shutdown aborts the local request "
+        "without emitting a retryable migration error (1.3.0rc25)"
+    )
+)
+
+# Keep one active worker-failure case for every migration-policy outcome while
+# varying API, response, and request plane. Graceful-shutdown rows remain
+# explicit skips until TRT-LLM emits a retryable migration error.
+MIGRATION_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "completion",
+        True,
+        "nats",
+        id="migration_enabled-no_seq_cap-worker_failure-completion-stream-nats",
+    ),
+    pytest.param(
+        3,
+        None,
+        False,
+        "chat",
+        False,
+        "tcp",
+        marks=GRACEFUL_MIGRATION_SKIP,
+        id="migration_enabled-no_seq_cap-graceful_shutdown-chat-unary-tcp",
+    ),
+    pytest.param(
+        0,
+        None,
+        True,
+        "chat",
+        False,
+        "tcp",
+        id="migration_disabled-worker_failure-chat-unary-tcp",
+    ),
+    pytest.param(
+        0,
+        None,
+        False,
+        "completion",
+        True,
+        "nats",
+        marks=GRACEFUL_MIGRATION_SKIP,
+        id="migration_disabled-graceful_shutdown-completion-stream-nats",
+    ),
+    pytest.param(
+        3,
+        1,
+        True,
+        "completion",
+        True,
+        "tcp",
+        id="max_seq_len_exceeded-worker_failure-completion-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1,
+        False,
+        "chat",
+        False,
+        "nats",
+        marks=GRACEFUL_MIGRATION_SKIP,
+        id="max_seq_len_exceeded-graceful_shutdown-chat-unary-nats",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        True,
+        "completion",
+        False,
+        "nats",
+        id="max_seq_len_not_exceeded-worker_failure-completion-unary-nats",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        False,
+        "chat",
+        True,
+        "tcp",
+        marks=GRACEFUL_MIGRATION_SKIP,
+        id="max_seq_len_not_exceeded-graceful_shutdown-chat-stream-tcp",
+    ),
+]
+
+# Decode migration must be streaming so the fault can be injected after
+# generation starts. Every migration-policy outcome below is runnable.
+DECODE_MIGRATION_CASES = [
+    pytest.param(
+        3,
+        None,
+        True,
+        "completion",
+        "nats",
+        id="migration_enabled-worker_failure-completion-stream-nats",
+    ),
+    pytest.param(
+        0,
+        None,
+        True,
+        "completion",
+        "tcp",
+        id="migration_disabled-worker_failure-completion-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1,
+        True,
+        "chat",
+        "tcp",
+        id="max_seq_len_exceeded-worker-failure-chat-stream-tcp",
+    ),
+    pytest.param(
+        3,
+        1_000_000,
+        True,
+        "chat",
+        "nats",
+        id="max_seq_len_not_exceeded-worker-failure-chat-stream-nats",
+    ),
+]
+
+# KV re-transfer is exercised after the first decode token proves the initial
+# transfer completed. These cases isolate API and request-plane behavior;
+# graceful shutdown remains skipped until TRT-LLM emits a retryable error.
+KV_TRANSFER_CASES = [
+    pytest.param(
+        3, None, True, "chat", True, "nats", id="worker-failure-chat-stream-nats"
+    ),
+    pytest.param(
+        3,
+        None,
+        True,
+        "completion",
+        True,
+        "tcp",
+        id="worker-failure-completion-stream-tcp",
+    ),
+]
+
+MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "stream",
+        "request_plane",
+    ),
+    MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
+DECODE_MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "request_plane",
+    ),
+    DECODE_MIGRATION_CASES,
+    indirect=["request_plane"],
+)
+
+KV_TRANSFER_MIGRATION_PARAMETERS = pytest.mark.parametrize(
+    (
+        "migration_limit",
+        "migration_max_seq_len",
+        "immediate_kill",
+        "request_api",
+        "stream",
+        "request_plane",
+    ),
+    KV_TRANSFER_CASES,
+    indirect=["request_plane"],
+)
+
+
+def read_trtllm_kv_transfer_metrics(worker_system_port: int) -> tuple[float, float]:
+    """Read the worker's successful-transfer count and transferred-byte sum."""
+    response = requests.get(
+        f"http://localhost:{worker_system_port}/metrics", timeout=1
+    )
+    response.raise_for_status()
+    return (
+        sum_metric_samples(response.text, "trtllm_kv_transfer_success_total"),
+        sum_metric_samples(response.text, "trtllm_kv_transfer_bytes_sum"),
+    )
+
+
+def wait_for_trtllm_kv_transfer_success(
+    worker_system_port: int,
+    baseline_count: float,
+    baseline_bytes: float,
+    max_wait_time: float = 10.0,
+) -> None:
+    """Require the replacement decode worker to complete one KV transfer."""
+    deadline = time.monotonic() + max_wait_time
+    transfer_count = 0.0
+    transfer_bytes = 0.0
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            transfer_count, transfer_bytes = read_trtllm_kv_transfer_metrics(
+                worker_system_port
+            )
+            if (
+                transfer_count - baseline_count == 1
+                and transfer_bytes - baseline_bytes > 0
+            ):
+                return
+        except (requests.RequestException, ValueError) as error:
+            last_error = error
+        time.sleep(0.1)
+
+    pytest.fail(
+        "Replacement decode worker did not complete exactly one positive-byte "
+        f"KV transfer; baseline_count={baseline_count}, "
+        f"transfer_count={transfer_count}, baseline_bytes={baseline_bytes}, "
+        f"transfer_bytes={transfer_bytes}, last_error={last_error}"
+    )
+
 
 pytestmark = [
     pytest.mark.fault_tolerance,
@@ -31,42 +275,6 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
-    pytest.mark.parametrize(
-        "migration_limit", [3, 0], ids=["migration_enabled", "migration_disabled"]
-    ),
-    pytest.mark.parametrize(
-        "migration_max_seq_len",
-        [
-            pytest.param(None, id="max_seq_len_disabled"),
-            pytest.param(1_000_000, id="max_seq_len_not_exceeded"),
-            pytest.param(1, id="max_seq_len_exceeded"),
-        ],
-    ),
-    pytest.mark.parametrize(
-        "immediate_kill", [True, False], ids=["worker_failure", "graceful_shutdown"]
-    ),
-    pytest.mark.parametrize(
-        "request_api",
-        [
-            pytest.param("chat"),
-            pytest.param(
-                "completion",
-                marks=pytest.mark.skip(reason="Behavior unverified yet"),
-            ),
-        ],
-    ),
-    pytest.mark.parametrize(
-        "stream",
-        [
-            pytest.param(True, id="stream"),
-            pytest.param(
-                False,
-                id="unary",
-                marks=pytest.mark.skip(reason="Behavior unverified yet"),
-            ),
-        ],
-    ),
-    pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
 ]
 
 
@@ -88,12 +296,27 @@ class DynamoWorkerProcess(ManagedProcess):
         request,
         worker_id: str,
         frontend_port: int,
+        log_root: Path,
         mode: str = "agg",
+        max_seq_len: int = 8192,
+        publish_metrics: bool = False,
+        enable_block_reuse: bool = True,
     ):
         self.worker_id = worker_id
+        allocated_ports: list[int] = []
+        request.addfinalizer(lambda ports=allocated_ports: deallocate_ports(ports))
+
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
-        request.addfinalizer(lambda port=self.system_port: deallocate_port(port))
+        allocated_ports.append(self.system_port)
         self.mode = mode
+
+        env = os.environ.copy()
+        if "_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS" not in env:
+            kv_mark = request.node.get_closest_marker("requested_trtllm_kv_tokens")
+            if kv_mark:
+                env["_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS"] = str(
+                    int(kv_mark.args[0])
+                )
 
         command = [
             "python3",
@@ -104,26 +327,33 @@ class DynamoWorkerProcess(ManagedProcess):
             "--disaggregation-mode",
             mode,
             "--max-seq-len",
-            "8192",
+            str(max_seq_len),
             "--max-num-tokens",
-            "8192",
+            str(max_seq_len),
             "--free-gpu-memory-fraction",
             "0.15",  # avoid validation error on TRT-LLM available memory checks
         ]
         if mode != "agg":
-            config_file = (
-                f"test_request_migration_trtllm_config_{self.system_port}.yaml"
-            )
-            with open(config_file, "w") as f:
+            config_file = log_root / f"trtllm_config_{self.system_port}.yaml"
+            with config_file.open("w") as f:
                 f.write(
-                    "cache_transceiver_config:\n  backend: DEFAULT\n  max_tokens_in_buffer: 8192\n"
+                    "cache_transceiver_config:\n"
+                    "  backend: DEFAULT\n"
+                    f"  max_tokens_in_buffer: {max_seq_len}\n"
                 )
                 f.write("disable_overlap_scheduler: true\n")
-                f.write("kv_cache_config:\n  max_tokens: 8192\n")
-            command += ["--extra-engine-args", config_file]
+                f.write(
+                    "kv_cache_config:\n"
+                    f"  max_tokens: {max_seq_len}\n"
+                )
+                if not enable_block_reuse:
+                    f.write("  enable_block_reuse: false\n")
+            command += ["--extra-engine-args", str(config_file)]
+        if publish_metrics:
+            command.append("--publish-metrics")
+        command.extend(build_trtllm_override_args(env))
 
         # Set environment variables
-        env = os.environ.copy()
         env["DYN_REQUEST_PLANE"] = request.getfixturevalue("request_plane")
 
         env["DYN_LOG"] = "debug"
@@ -148,42 +378,25 @@ class DynamoWorkerProcess(ManagedProcess):
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api)
             )
 
-        # TODO: Have the managed process take a command name explicitly to distinguish
-        #       between processes started with the same command.
-        log_dir = f"{request.node.name}_{worker_id}"
-
-        # Clean up any existing log directory from previous runs
-        try:
-            shutil.rmtree(log_dir)
-            logger.info(f"Cleaned up existing log directory: {log_dir}")
-        except FileNotFoundError:
-            # Directory doesn't exist, which is fine
-            pass
+        log_dir = log_root / worker_id
 
         super().__init__(
             command=command,
             env=env,
             health_check_urls=health_check_urls,
             timeout=300,
-            display_output=True,
+            display_output=False,
             terminate_all_matching_process_names=False,
-            log_dir=log_dir,
+            log_dir=str(log_dir),
             display_name=worker_id,
         )
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Release allocated port when worker exits."""
-        try:
-            # system_port is always allocated in __init__
-            deallocate_port(self.system_port)
-        except Exception as e:
-            logging.warning(f"Failed to release TRT-LLM worker port: {e}")
-
-        return super().__exit__(exc_type, exc_val, exc_tb)
 
 
 @pytest.mark.timeout(290)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(4.7)
+@pytest.mark.requested_trtllm_kv_tokens(4096)
+@MIGRATION_PARAMETERS
 def test_request_migration_trtllm_aggregated(
     request,
     runtime_services_dynamic_ports,
@@ -194,6 +407,7 @@ def test_request_migration_trtllm_aggregated(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for aggregated worker request migration.
@@ -214,111 +428,52 @@ def test_request_migration_trtllm_aggregated(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start 2 workers
-        with DynamoWorkerProcess(request, "worker1", frontend.frontend_port) as worker1:
-            logger.info(f"Worker 1 PID: {worker1.get_pid()}")
-
-            with DynamoWorkerProcess(
-                request,
-                "worker2",
-                frontend.frontend_port,
-            ) as worker2:
-                logger.info(f"Worker 2 PID: {worker2.get_pid()}")
-
-                # Step 3: Run migration test
-                run_migration_test(
-                    frontend,
-                    worker1,
-                    worker2,
-                    receiving_pattern="AggregatedHandler Request ID: ",
-                    migration_limit=migration_limit,
-                    migration_max_seq_len=migration_max_seq_len,
-                    immediate_kill=immediate_kill,
-                    use_chat_completion=(request_api == "chat"),
-                    stream=stream,
-                )
-
-
-@pytest.mark.skip(
-    reason="Prefill migration not yet supported, XFail eats up CI time due to timeout"
-)
-@pytest.mark.timeout(350)  # 3x average
-@pytest.mark.nightly
-def test_request_migration_trtllm_prefill(
-    request,
-    runtime_services_dynamic_ports,
-    set_ucx_tls_no_mm,
-    predownload_models,
-    migration_limit,
-    migration_max_seq_len,
-    immediate_kill,
-    request_api,
-    stream,
-):
-    """
-    End-to-end test for prefill worker request migration in disaggregated mode.
-
-    Setup: 1 decode worker + 2 prefill workers
-
-    Parameters:
-        immediate_kill: True for abrupt kill (SIGKILL), False for graceful shutdown (SIGTERM)
-        migration_limit: > 0 to verify migration succeeds, 0 to verify request fails
-        request_api: "chat" for chat completion API, "completion" for completion API
-        stream: True for streaming, False for non-streaming
-    """
-
-    # Step 1: Start the frontend
-    with DynamoFrontendProcess(
-        request,
-        migration_limit=migration_limit,
-        migration_max_seq_len=migration_max_seq_len,
-    ) as frontend:
-        logger.info("Frontend started successfully")
-
-        # Step 2: Start decode worker first (required for prefill workers to connect)
-        with DynamoWorkerProcess(
+        worker1 = DynamoWorkerProcess(
             request,
-            "worker0",
+            "worker1",
             frontend.frontend_port,
-            mode="decode",
-        ) as decode_worker:
-            logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
-
-            # Step 3: Start 2 prefill workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
+            tmp_path,
+            max_seq_len=AGGREGATED_MAX_SEQ_LEN,
+        )
+        worker2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            max_seq_len=AGGREGATED_MAX_SEQ_LEN,
+        )
+        with managed_processes_concurrently(worker1, worker2):
+            logger.info("Worker 1 PID: %s", worker1.get_pid())
+            logger.info("Worker 2 PID: %s", worker2.get_pid())
+            wait_for_endpoint_instances(
                 frontend.frontend_port,
-                mode="prefill",
-            ) as prefill1:
-                logger.info(f"Prefill Worker 1 PID: {prefill1.get_pid()}")
+                {("backend", "generate"): 2},
+            )
 
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    mode="prefill",
-                ) as prefill2:
-                    logger.info(f"Prefill Worker 2 PID: {prefill2.get_pid()}")
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        prefill1,
-                        prefill2,
-                        receiving_pattern="Prefill Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        use_long_prompt=True,
-                    )
+            run_migration_test(
+                frontend,
+                worker1,
+                worker2,
+                receiving_pattern="AggregatedHandler Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=stream,
+                max_tokens=AGGREGATED_MAX_TOKENS,
+                use_long_prompt=True,
+                long_prompt_repetitions=AGGREGATED_PROMPT_REPETITIONS,
+                expected_ongoing_request_count=1,
+                verify_replacement_worker=True,
+                force_max_output_tokens=True,
+            )
 
 
-@pytest.mark.skip(reason="Decode worker can get stuck downloading kv cache")
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(7.0)
+@pytest.mark.requested_trtllm_kv_tokens(2048)
+@KV_TRANSFER_MIGRATION_PARAMETERS
 def test_request_migration_trtllm_kv_transfer(
     request,
     runtime_services_dynamic_ports,
@@ -329,6 +484,7 @@ def test_request_migration_trtllm_kv_transfer(
     immediate_kill,
     request_api,
     stream,
+    tmp_path,
 ):
     """
     End-to-end test for request migration during KV transfer in disaggregated mode.
@@ -350,49 +506,97 @@ def test_request_migration_trtllm_kv_transfer(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start prefill worker first
-        with DynamoWorkerProcess(
+        prefill_worker = DynamoWorkerProcess(
             request,
             "worker0",
             frontend.frontend_port,
+            tmp_path,
             mode="prefill",
-        ) as prefill_worker:
-            logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
-
-            # Step 3: Start 2 decode workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
+            max_seq_len=KV_TRANSFER_MAX_SEQ_LEN,
+            enable_block_reuse=False,
+        )
+        decode1 = DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            mode="decode",
+            max_seq_len=KV_TRANSFER_MAX_SEQ_LEN,
+            publish_metrics=True,
+            enable_block_reuse=False,
+        )
+        decode2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            mode="decode",
+            max_seq_len=KV_TRANSFER_MAX_SEQ_LEN,
+            publish_metrics=True,
+            enable_block_reuse=False,
+        )
+        with managed_processes_concurrently(prefill_worker, decode1, decode2):
+            logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
+            logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+            logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
+            wait_for_endpoint_instances(
                 frontend.frontend_port,
-                mode="decode",
-            ) as decode1:
-                logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
+                {("prefill", "generate"): 1, ("backend", "generate"): 2},
+            )
 
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    mode="decode",
-                ) as decode2:
-                    logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
+            start_reference_request = (
+                start_chat_completion_request
+                if request_api == "chat"
+                else start_completion_request
+            )
+            reference_thread, reference_response = start_reference_request(
+                frontend.frontend_port,
+                stream=stream,
+                use_long_prompt=True,
+                max_tokens=KV_TRANSFER_MAX_TOKENS,
+                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
+                force_max_output_tokens=True,
+            )
+            reference_text = validate_response(
+                reference_thread,
+                reference_response,
+                expected_completion_tokens=KV_TRANSFER_MAX_TOKENS,
+            )
+            transfer_baselines = {
+                worker.system_port: read_trtllm_kv_transfer_metrics(worker.system_port)
+                for worker in (decode1, decode2)
+            }
 
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        decode1,
-                        decode2,
-                        receiving_pattern="Decode Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        use_long_prompt=True,
-                    )
+            replacement_worker = run_migration_test(
+                frontend,
+                decode1,
+                decode2,
+                receiving_pattern="Decode Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=stream,
+                max_tokens=KV_TRANSFER_MAX_TOKENS,
+                use_long_prompt=True,
+                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
+                wait_for_new_response_before_stop=True,
+                expected_ongoing_request_count=1,
+                verify_replacement_worker=True,
+                force_max_output_tokens=True,
+                expected_response_text=reference_text,
+            )
+            wait_for_trtllm_kv_transfer_success(
+                replacement_worker.system_port,
+                *transfer_baselines[replacement_worker.system_port],
+            )
 
 
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(7.0)
+@pytest.mark.requested_trtllm_kv_tokens(4096)
+@DECODE_MIGRATION_PARAMETERS
 def test_request_migration_trtllm_decode(
     request,
     runtime_services_dynamic_ports,
@@ -402,7 +606,7 @@ def test_request_migration_trtllm_decode(
     migration_max_seq_len,
     immediate_kill,
     request_api,
-    stream,
+    tmp_path,
 ):
     """
     End-to-end test for decode worker request migration in disaggregated mode.
@@ -415,11 +619,6 @@ def test_request_migration_trtllm_decode(
         request_api: "chat" for chat completion API, "completion" for completion API
         stream: True for streaming, False for non-streaming
     """
-    if not stream:
-        pytest.skip(
-            "Decode test requires streaming to wait for response before stopping worker"
-        )
-
     # Step 1: Start the frontend
     with DynamoFrontendProcess(
         request,
@@ -428,42 +627,52 @@ def test_request_migration_trtllm_decode(
     ) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start prefill worker first
-        with DynamoWorkerProcess(
+        prefill_worker = DynamoWorkerProcess(
             request,
             "worker0",
             frontend.frontend_port,
+            tmp_path,
             mode="prefill",
-        ) as prefill_worker:
-            logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
-
-            # Step 3: Start 2 decode workers
-            with DynamoWorkerProcess(
-                request,
-                "worker1",
+            max_seq_len=DECODE_MAX_SEQ_LEN,
+        )
+        decode1 = DynamoWorkerProcess(
+            request,
+            "worker1",
+            frontend.frontend_port,
+            tmp_path,
+            mode="decode",
+            max_seq_len=DECODE_MAX_SEQ_LEN,
+        )
+        decode2 = DynamoWorkerProcess(
+            request,
+            "worker2",
+            frontend.frontend_port,
+            tmp_path,
+            mode="decode",
+            max_seq_len=DECODE_MAX_SEQ_LEN,
+        )
+        with managed_processes_concurrently(prefill_worker, decode1, decode2):
+            logger.info("Prefill Worker PID: %s", prefill_worker.get_pid())
+            logger.info("Decode Worker 1 PID: %s", decode1.get_pid())
+            logger.info("Decode Worker 2 PID: %s", decode2.get_pid())
+            wait_for_endpoint_instances(
                 frontend.frontend_port,
-                mode="decode",
-            ) as decode1:
-                logger.info(f"Decode Worker 1 PID: {decode1.get_pid()}")
+                {("prefill", "generate"): 1, ("backend", "generate"): 2},
+            )
 
-                with DynamoWorkerProcess(
-                    request,
-                    "worker2",
-                    frontend.frontend_port,
-                    mode="decode",
-                ) as decode2:
-                    logger.info(f"Decode Worker 2 PID: {decode2.get_pid()}")
-
-                    # Step 4: Run migration test
-                    run_migration_test(
-                        frontend,
-                        decode1,
-                        decode2,
-                        receiving_pattern="Decode Request ID: ",
-                        migration_limit=migration_limit,
-                        migration_max_seq_len=migration_max_seq_len,
-                        immediate_kill=immediate_kill,
-                        use_chat_completion=(request_api == "chat"),
-                        stream=stream,
-                        wait_for_new_response_before_stop=True,
-                    )
+            run_migration_test(
+                frontend,
+                decode1,
+                decode2,
+                receiving_pattern="Decode Request ID: ",
+                migration_limit=migration_limit,
+                migration_max_seq_len=migration_max_seq_len,
+                immediate_kill=immediate_kill,
+                use_chat_completion=(request_api == "chat"),
+                stream=True,
+                max_tokens=DECODE_MAX_TOKENS,
+                wait_for_new_response_before_stop=True,
+                expected_ongoing_request_count=1,
+                verify_replacement_worker=True,
+                force_max_output_tokens=True,
+            )

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -23,9 +23,6 @@ from .utils import (
     DynamoFrontendProcess,
     managed_processes_concurrently,
     run_migration_test,
-    start_chat_completion_request,
-    start_completion_request,
-    validate_response,
     wait_for_endpoint_instances,
 )
 
@@ -394,7 +391,7 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(290)  # 3x average
 @pytest.mark.nightly
-@pytest.mark.profiled_vram_gib(4.7)
+@pytest.mark.profiled_vram_gib(7.2)
 @pytest.mark.requested_trtllm_kv_tokens(4096)
 @MIGRATION_PARAMETERS
 def test_request_migration_trtllm_aggregated(
@@ -471,7 +468,7 @@ def test_request_migration_trtllm_aggregated(
 
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
-@pytest.mark.profiled_vram_gib(7.0)
+@pytest.mark.profiled_vram_gib(10.4)
 @pytest.mark.requested_trtllm_kv_tokens(2048)
 @KV_TRANSFER_MIGRATION_PARAMETERS
 def test_request_migration_trtllm_kv_transfer(
@@ -544,24 +541,6 @@ def test_request_migration_trtllm_kv_transfer(
                 {("prefill", "generate"): 1, ("backend", "generate"): 2},
             )
 
-            start_reference_request = (
-                start_chat_completion_request
-                if request_api == "chat"
-                else start_completion_request
-            )
-            reference_thread, reference_response = start_reference_request(
-                frontend.frontend_port,
-                stream=stream,
-                use_long_prompt=True,
-                max_tokens=KV_TRANSFER_MAX_TOKENS,
-                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
-                force_max_output_tokens=True,
-            )
-            reference_text = validate_response(
-                reference_thread,
-                reference_response,
-                expected_completion_tokens=KV_TRANSFER_MAX_TOKENS,
-            )
             transfer_baselines = {
                 worker.system_port: read_trtllm_kv_transfer_metrics(worker.system_port)
                 for worker in (decode1, decode2)
@@ -584,7 +563,6 @@ def test_request_migration_trtllm_kv_transfer(
                 expected_ongoing_request_count=1,
                 verify_replacement_worker=True,
                 force_max_output_tokens=True,
-                expected_response_text=reference_text,
             )
             wait_for_trtllm_kv_transfer_success(
                 replacement_worker.system_port,
@@ -594,7 +572,7 @@ def test_request_migration_trtllm_kv_transfer(
 
 @pytest.mark.timeout(350)  # 3x average
 @pytest.mark.nightly
-@pytest.mark.profiled_vram_gib(7.0)
+@pytest.mark.profiled_vram_gib(12.6)
 @pytest.mark.requested_trtllm_kv_tokens(4096)
 @DECODE_MIGRATION_PARAMETERS
 def test_request_migration_trtllm_decode(

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -37,6 +37,7 @@ DECODE_MAX_TOKENS = 3072
 KV_TRANSFER_MAX_SEQ_LEN = 2048
 KV_TRANSFER_MAX_TOKENS = 1536
 KV_TRANSFER_BASELINE_MAX_TOKENS = 256
+KV_TRANSFER_BASELINE_REQUESTS = 3
 KV_TRANSFER_PROMPT_REPETITIONS = 128
 
 # Keep one active worker-failure case for every migration-policy outcome while
@@ -490,18 +491,22 @@ def test_request_migration_trtllm_kv_transfer(
                 {("prefill", "generate"): 1, ("backend", "generate"): 2},
             )
 
-            # The fault is injected after five streamed chunks. A 256-token
-            # reference therefore checks deterministic continuation beyond it
-            # without paying for a second full-length generation.
-            baseline_output = request_to_completion(
-                frontend.frontend_port,
-                use_chat_completion=(request_api == "chat"),
-                stream=stream,
-                max_tokens=KV_TRANSFER_BASELINE_MAX_TOKENS,
-                use_long_prompt=True,
-                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
-                force_max_output_tokens=True,
-            )
+            # GPU model output can diverge despite fixed sampling parameters.
+            # Characterize the stable prefix across both round-robin decode
+            # workers, then require migration to preserve it past the fault.
+            baseline_outputs = [
+                request_to_completion(
+                    frontend.frontend_port,
+                    use_chat_completion=(request_api == "chat"),
+                    stream=stream,
+                    max_tokens=KV_TRANSFER_BASELINE_MAX_TOKENS,
+                    use_long_prompt=True,
+                    long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
+                    force_max_output_tokens=True,
+                )
+                for _ in range(KV_TRANSFER_BASELINE_REQUESTS)
+            ]
+            stable_output_prefix = os.path.commonprefix(baseline_outputs)
 
             transfer_baselines = {
                 worker.system_port: read_trtllm_kv_transfer_metrics(worker.system_port)
@@ -525,7 +530,7 @@ def test_request_migration_trtllm_kv_transfer(
                 expected_ongoing_request_count=1,
                 verify_replacement_worker=True,
                 force_max_output_tokens=True,
-                expected_output_prefix=baseline_output,
+                expected_output_prefix=stable_output_prefix,
             )
             wait_for_trtllm_kv_transfer_success(
                 replacement_worker.system_port,

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -19,7 +19,11 @@ from tests.utils.port_utils import allocate_port, deallocate_ports
 from tests.utils.prometheus import sum_metric_samples
 
 # Customized utils for migration tests
-from .request_utils import assert_output_prefix, request_to_completion
+from .request_utils import (
+    OutputContinuityError,
+    assert_output_prefix,
+    request_to_completion,
+)
 from .utils import (
     DynamoFrontendProcess,
     managed_processes_concurrently,
@@ -132,6 +136,14 @@ KV_TRANSFER_CASES = [
         "completion",
         True,
         "tcp",
+        marks=pytest.mark.xfail(
+            reason=(
+                "Known TensorRT-LLM 1.3.0rc25 KV-migration output-continuity "
+                "failure; tracked in https://github.com/ai-dynamo/dynamo/pull/14609"
+            ),
+            raises=OutputContinuityError,
+            strict=False,
+        ),
         id="worker-failure-completion-stream-tcp",
     ),
 ]

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -19,6 +19,7 @@ from tests.utils.port_utils import allocate_port, deallocate_ports
 from tests.utils.prometheus import sum_metric_samples
 
 # Customized utils for migration tests
+from .request_utils import request_to_completion
 from .utils import (
     DynamoFrontendProcess,
     managed_processes_concurrently,
@@ -35,6 +36,7 @@ DECODE_MAX_SEQ_LEN = 4096
 DECODE_MAX_TOKENS = 3072
 KV_TRANSFER_MAX_SEQ_LEN = 2048
 KV_TRANSFER_MAX_TOKENS = 1536
+KV_TRANSFER_BASELINE_MAX_TOKENS = 256
 KV_TRANSFER_PROMPT_REPETITIONS = 128
 
 GRACEFUL_MIGRATION_SKIP = pytest.mark.skip(
@@ -536,6 +538,19 @@ def test_request_migration_trtllm_kv_transfer(
                 {("prefill", "generate"): 1, ("backend", "generate"): 2},
             )
 
+            # The fault is injected after five streamed chunks. A 256-token
+            # reference therefore checks deterministic continuation beyond it
+            # without paying for a second full-length generation.
+            baseline_output = request_to_completion(
+                frontend.frontend_port,
+                use_chat_completion=(request_api == "chat"),
+                stream=stream,
+                max_tokens=KV_TRANSFER_BASELINE_MAX_TOKENS,
+                use_long_prompt=True,
+                long_prompt_repetitions=KV_TRANSFER_PROMPT_REPETITIONS,
+                force_max_output_tokens=True,
+            )
+
             transfer_baselines = {
                 worker.system_port: read_trtllm_kv_transfer_metrics(worker.system_port)
                 for worker in (decode1, decode2)
@@ -558,6 +573,7 @@ def test_request_migration_trtllm_kv_transfer(
                 expected_ongoing_request_count=1,
                 verify_replacement_worker=True,
                 force_max_output_tokens=True,
+                expected_output_prefix=baseline_output,
             )
             wait_for_trtllm_kv_transfer_success(
                 replacement_worker.system_port,

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -222,9 +222,7 @@ KV_TRANSFER_MIGRATION_PARAMETERS = pytest.mark.parametrize(
 
 def read_trtllm_kv_transfer_metrics(worker_system_port: int) -> tuple[float, float]:
     """Read the worker's successful-transfer count and transferred-byte sum."""
-    response = requests.get(
-        f"http://localhost:{worker_system_port}/metrics", timeout=1
-    )
+    response = requests.get(f"http://localhost:{worker_system_port}/metrics", timeout=1)
     response.raise_for_status()
     return (
         sum_metric_samples(response.text, "trtllm_kv_transfer_success_total"),
@@ -339,10 +337,7 @@ class DynamoWorkerProcess(ManagedProcess):
                     f"  max_tokens_in_buffer: {max_seq_len}\n"
                 )
                 f.write("disable_overlap_scheduler: true\n")
-                f.write(
-                    "kv_cache_config:\n"
-                    f"  max_tokens: {max_seq_len}\n"
-                )
+                f.write("kv_cache_config:\n" f"  max_tokens: {max_seq_len}\n")
                 if not enable_block_reuse:
                     f.write("  enable_block_reuse: false\n")
             command += ["--extra-engine-args", str(config_file)]

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -39,16 +39,8 @@ KV_TRANSFER_MAX_TOKENS = 1536
 KV_TRANSFER_BASELINE_MAX_TOKENS = 256
 KV_TRANSFER_PROMPT_REPETITIONS = 128
 
-GRACEFUL_MIGRATION_SKIP = pytest.mark.skip(
-    reason=(
-        "TRT-LLM aggregate/decode graceful shutdown aborts the local request "
-        "without emitting a retryable migration error (1.3.0rc25)"
-    )
-)
-
 # Keep one active worker-failure case for every migration-policy outcome while
-# varying API, response, and request plane. Graceful-shutdown rows remain
-# explicit skips until TRT-LLM emits a retryable migration error.
+# varying API, response, and request plane.
 MIGRATION_CASES = [
     pytest.param(
         3,
@@ -60,16 +52,6 @@ MIGRATION_CASES = [
         id="migration_enabled-no_seq_cap-worker_failure-completion-stream-nats",
     ),
     pytest.param(
-        3,
-        None,
-        False,
-        "chat",
-        False,
-        "tcp",
-        marks=GRACEFUL_MIGRATION_SKIP,
-        id="migration_enabled-no_seq_cap-graceful_shutdown-chat-unary-tcp",
-    ),
-    pytest.param(
         0,
         None,
         True,
@@ -77,16 +59,6 @@ MIGRATION_CASES = [
         False,
         "tcp",
         id="migration_disabled-worker_failure-chat-unary-tcp",
-    ),
-    pytest.param(
-        0,
-        None,
-        False,
-        "completion",
-        True,
-        "nats",
-        marks=GRACEFUL_MIGRATION_SKIP,
-        id="migration_disabled-graceful_shutdown-completion-stream-nats",
     ),
     pytest.param(
         3,
@@ -99,16 +71,6 @@ MIGRATION_CASES = [
     ),
     pytest.param(
         3,
-        1,
-        False,
-        "chat",
-        False,
-        "nats",
-        marks=GRACEFUL_MIGRATION_SKIP,
-        id="max_seq_len_exceeded-graceful_shutdown-chat-unary-nats",
-    ),
-    pytest.param(
-        3,
         1_000_000,
         True,
         "completion",
@@ -116,20 +78,10 @@ MIGRATION_CASES = [
         "nats",
         id="max_seq_len_not_exceeded-worker_failure-completion-unary-nats",
     ),
-    pytest.param(
-        3,
-        1_000_000,
-        False,
-        "chat",
-        True,
-        "tcp",
-        marks=GRACEFUL_MIGRATION_SKIP,
-        id="max_seq_len_not_exceeded-graceful_shutdown-chat-stream-tcp",
-    ),
 ]
 
 # Decode migration must be streaming so the fault can be injected after
-# generation starts. Every migration-policy outcome below is runnable.
+# generation starts.
 DECODE_MIGRATION_CASES = [
     pytest.param(
         3,

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -19,7 +19,7 @@ from tests.utils.port_utils import allocate_port, deallocate_ports
 from tests.utils.prometheus import sum_metric_samples
 
 # Customized utils for migration tests
-from .request_utils import request_to_completion
+from .request_utils import assert_output_prefix, request_to_completion
 from .utils import (
     DynamoFrontendProcess,
     managed_processes_concurrently,
@@ -513,7 +513,7 @@ def test_request_migration_trtllm_kv_transfer(
                 for worker in (decode1, decode2)
             }
 
-            replacement_worker = run_migration_test(
+            replacement_worker, migrated_output = run_migration_test(
                 frontend,
                 decode1,
                 decode2,
@@ -536,6 +536,8 @@ def test_request_migration_trtllm_kv_transfer(
                 replacement_worker.system_port,
                 *transfer_baselines[replacement_worker.system_port],
             )
+            assert migrated_output is not None
+            assert_output_prefix(migrated_output, stable_output_prefix)
 
 
 @pytest.mark.timeout(350)  # 3x average

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import re
 import threading
 import time
 from collections.abc import Callable, Iterator
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
+from dataclasses import dataclass, field
 
 import pytest
 import requests
@@ -23,6 +25,17 @@ from tests.utils.prometheus import sum_metric_samples
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class MigrationResponse:
+    """Client-visible response state collected by the request thread."""
+
+    observations: list[tuple[str | None | Exception, float]] = field(
+        default_factory=list
+    )
+    finish_reason: str | None = None
+    completion_tokens: int | None = None
+
+
 @contextmanager
 def managed_processes_concurrently(
     *processes: ManagedProcess,
@@ -33,24 +46,72 @@ def managed_processes_concurrently(
         return
 
     entered: list[ManagedProcess | None] = [None] * len(processes)
-    startup_error: BaseException | None = None
-    with ThreadPoolExecutor(max_workers=len(processes)) as executor:
-        futures = [executor.submit(process.__enter__) for process in processes]
-        for index, future in enumerate(futures):
+    startup_cancelled = threading.Event()
+    entered_lock = threading.Lock()
+
+    def enter_process(index: int, process: ManagedProcess) -> ManagedProcess:
+        entered_process = process.__enter__()
+        with entered_lock:
+            if startup_cancelled.is_set():
+                cleanup_immediately = True
+            else:
+                entered[index] = entered_process
+                cleanup_immediately = False
+
+        if cleanup_immediately:
             try:
-                entered[index] = future.result()
-            except BaseException as error:
-                if startup_error is None:
-                    startup_error = error
+                entered_process.__exit__(None, None, None)
+            except Exception:
+                logger.exception("Failed to clean up a late-starting process")
+        return entered_process
+
+    executor = ThreadPoolExecutor(max_workers=len(processes))
+    futures = [
+        executor.submit(enter_process, index, process)
+        for index, process in enumerate(processes)
+    ]
+
+    def cancel_startup(*, terminate_in_progress: bool = False) -> None:
+        startup_cancelled.set()
+        for future in futures:
+            future.cancel()
+        with entered_lock:
+            started = [process for process in entered if process is not None]
+            entered[:] = [None] * len(processes)
+        for process in reversed(started):
+            try:
+                process.__exit__(None, None, None)
+            except Exception:
+                logger.exception("Failed to clean up a concurrently started process")
+        if terminate_in_progress:
+            for process, future in zip(processes, futures, strict=True):
+                if future.done() or process in started:
+                    continue
+                try:
+                    process.__exit__(None, None, None)
+                except Exception:
+                    logger.exception("Failed to terminate a process during startup")
+        # Wait until every startup task has either observed the terminated child
+        # or cleaned up a late start. This prevents fixture/port teardown from
+        # racing a worker that is still inside ManagedProcess.__enter__().
+        executor.shutdown(wait=True, cancel_futures=True)
+
+    try:
+        for future in as_completed(futures):
+            future.result()
+    except Exception:
+        cancel_startup()
+        raise
+    except BaseException:
+        cancel_startup(terminate_in_progress=True)
+        raise
+    else:
+        executor.shutdown(wait=True)
 
     with ExitStack() as stack:
         for process in entered:
             if process is not None:
                 stack.callback(process.__exit__, None, None, None)
-
-        if startup_error is not None:
-            raise startup_error
-
         yield tuple(process for process in entered if process is not None)
 
 
@@ -104,12 +165,13 @@ def start_completion_request(
     max_tokens: int | None = None,
     long_prompt_repetitions: int = 8_000,
     force_max_output_tokens: bool = False,
-) -> tuple:
+) -> tuple[threading.Thread, MigrationResponse]:
     """
     Start a long-running completion request in a separate thread.
 
-    Responses are processed internally to extract content. First entry is (None, start_time)
-    to mark when request was sent. Subsequent entries contain extracted content or exceptions.
+    Responses are processed internally to extract content and terminal metadata.
+    The first observation is ``(None, start_time)``; subsequent observations
+    contain extracted content or exceptions.
 
     Args:
         frontend_port: Port where the frontend is running
@@ -121,12 +183,9 @@ def start_completion_request(
             budget. Requires max_tokens.
 
     Returns:
-        tuple: (request_thread, response_list) where response_list contains
-               (str | None | Exception, float) tuples.
-               - For streaming: each entry is (content_word, timestamp)
-               - For non-streaming: single entry is (full_content, timestamp)
+        The request thread and its shared response state.
     """
-    response_list: list[tuple[str | None | Exception, float]] = []
+    response = MigrationResponse()
 
     def send_request():
         prompt = "Tell me a long long long story about yourself?"
@@ -139,7 +198,7 @@ def start_completion_request(
             prompt[:50],
         )
 
-        response_list.append((None, time.monotonic()))  # start observation
+        response.observations.append((None, time.monotonic()))
 
         try:
             client = _make_client(frontend_port)
@@ -159,28 +218,39 @@ def start_completion_request(
                     "ignore_eos": True,
                     "min_tokens": max_tokens,
                 }
+                if stream:
+                    request_args["stream_options"] = {"include_usage": True}
             if stream:
                 for chunk in client.completions.create(**request_args):
-                    text = chunk.choices[0].text if chunk.choices else None
+                    if chunk.usage is not None:
+                        response.completion_tokens = chunk.usage.completion_tokens
+                    choice = chunk.choices[0] if chunk.choices else None
+                    if choice is not None and choice.finish_reason is not None:
+                        response.finish_reason = choice.finish_reason
+                    text = choice.text if choice is not None else None
                     # Match the original hand-rolled parser: keep empty strings,
                     # drop only None. Empty chunks (e.g. the first stream frame)
                     # still count as a response arrival for delay measurement.
                     if text is not None:
-                        response_list.append((text, time.monotonic()))
+                        response.observations.append((text, time.monotonic()))
             else:
                 resp = client.completions.create(**request_args)
-                response_list.append((resp.choices[0].text, time.monotonic()))
+                choice = resp.choices[0]
+                response.finish_reason = choice.finish_reason
+                if resp.usage is not None:
+                    response.completion_tokens = resp.usage.completion_tokens
+                response.observations.append((choice.text, time.monotonic()))
         except Exception as error:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions (network, etc.) also bubble.
             logger.error("Request failed with error: %s", error)
-            response_list.append((error, time.monotonic()))
+            response.observations.append((error, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
 
-    return request_thread, response_list
+    return request_thread, response
 
 
 def start_chat_completion_request(
@@ -190,12 +260,13 @@ def start_chat_completion_request(
     max_tokens: int | None = None,
     long_prompt_repetitions: int = 8_000,
     force_max_output_tokens: bool = False,
-) -> tuple:
+) -> tuple[threading.Thread, MigrationResponse]:
     """
     Start a long-running chat completion request in a separate thread.
 
-    Responses are processed internally to extract content. First entry is (None, start_time)
-    to mark when request was sent. Subsequent entries contain extracted content or exceptions.
+    Responses are processed internally to extract content and terminal metadata.
+    The first observation is ``(None, start_time)``; subsequent observations
+    contain extracted content or exceptions.
 
     Args:
         frontend_port: Port where the frontend is running
@@ -207,12 +278,9 @@ def start_chat_completion_request(
             budget. Requires max_tokens.
 
     Returns:
-        tuple: (request_thread, response_list) where response_list contains
-               (str | None | Exception, float) tuples.
-               - For streaming: each entry is (content_word, timestamp)
-               - For non-streaming: single entry is (full_content, timestamp)
+        The request thread and its shared response state.
     """
-    response_list: list[tuple[str | None | Exception, float]] = []
+    response = MigrationResponse()
 
     def send_request():
         prompt = "Tell me a long long long story about yourself?"
@@ -225,7 +293,7 @@ def start_chat_completion_request(
             prompt[:50],
         )
 
-        response_list.append((None, time.monotonic()))  # start observation
+        response.observations.append((None, time.monotonic()))
 
         try:
             client = _make_client(frontend_port)
@@ -245,35 +313,49 @@ def start_chat_completion_request(
                     "ignore_eos": True,
                     "min_tokens": max_tokens,
                 }
+                if stream:
+                    request_args["stream_options"] = {"include_usage": True}
             if stream:
                 for chunk in client.chat.completions.create(**request_args):
-                    content = chunk.choices[0].delta.content if chunk.choices else None
+                    if chunk.usage is not None:
+                        response.completion_tokens = chunk.usage.completion_tokens
+                    choice = chunk.choices[0] if chunk.choices else None
+                    if choice is not None and choice.finish_reason is not None:
+                        response.finish_reason = choice.finish_reason
+                    content = choice.delta.content if choice is not None else None
                     # Match the original hand-rolled parser: keep empty strings,
                     # drop only None. Empty chunks (e.g. the first `role`-only
                     # stream frame) still count as a response arrival for delay
                     # measurement.
                     if content is not None:
-                        response_list.append((content, time.monotonic()))
+                        response.observations.append((content, time.monotonic()))
             else:
                 resp = client.chat.completions.create(**request_args)
-                response_list.append(
-                    (resp.choices[0].message.content, time.monotonic())
+                choice = resp.choices[0]
+                response.finish_reason = choice.finish_reason
+                if resp.usage is not None:
+                    response.completion_tokens = resp.usage.completion_tokens
+                response.observations.append(
+                    (choice.message.content, time.monotonic())
                 )
         except Exception as error:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
             # and timeouts. Non-openai exceptions also bubble for visibility.
             logger.error("Request failed with error: %s", error)
-            response_list.append((error, time.monotonic()))
+            response.observations.append((error, time.monotonic()))
 
     request_thread = threading.Thread(target=send_request, daemon=True)
     request_thread.start()
 
-    return request_thread, response_list
+    return request_thread, response
 
 
 def determine_request_receiving_worker(
-    worker1: ManagedProcess, worker2: ManagedProcess, receiving_pattern: str
+    worker1: ManagedProcess,
+    worker2: ManagedProcess,
+    receiving_pattern: str,
+    log_offsets: tuple[int, int] = (0, 0),
 ) -> tuple[ManagedProcess, str, str]:
     """
     Determine which worker received the request while inspecting both logs together.
@@ -297,10 +379,11 @@ def determine_request_receiving_worker(
     request_re = re.compile(re.escape(receiving_pattern) + r"(?P<request_id>\S+)")
     poll_event = threading.Event()
 
-    def request_ids(worker: ManagedProcess) -> list[str]:
+    def request_ids(worker: ManagedProcess, log_offset: int) -> list[str]:
         try:
-            with open(worker.log_path, "r") as log_file:
-                return request_re.findall(log_file.read())
+            with open(worker.log_path, "rb") as log_file:
+                log_file.seek(log_offset)
+                return request_re.findall(log_file.read().decode(errors="ignore"))
         except FileNotFoundError:
             return []
         except OSError as error:
@@ -311,8 +394,8 @@ def determine_request_receiving_worker(
     last_worker1_ids: list[str] = []
     last_worker2_ids: list[str] = []
     while time.monotonic() < deadline:
-        last_worker1_ids = request_ids(worker1)
-        last_worker2_ids = request_ids(worker2)
+        last_worker1_ids = request_ids(worker1, log_offsets[0])
+        last_worker2_ids = request_ids(worker2, log_offsets[1])
 
         if last_worker1_ids and last_worker2_ids:
             pytest.fail(
@@ -464,7 +547,7 @@ def wait_for_endpoint_instance_reduction(
 
 
 def wait_for_response(
-    response_list: list[tuple[str | None | Exception, float]],
+    response: MigrationResponse,
     num_responses: int = 5,
     max_wait_time: float = 10.0,
 ) -> None:
@@ -472,7 +555,7 @@ def wait_for_response(
     Block until at least ``num_responses`` non-empty payload chunks exist.
 
     Args:
-        response_list: List being populated by background thread
+        response: Response state being populated by the background thread
         num_responses: Absolute minimum number of non-empty payload chunks (default 5)
         max_wait_time: Maximum time to wait in seconds (default 10s)
     """
@@ -481,14 +564,18 @@ def wait_for_response(
 
     while time.monotonic() < deadline:
         content_count = sum(
-            1 for response, _ in response_list if isinstance(response, str) and response
+            1
+            for content, _ in response.observations
+            if isinstance(content, str) and content
         )
         if content_count >= num_responses:
             return
         time.sleep(poll_interval)
 
     content_count = sum(
-        1 for response, _ in response_list if isinstance(response, str) and response
+        1
+        for content, _ in response.observations
+        if isinstance(content, str) and content
     )
     pytest.fail(
         f"Only observed {content_count}/{num_responses} non-empty response chunks "
@@ -544,8 +631,9 @@ def wait_for_worker_generate_completion(
 
 def validate_response(
     request_thread: threading.Thread,
-    response_list: list[tuple[str | None | Exception, float]],
-) -> None:
+    response: MigrationResponse,
+    expected_completion_tokens: int | None = None,
+) -> str:
     """
     Wait for and validate the response after migration.
     Timing observations are logged for diagnosis, but they are not correctness
@@ -554,18 +642,20 @@ def validate_response(
 
     Args:
         request_thread: The thread running the request
-        response_list: List of (content_string | None | Exception, timestamp) tuples.
-                       Content is already parsed - no SSE format parsing needed.
+        response: Client-visible content and terminal response metadata.
+        expected_completion_tokens: When set, require a length-limited response
+            with exactly this many completion tokens.
     """
     request_thread.join(timeout=240)
     assert not request_thread.is_alive(), "Request did not complete within 240 seconds"
 
-    assert len(response_list) > 0, "Missing first entry with start timestamp"
-    assert response_list[0][0] is None, "First entry should be start timestamp only"
-    prev_timestamp = response_list[0][1]
+    observations = response.observations
+    assert observations, "Missing first entry with start timestamp"
+    assert observations[0][0] is None, "First entry should be start timestamp only"
+    prev_timestamp = observations[0][1]
 
     response_words: list[str] = []
-    for res, timestamp in response_list[1:]:
+    for res, timestamp in observations[1:]:
         delay = timestamp - prev_timestamp
         if delay > 2.0:
             logger.info("Observed %.3fs before the next response chunk", delay)
@@ -578,12 +668,26 @@ def validate_response(
         # Content is already parsed - just collect it
         response_words.append(res)
 
-    assert response_words, "Request completed without any response content"
+    assert any(response_words), "Request completed without any non-empty response content"
+    assert response.finish_reason is not None, (
+        "Request completed without a terminal finish reason"
+    )
+    if expected_completion_tokens is not None:
+        assert response.finish_reason == "length", (
+            "Forced-length request terminated unexpectedly: "
+            f"finish_reason={response.finish_reason!r}"
+        )
+        assert response.completion_tokens == expected_completion_tokens, (
+            "Forced-length request returned the wrong completion-token count: "
+            f"expected={expected_completion_tokens}, "
+            f"actual={response.completion_tokens}"
+        )
     logger.info(
         "Received %s response(s): %s...",
         len(response_words),
         "".join(response_words)[:100],
     )
+    return "".join(response_words)
 
 
 def _parse_migration_metric(
@@ -728,7 +832,8 @@ def run_migration_test(
     verify_replacement_worker: bool = False,
     before_worker_fault: Callable[[], None] | None = None,
     force_max_output_tokens: bool = False,
-) -> None:
+    expected_response_text: str | None = None,
+) -> ManagedProcess:
     """
     Run the common migration test flow after frontend and workers are started.
 
@@ -761,10 +866,23 @@ def run_migration_test(
         force_max_output_tokens: Disable EOS and require the request's full
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
+        expected_response_text: Deterministic fault-free response to require
+            after migration, including every client-visible output chunk.
+
+    Returns:
+        The surviving worker selected as the replacement target. Successful
+            migration cases retry the request on this worker.
     """
+    # Ignore requests already present in the worker logs, such as a deterministic
+    # baseline request used to validate migration output continuity.
+    log_offsets = tuple(
+        os.path.getsize(worker.log_path) if worker.log_path else 0
+        for worker in (worker1, worker2)
+    )
+
     # Step 1: Send the request
     if use_chat_completion:
-        request_thread, response_list = start_chat_completion_request(
+        request_thread, response = start_chat_completion_request(
             frontend.frontend_port,
             stream=stream,
             use_long_prompt=use_long_prompt,
@@ -773,7 +891,7 @@ def run_migration_test(
             force_max_output_tokens=force_max_output_tokens,
         )
     else:
-        request_thread, response_list = start_completion_request(
+        request_thread, response = start_completion_request(
             frontend.frontend_port,
             stream=stream,
             use_long_prompt=use_long_prompt,
@@ -784,7 +902,10 @@ def run_migration_test(
 
     # Step 2: Determine which worker received the request
     worker, worker_name, request_id = determine_request_receiving_worker(
-        worker1, worker2, receiving_pattern=receiving_pattern
+        worker1,
+        worker2,
+        receiving_pattern=receiving_pattern,
+        log_offsets=log_offsets,
     )
     replacement_worker = worker2 if worker is worker1 else worker1
     assert (
@@ -793,7 +914,7 @@ def run_migration_test(
 
     # Step 3: Optionally wait for new response before stop (for decode tests)
     if wait_for_new_response_before_stop:
-        wait_for_response(response_list)
+        wait_for_response(response)
         assert (
             request_thread.is_alive()
         ), "Request completed before the worker fault was injected"
@@ -832,7 +953,18 @@ def run_migration_test(
                     receiving_pattern,
                     request_id,
                 )
-            validate_response(request_thread, response_list)
+            response_text = validate_response(
+                request_thread,
+                response,
+                expected_completion_tokens=(
+                    max_tokens if force_max_output_tokens else None
+                ),
+            )
+            if expected_response_text is not None:
+                assert response_text == expected_response_text, (
+                    "Migrated response differs from the deterministic "
+                    "fault-free response"
+                )
             if verify_replacement_worker:
                 worker_system_port = getattr(replacement_worker, "system_port", None)
                 assert isinstance(
@@ -843,7 +975,7 @@ def run_migration_test(
             # openai.APIError covers both mid-stream structured error frames and
             # HTTP non-200 responses.
             with pytest.raises(APIError):
-                validate_response(request_thread, response_list)
+                validate_response(request_thread, response)
 
     # Step 6: Verify that migration behaved as expected via the frontend's
     # Prometheus metrics (a stable structured surface) instead of asserting on
@@ -862,3 +994,5 @@ def run_migration_test(
         expected_max_seq_len_exceeded_count=1 if migration_max_seq_len == 1 else 0,
         exact_counts=exact_metric_counts,
     )
+
+    return replacement_worker

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -618,6 +618,20 @@ def run_migration_test(
         assert (
             request_thread.is_alive()
         ), "Request completed before the worker fault was injected"
+        if expected_output_prefix is not None:
+            output_before_fault = "".join(
+                content
+                for content, _ in response.observations
+                if isinstance(content, str)
+            )
+            assert expected_output_prefix.startswith(output_before_fault), (
+                "Fault-free reference does not match the output emitted before "
+                "the fault; the content oracle is not stable"
+            )
+            assert len(expected_output_prefix) >= len(output_before_fault) + 32, (
+                "Fault-free stable prefix must cover at least 32 characters "
+                "after the fault boundary"
+            )
 
     if before_worker_fault is not None:
         before_worker_fault()

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -335,9 +335,7 @@ def start_chat_completion_request(
                 response.finish_reason = choice.finish_reason
                 if resp.usage is not None:
                     response.completion_tokens = resp.usage.completion_tokens
-                response.observations.append(
-                    (choice.message.content, time.monotonic())
-                )
+                response.observations.append((choice.message.content, time.monotonic()))
         except Exception as error:
             # openai.APIError subclasses cover HTTP non-200, mid-stream
             # structured `data: {"error": {...}}` frames, connection failures,
@@ -588,9 +586,7 @@ def read_worker_generate_metrics(
     component: str = "backend",
 ) -> tuple[float, float]:
     """Read completed-request and response-byte totals for one worker endpoint."""
-    response = requests.get(
-        f"http://localhost:{worker_system_port}/metrics", timeout=1
-    )
+    response = requests.get(f"http://localhost:{worker_system_port}/metrics", timeout=1)
     response.raise_for_status()
     labels = {"dynamo_component": component, "dynamo_endpoint": "generate"}
     return (
@@ -690,10 +686,12 @@ def validate_response(
         # Content is already parsed - just collect it
         response_words.append(res)
 
-    assert any(response_words), "Request completed without any non-empty response content"
-    assert response.finish_reason is not None, (
-        "Request completed without a terminal finish reason"
-    )
+    assert any(
+        response_words
+    ), "Request completed without any non-empty response content"
+    assert (
+        response.finish_reason is not None
+    ), "Request completed without a terminal finish reason"
     if expected_completion_tokens is not None:
         assert response.finish_reason == "length", (
             "Forced-length request terminated unexpectedly: "
@@ -937,9 +935,7 @@ def run_migration_test(
         assert isinstance(
             worker_system_port, int
         ), "Replacement-worker verification requires an integer system_port"
-        replacement_generate_baseline = read_worker_generate_metrics(
-            worker_system_port
-        )
+        replacement_generate_baseline = read_worker_generate_metrics(worker_system_port)
 
     # Step 3: Optionally wait for new response before stop (for decode tests)
     if wait_for_new_response_before_stop:

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -9,11 +9,10 @@ import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
-from dataclasses import dataclass, field
 
 import pytest
 import requests
-from openai import APIError, OpenAI
+from openai import APIError
 
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import (
@@ -22,18 +21,9 @@ from tests.utils.managed_process import (
 from tests.utils.managed_process import ManagedProcess, terminate_process_tree
 from tests.utils.prometheus import sum_metric_samples
 
+from .request_utils import start_request, validate_response, wait_for_response
+
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class MigrationResponse:
-    """Client-visible response state collected by the request thread."""
-
-    observations: list[tuple[str | None | Exception, float]] = field(
-        default_factory=list
-    )
-    finish_reason: str | None = None
-    completion_tokens: int | None = None
 
 
 @contextmanager
@@ -71,7 +61,7 @@ def managed_processes_concurrently(
         for index, process in enumerate(processes)
     ]
 
-    def cancel_startup(*, terminate_in_progress: bool = False) -> None:
+    def cancel_startup() -> None:
         startup_cancelled.set()
         for future in futures:
             future.cancel()
@@ -83,14 +73,10 @@ def managed_processes_concurrently(
                 process.__exit__(None, None, None)
             except Exception:
                 logger.exception("Failed to clean up a concurrently started process")
-        if terminate_in_progress:
-            for process, future in zip(processes, futures, strict=True):
-                if future.done() or process in started:
-                    continue
-                try:
-                    process.__exit__(None, None, None)
-                except Exception:
-                    logger.exception("Failed to terminate a process during startup")
+        for process, future in zip(processes, futures, strict=True):
+            if future.done() or process in started:
+                continue
+            process.cancel_startup()
         # Wait until every startup task has either observed the terminated child
         # or cleaned up a late start. This prevents fixture/port teardown from
         # racing a worker that is still inside ManagedProcess.__enter__().
@@ -103,7 +89,7 @@ def managed_processes_concurrently(
         cancel_startup()
         raise
     except BaseException:
-        cancel_startup(terminate_in_progress=True)
+        cancel_startup()
         raise
     else:
         executor.shutdown(wait=True)
@@ -142,211 +128,6 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
             display_name="frontend",
         )
         self.timeout = startup_timeout_s
-
-
-def _make_client(frontend_port: int) -> OpenAI:
-    """Build an OpenAI client pointed at the test frontend.
-
-    max_retries=0 so fault-tolerance tests see the first error instead of
-    silent retries; api_key is a placeholder since the frontend doesn't auth.
-    """
-    return OpenAI(
-        base_url=f"http://localhost:{frontend_port}/v1",
-        api_key="not-needed",
-        max_retries=0,
-        timeout=240,
-    )
-
-
-def start_completion_request(
-    frontend_port: int,
-    stream: bool,
-    use_long_prompt: bool = False,
-    max_tokens: int | None = None,
-    long_prompt_repetitions: int = 8_000,
-    force_max_output_tokens: bool = False,
-) -> tuple[threading.Thread, MigrationResponse]:
-    """
-    Start a long-running completion request in a separate thread.
-
-    Responses are processed internally to extract content and terminal metadata.
-    The first observation is ``(None, start_time)``; subsequent observations
-    contain extracted content or exceptions.
-
-    Args:
-        frontend_port: Port where the frontend is running
-        stream: Whether to use streaming responses
-        use_long_prompt: Whether to use a long prompt (~8000 tokens)
-        max_tokens: Explicit output-token cap, or the backend default when unset
-        long_prompt_repetitions: Number of repeated words in the long prompt
-        force_max_output_tokens: Disable EOS and require the full output-token
-            budget. Requires max_tokens.
-
-    Returns:
-        The request thread and its shared response state.
-    """
-    response = MigrationResponse()
-
-    def send_request():
-        prompt = "Tell me a long long long story about yourself?"
-        if use_long_prompt:
-            prompt += " Make sure it is" + " long" * long_prompt_repetitions + "!"
-
-        logger.info(
-            "Sending completion request (stream=%s) with prompt: '%s...'",
-            stream,
-            prompt[:50],
-        )
-
-        response.observations.append((None, time.monotonic()))
-
-        try:
-            client = _make_client(frontend_port)
-            request_args = {
-                "model": FAULT_TOLERANCE_MODEL_NAME,
-                "prompt": prompt,
-                "stream": stream,
-                "temperature": 0,
-                "seed": 0,
-            }
-            if max_tokens is not None:
-                request_args["max_tokens"] = max_tokens
-            if force_max_output_tokens:
-                if max_tokens is None:
-                    raise ValueError("force_max_output_tokens requires max_tokens")
-                request_args["extra_body"] = {
-                    "ignore_eos": True,
-                    "min_tokens": max_tokens,
-                }
-                if stream:
-                    request_args["stream_options"] = {"include_usage": True}
-            if stream:
-                for chunk in client.completions.create(**request_args):
-                    if chunk.usage is not None:
-                        response.completion_tokens = chunk.usage.completion_tokens
-                    choice = chunk.choices[0] if chunk.choices else None
-                    if choice is not None and choice.finish_reason is not None:
-                        response.finish_reason = choice.finish_reason
-                    text = choice.text if choice is not None else None
-                    # Match the original hand-rolled parser: keep empty strings,
-                    # drop only None. Empty chunks (e.g. the first stream frame)
-                    # still count as a response arrival for delay measurement.
-                    if text is not None:
-                        response.observations.append((text, time.monotonic()))
-            else:
-                resp = client.completions.create(**request_args)
-                choice = resp.choices[0]
-                response.finish_reason = choice.finish_reason
-                if resp.usage is not None:
-                    response.completion_tokens = resp.usage.completion_tokens
-                response.observations.append((choice.text, time.monotonic()))
-        except Exception as error:
-            # openai.APIError subclasses cover HTTP non-200, mid-stream
-            # structured `data: {"error": {...}}` frames, connection failures,
-            # and timeouts. Non-openai exceptions (network, etc.) also bubble.
-            logger.error("Request failed with error: %s", error)
-            response.observations.append((error, time.monotonic()))
-
-    request_thread = threading.Thread(target=send_request, daemon=True)
-    request_thread.start()
-
-    return request_thread, response
-
-
-def start_chat_completion_request(
-    frontend_port: int,
-    stream: bool,
-    use_long_prompt: bool = False,
-    max_tokens: int | None = None,
-    long_prompt_repetitions: int = 8_000,
-    force_max_output_tokens: bool = False,
-) -> tuple[threading.Thread, MigrationResponse]:
-    """
-    Start a long-running chat completion request in a separate thread.
-
-    Responses are processed internally to extract content and terminal metadata.
-    The first observation is ``(None, start_time)``; subsequent observations
-    contain extracted content or exceptions.
-
-    Args:
-        frontend_port: Port where the frontend is running
-        stream: Whether to use streaming responses
-        use_long_prompt: Whether to use a long prompt (~8000 tokens)
-        max_tokens: Explicit output-token cap, or the backend default when unset
-        long_prompt_repetitions: Number of repeated words in the long prompt
-        force_max_output_tokens: Disable EOS and require the full output-token
-            budget. Requires max_tokens.
-
-    Returns:
-        The request thread and its shared response state.
-    """
-    response = MigrationResponse()
-
-    def send_request():
-        prompt = "Tell me a long long long story about yourself?"
-        if use_long_prompt:
-            prompt += " Make sure it is" + " long" * long_prompt_repetitions + "!"
-
-        logger.info(
-            "Sending chat completion request (stream=%s) with prompt: '%s...'",
-            stream,
-            prompt[:50],
-        )
-
-        response.observations.append((None, time.monotonic()))
-
-        try:
-            client = _make_client(frontend_port)
-            request_args = {
-                "model": FAULT_TOLERANCE_MODEL_NAME,
-                "messages": [{"role": "user", "content": prompt}],
-                "stream": stream,
-                "temperature": 0,
-                "seed": 0,
-            }
-            if max_tokens is not None:
-                request_args["max_tokens"] = max_tokens
-            if force_max_output_tokens:
-                if max_tokens is None:
-                    raise ValueError("force_max_output_tokens requires max_tokens")
-                request_args["extra_body"] = {
-                    "ignore_eos": True,
-                    "min_tokens": max_tokens,
-                }
-                if stream:
-                    request_args["stream_options"] = {"include_usage": True}
-            if stream:
-                for chunk in client.chat.completions.create(**request_args):
-                    if chunk.usage is not None:
-                        response.completion_tokens = chunk.usage.completion_tokens
-                    choice = chunk.choices[0] if chunk.choices else None
-                    if choice is not None and choice.finish_reason is not None:
-                        response.finish_reason = choice.finish_reason
-                    content = choice.delta.content if choice is not None else None
-                    # Match the original hand-rolled parser: keep empty strings,
-                    # drop only None. Empty chunks (e.g. the first `role`-only
-                    # stream frame) still count as a response arrival for delay
-                    # measurement.
-                    if content is not None:
-                        response.observations.append((content, time.monotonic()))
-            else:
-                resp = client.chat.completions.create(**request_args)
-                choice = resp.choices[0]
-                response.finish_reason = choice.finish_reason
-                if resp.usage is not None:
-                    response.completion_tokens = resp.usage.completion_tokens
-                response.observations.append((choice.message.content, time.monotonic()))
-        except Exception as error:
-            # openai.APIError subclasses cover HTTP non-200, mid-stream
-            # structured `data: {"error": {...}}` frames, connection failures,
-            # and timeouts. Non-openai exceptions also bubble for visibility.
-            logger.error("Request failed with error: %s", error)
-            response.observations.append((error, time.monotonic()))
-
-    request_thread = threading.Thread(target=send_request, daemon=True)
-    request_thread.start()
-
-    return request_thread, response
 
 
 def determine_request_receiving_worker(
@@ -544,43 +325,6 @@ def wait_for_endpoint_instance_reduction(
     )
 
 
-def wait_for_response(
-    response: MigrationResponse,
-    num_responses: int = 5,
-    max_wait_time: float = 10.0,
-) -> None:
-    """
-    Block until at least ``num_responses`` non-empty payload chunks exist.
-
-    Args:
-        response: Response state being populated by the background thread
-        num_responses: Absolute minimum number of non-empty payload chunks (default 5)
-        max_wait_time: Maximum time to wait in seconds (default 10s)
-    """
-    poll_interval = 0.001  # 1ms
-    deadline = time.monotonic() + max_wait_time
-
-    while time.monotonic() < deadline:
-        content_count = sum(
-            1
-            for content, _ in response.observations
-            if isinstance(content, str) and content
-        )
-        if content_count >= num_responses:
-            return
-        time.sleep(poll_interval)
-
-    content_count = sum(
-        1
-        for content, _ in response.observations
-        if isinstance(content, str) and content
-    )
-    pytest.fail(
-        f"Only observed {content_count}/{num_responses} non-empty response chunks "
-        f"within {max_wait_time}s"
-    )
-
-
 def read_worker_generate_metrics(
     worker_system_port: int,
     component: str = "backend",
@@ -645,69 +389,6 @@ def wait_for_worker_generate_completion(
         f"baseline_response_bytes={baseline_response_bytes}, "
         f"response_bytes={response_bytes}, last_error={last_error}"
     )
-
-
-def validate_response(
-    request_thread: threading.Thread,
-    response: MigrationResponse,
-    expected_completion_tokens: int | None = None,
-) -> str:
-    """
-    Wait for and validate the response after migration.
-    Timing observations are logged for diagnosis, but they are not correctness
-    assertions. Loaded CI nodes and concurrent GPU tests can legitimately change
-    TTFT/TPOT without changing migration behavior.
-
-    Args:
-        request_thread: The thread running the request
-        response: Client-visible content and terminal response metadata.
-        expected_completion_tokens: When set, require a length-limited response
-            with exactly this many completion tokens.
-    """
-    request_thread.join(timeout=240)
-    assert not request_thread.is_alive(), "Request did not complete within 240 seconds"
-
-    observations = response.observations
-    assert observations, "Missing first entry with start timestamp"
-    assert observations[0][0] is None, "First entry should be start timestamp only"
-    prev_timestamp = observations[0][1]
-
-    response_words: list[str] = []
-    for res, timestamp in observations[1:]:
-        delay = timestamp - prev_timestamp
-        if delay > 2.0:
-            logger.info("Observed %.3fs before the next response chunk", delay)
-        prev_timestamp = timestamp
-
-        assert res is not None, "Response entry should not be None"
-        if isinstance(res, Exception):
-            raise res
-
-        # Content is already parsed - just collect it
-        response_words.append(res)
-
-    assert any(
-        response_words
-    ), "Request completed without any non-empty response content"
-    assert (
-        response.finish_reason is not None
-    ), "Request completed without a terminal finish reason"
-    if expected_completion_tokens is not None:
-        assert response.finish_reason == "length", (
-            "Forced-length request terminated unexpectedly: "
-            f"finish_reason={response.finish_reason!r}"
-        )
-        assert response.completion_tokens == expected_completion_tokens, (
-            "Forced-length request returned the wrong completion-token count: "
-            f"expected={expected_completion_tokens}, "
-            f"actual={response.completion_tokens}"
-        )
-    logger.info(
-        "Received %s response(s): %s...",
-        len(response_words),
-        "".join(response_words)[:100],
-    )
-    return "".join(response_words)
 
 
 def _parse_migration_metric(
@@ -852,6 +533,7 @@ def run_migration_test(
     verify_replacement_worker: bool = False,
     before_worker_fault: Callable[[], None] | None = None,
     force_max_output_tokens: bool = False,
+    expected_output_prefix: str | None = None,
 ) -> ManagedProcess:
     """
     Run the common migration test flow after frontend and workers are started.
@@ -885,6 +567,8 @@ def run_migration_test(
         force_max_output_tokens: Disable EOS and require the request's full
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
+        expected_output_prefix: Deterministic fault-free output that must prefix
+            the migrated response.
 
     Returns:
         The surviving worker selected as the replacement target. Successful
@@ -898,24 +582,15 @@ def run_migration_test(
     )
 
     # Step 1: Send the request
-    if use_chat_completion:
-        request_thread, response = start_chat_completion_request(
-            frontend.frontend_port,
-            stream=stream,
-            use_long_prompt=use_long_prompt,
-            max_tokens=max_tokens,
-            long_prompt_repetitions=long_prompt_repetitions,
-            force_max_output_tokens=force_max_output_tokens,
-        )
-    else:
-        request_thread, response = start_completion_request(
-            frontend.frontend_port,
-            stream=stream,
-            use_long_prompt=use_long_prompt,
-            max_tokens=max_tokens,
-            long_prompt_repetitions=long_prompt_repetitions,
-            force_max_output_tokens=force_max_output_tokens,
-        )
+    request_thread, response = start_request(
+        frontend.frontend_port,
+        use_chat_completion=use_chat_completion,
+        stream=stream,
+        use_long_prompt=use_long_prompt,
+        max_tokens=max_tokens,
+        long_prompt_repetitions=long_prompt_repetitions,
+        force_max_output_tokens=force_max_output_tokens,
+    )
 
     # Step 2: Determine which worker received the request
     worker, worker_name, request_id = determine_request_receiving_worker(
@@ -984,6 +659,7 @@ def run_migration_test(
                 expected_completion_tokens=(
                     max_tokens if force_max_output_tokens else None
                 ),
+                expected_output_prefix=expected_output_prefix,
             )
             if verify_replacement_worker:
                 worker_system_port = getattr(replacement_worker, "system_port", None)

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -583,14 +583,38 @@ def wait_for_response(
     )
 
 
+def read_worker_generate_metrics(
+    worker_system_port: int,
+    component: str = "backend",
+) -> tuple[float, float]:
+    """Read completed-request and response-byte totals for one worker endpoint."""
+    response = requests.get(
+        f"http://localhost:{worker_system_port}/metrics", timeout=1
+    )
+    response.raise_for_status()
+    labels = {"dynamo_component": component, "dynamo_endpoint": "generate"}
+    return (
+        sum_metric_samples(
+            response.text,
+            "dynamo_component_request_duration_seconds_count",
+            labels,
+        ),
+        sum_metric_samples(
+            response.text,
+            "dynamo_component_response_bytes_total",
+            labels,
+        ),
+    )
+
+
 def wait_for_worker_generate_completion(
     worker_system_port: int,
+    baseline_duration_count: float,
+    baseline_response_bytes: float,
     component: str = "backend",
     max_wait_time: float = 10.0,
 ) -> None:
-    """Prove the replacement worker drained one request and emitted response bytes."""
-    metrics_url = f"http://localhost:{worker_system_port}/metrics"
-    labels = {"dynamo_component": component, "dynamo_endpoint": "generate"}
+    """Prove the replacement worker drained one new request with response bytes."""
     deadline = time.monotonic() + max_wait_time
     duration_count = 0.0
     response_bytes = 0.0
@@ -599,22 +623,17 @@ def wait_for_worker_generate_completion(
 
     while time.monotonic() < deadline:
         try:
-            response = requests.get(metrics_url, timeout=1)
-            response.raise_for_status()
-            duration_count = sum_metric_samples(
-                response.text,
-                "dynamo_component_request_duration_seconds_count",
-                labels,
+            duration_count, response_bytes = read_worker_generate_metrics(
+                worker_system_port,
+                component,
             )
-            response_bytes = sum_metric_samples(
-                response.text,
-                "dynamo_component_response_bytes_total",
-                labels,
-            )
-            if duration_count == 1 and response_bytes > 0:
+            if (
+                duration_count - baseline_duration_count == 1
+                and response_bytes - baseline_response_bytes > 0
+            ):
                 logger.info(
-                    "Replacement worker completed one request with %s response bytes",
-                    response_bytes,
+                    "Replacement worker completed one new request with %s response bytes",
+                    response_bytes - baseline_response_bytes,
                 )
                 return
         except (requests.RequestException, ValueError) as error:
@@ -623,8 +642,11 @@ def wait_for_worker_generate_completion(
         poll_event.wait(timeout=0.1)
 
     pytest.fail(
-        "Replacement worker did not complete exactly one generate request with "
-        f"response bytes within {max_wait_time}s; duration_count={duration_count}, "
+        "Replacement worker did not complete exactly one new generate request with "
+        f"response bytes within {max_wait_time}s; "
+        f"baseline_duration_count={baseline_duration_count}, "
+        f"duration_count={duration_count}, "
+        f"baseline_response_bytes={baseline_response_bytes}, "
         f"response_bytes={response_bytes}, last_error={last_error}"
     )
 
@@ -832,7 +854,6 @@ def run_migration_test(
     verify_replacement_worker: bool = False,
     before_worker_fault: Callable[[], None] | None = None,
     force_max_output_tokens: bool = False,
-    expected_response_text: str | None = None,
 ) -> ManagedProcess:
     """
     Run the common migration test flow after frontend and workers are started.
@@ -866,15 +887,13 @@ def run_migration_test(
         force_max_output_tokens: Disable EOS and require the request's full
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
-        expected_response_text: Deterministic fault-free response to require
-            after migration, including every client-visible output chunk.
 
     Returns:
         The surviving worker selected as the replacement target. Successful
             migration cases retry the request on this worker.
     """
-    # Ignore requests already present in the worker logs, such as a deterministic
-    # baseline request used to validate migration output continuity.
+    # Ignore requests already present in the worker logs so the receiving-worker
+    # lookup only considers the request started below.
     log_offsets = tuple(
         os.path.getsize(worker.log_path) if worker.log_path else 0
         for worker in (worker1, worker2)
@@ -911,6 +930,16 @@ def run_migration_test(
     assert (
         request_thread.is_alive()
     ), "Request completed before the migration fault could be injected"
+
+    replacement_generate_baseline: tuple[float, float] | None = None
+    if verify_replacement_worker:
+        worker_system_port = getattr(replacement_worker, "system_port", None)
+        assert isinstance(
+            worker_system_port, int
+        ), "Replacement-worker verification requires an integer system_port"
+        replacement_generate_baseline = read_worker_generate_metrics(
+            worker_system_port
+        )
 
     # Step 3: Optionally wait for new response before stop (for decode tests)
     if wait_for_new_response_before_stop:
@@ -953,24 +982,23 @@ def run_migration_test(
                     receiving_pattern,
                     request_id,
                 )
-            response_text = validate_response(
+            validate_response(
                 request_thread,
                 response,
                 expected_completion_tokens=(
                     max_tokens if force_max_output_tokens else None
                 ),
             )
-            if expected_response_text is not None:
-                assert response_text == expected_response_text, (
-                    "Migrated response differs from the deterministic "
-                    "fault-free response"
-                )
             if verify_replacement_worker:
                 worker_system_port = getattr(replacement_worker, "system_port", None)
                 assert isinstance(
                     worker_system_port, int
                 ), "Replacement-worker verification requires an integer system_port"
-                wait_for_worker_generate_completion(worker_system_port)
+                assert replacement_generate_baseline is not None
+                wait_for_worker_generate_completion(
+                    worker_system_port,
+                    *replacement_generate_baseline,
+                )
         else:
             # openai.APIError covers both mid-stream structured error frames and
             # HTTP non-200 responses.

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -534,7 +534,7 @@ def run_migration_test(
     before_worker_fault: Callable[[], None] | None = None,
     force_max_output_tokens: bool = False,
     expected_output_prefix: str | None = None,
-) -> ManagedProcess:
+) -> tuple[ManagedProcess, str | None]:
     """
     Run the common migration test flow after frontend and workers are started.
 
@@ -567,12 +567,12 @@ def run_migration_test(
         force_max_output_tokens: Disable EOS and require the request's full
             max_tokens budget so state-based fault synchronization cannot race
             an early EOS.
-        expected_output_prefix: Deterministic fault-free output that must prefix
-            the migrated response.
+        expected_output_prefix: Stable fault-free output prefix used to prove
+            the content oracle extends beyond the fault boundary.
 
     Returns:
-        The surviving worker selected as the replacement target. Successful
-            migration cases retry the request on this worker.
+        The surviving replacement worker and the completed response output.
+            Failed migration cases return None for the output.
     """
     # Ignore requests already present in the worker logs so the receiving-worker
     # lookup only considers the request started below.
@@ -667,13 +667,12 @@ def run_migration_test(
                     receiving_pattern,
                     request_id,
                 )
-            validate_response(
+            completed_output = validate_response(
                 request_thread,
                 response,
                 expected_completion_tokens=(
                     max_tokens if force_max_output_tokens else None
                 ),
-                expected_output_prefix=expected_output_prefix,
             )
             if verify_replacement_worker:
                 worker_system_port = getattr(replacement_worker, "system_port", None)
@@ -690,6 +689,7 @@ def run_migration_test(
             # HTTP non-200 responses.
             with pytest.raises(APIError):
                 validate_response(request_thread, response)
+            completed_output = None
 
     # Step 6: Verify that migration behaved as expected via the frontend's
     # Prometheus metrics (a stable structured surface) instead of asserting on
@@ -709,4 +709,4 @@ def run_migration_test(
         exact_counts=exact_metric_counts,
     )
 
-    return replacement_worker
+    return replacement_worker, completed_output

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
@@ -187,6 +188,9 @@ class ManagedProcess:
     _log_path = None
     _tee_proc = None
     _sed_proc = None
+    _startup_cancelled: threading.Event = field(
+        default_factory=threading.Event, init=False, repr=False
+    )
 
     @property
     def log_path(self):
@@ -207,6 +211,7 @@ class ManagedProcess:
         return ""
 
     def __enter__(self):
+        self._startup_cancelled.clear()
         try:
             self._logger = logging.getLogger(self.__class__.__name__)
             # self._command_name = self.command[0]
@@ -244,6 +249,15 @@ class ManagedProcess:
                     "Error during cleanup in __enter__: %s", cleanup_err
                 )
             raise
+
+    def cancel_startup(self) -> None:
+        """Ask an in-progress ``__enter__`` call to stop and clean up.
+
+        Startup remains owned by the calling thread. Health-check loops observe
+        this signal and raise, which routes cleanup through ``__enter__``'s
+        existing exception path instead of racing a cross-thread ``__exit__``.
+        """
+        self._startup_cancelled.set()
 
     def _cleanup_stragglers(self):
         """Clean up straggler processes - called during exit and signal handling.
@@ -638,6 +652,8 @@ class ManagedProcess:
 
     def _check_process_alive(self, context=""):
         """Check if the main process is still alive. Raises RuntimeError if dead."""
+        if self._startup_cancelled.is_set():
+            raise RuntimeError("Managed process startup was cancelled")
         if self.proc and self.proc.poll() is not None:
             returncode = self.proc.returncode
             self._logger.error(

--- a/tests/utils/test_managed_process_teardown.py
+++ b/tests/utils/test_managed_process_teardown.py
@@ -123,7 +123,9 @@ def test_cancel_startup_is_owned_by_startup_thread(tmp_path):
         pid = mp.proc.pid
     finally:
         mp.cancel_startup()
-        startup_thread.join(timeout=5)
+        # Cancellation exits through normal cleanup, whose process-group grace
+        # period is eight seconds before forceful termination.
+        startup_thread.join(timeout=15)
 
     assert not startup_thread.is_alive(), "Cancelled startup did not return"
     assert len(startup_errors) == 1

--- a/tests/utils/test_managed_process_teardown.py
+++ b/tests/utils/test_managed_process_teardown.py
@@ -19,6 +19,7 @@ Always use unique markers scoped to the test invocation.
 import os
 import signal
 import subprocess
+import threading
 import time
 import uuid
 
@@ -91,6 +92,44 @@ def _bash_sleep_cmd(marker: str, tag: str = "") -> list[str]:
     The trailing `: noexit` prevents bash from exec-ing into sleep
     (which would lose the marker from the cmdline)."""
     return ["bash", "-c", f": {marker}{tag}; sleep 300; : noexit"]
+
+
+def test_cancel_startup_is_owned_by_startup_thread(tmp_path):
+    """Cancelling startup must stop the child without a cross-thread __exit__."""
+    mp = ManagedProcess(
+        command=_bash_sleep_cmd(_unique_marker()),
+        health_check_funcs=[lambda: False],
+        timeout=30,
+        display_output=False,
+        terminate_all_matching_process_names=False,
+        log_dir=str(tmp_path),
+    )
+    startup_errors: list[BaseException] = []
+
+    def start() -> None:
+        try:
+            mp.__enter__()
+        except BaseException as error:
+            startup_errors.append(error)
+
+    startup_thread = threading.Thread(target=start)
+    startup_thread.start()
+
+    try:
+        deadline = time.monotonic() + 5
+        while mp.proc is None:
+            assert time.monotonic() < deadline, "Managed process did not start"
+            time.sleep(0.01)
+        pid = mp.proc.pid
+    finally:
+        mp.cancel_startup()
+        startup_thread.join(timeout=5)
+
+    assert not startup_thread.is_alive(), "Cancelled startup did not return"
+    assert len(startup_errors) == 1
+    assert isinstance(startup_errors[0], RuntimeError)
+    assert "startup was cancelled" in str(startup_errors[0])
+    assert _wait_for_pid_death(pid), "Cancelled startup left its child running"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Enable 10 previously skipped TensorRT-LLM fault-tolerance cases across cancellation, aggregate migration, decode migration, and KV re-transfer.
- Replace the 384-row Cartesian migration collection with 10 focused active cases covering migration policy, request API, streaming mode, fault type, and NATS/TCP request planes. Unsupported graceful-shutdown placeholders are no longer collected; two focused prefill-migration contracts remain explicitly skipped as visible coverage debt.
- Strengthen terminal-response, request-ID, replacement-worker, process-lifecycle, Prometheus-delta, and KV-transfer assertions, and normalize forced-generation fields for TensorRT-LLM.
- Keep two prefill cancellation cases explicitly skipped because cancellation does not reach TensorRT-LLM before prefill completes.

The KV-transfer cancellation coverage validates Dynamo's deferred-abort workaround and end-to-end liveness. It does not prove that upstream TensorRT-LLM fixed abort-during-live-transfer: Dynamo's `_DeferredAbort` intentionally delays the engine abort until the first result/KV handoff completes.

## Known limitation

- The TCP/completions KV-migration case reproducibly changes generated output after handoff with TensorRT-LLM 1.3.0rc25, following three byte-identical fault-free baselines. The failure is an output-continuity defect in the Dynamo + TensorRT-LLM path; it is not yet isolated to TensorRT-LLM itself.
- Keep that case executable with a narrow, strict `xfail` that accepts only `OutputContinuityError`. Timeouts, request identity, migration, replacement completion, frontend metrics, and KV-transfer failures remain hard failures. A continuity fix becomes a hard XPASS failure so the quarantine must be removed.

## Validation

- Built source-matched runtime and test images from this branch for TensorRT-LLM 1.3.0rc25, vLLM 0.28.0, and SGLang 0.5.19.
- TensorRT-LLM cancellation matrix: 6 passed, 2 expected skips.
- TensorRT-LLM aggregate migration matrix: 4 passed.
- TensorRT-LLM decode migration matrix: 4 passed.
- TensorRT-LLM KV migration over NATS/chat: passed with exact output continuity.
- TensorRT-LLM TCP/completions KV migration: expected `OutputContinuityError` XFAIL on Prenyx with TensorRT-LLM 1.3.0rc25; all preceding structural and KV-transfer checks passed.
- TensorRT-LLM request-normalization unit test: 1 passed.
- Managed-process teardown regression module: 8 passed after allowing the existing 8-second graceful process-group cleanup window.
- NVML peak profiles: aggregate 7.2 GiB, KV re-transfer 10.4 GiB, decode 12.6 GiB.
- Representative vLLM shared-helper regressions: cancellation and streaming migration, 2 passed.
- Representative SGLang shared-helper regression: streaming migration, 1 passed.
- `ruff check`, `black --check`, `python -m py_compile`, and `git diff --check` passed for the final fix files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests now consistently recognize top-level `min_tokens` and `ignore_eos` settings within stop conditions while preserving existing nested values.
  - Streaming response handling now validates completion markers and JSON payloads, rejects error events, and enforces overall time limits.
  - Cancellation and migration scenarios now clean up temporary resources more reliably and verify continued worker availability.

- **Tests**
  - Expanded coverage for streaming cancellation, worker migration, replacement-worker behavior, KV transfer, metrics, and response completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

