### PR TITLE
feat(sglang): forward session_id and parent_session_id to sglang engine

### DIFF
--- a/components/src/dynamo/sglang/AGENTS.md
+++ b/components/src/dynamo/sglang/AGENTS.md
@@ -319,12 +319,27 @@ text-to-video-diffusion.sh  # 1-2 GPUs - Text-to-video (Wan2.1)
   metadata arrays positionally aligned when adapting the response.
 - **Zombie GPU processes**: `sgl_diffusion::scheduler` spawns a child process that
   survives parent kill. Always check `nvidia-smi` after teardown.
-- **Session identity**: SGLang 0.5.15 supports passive session-aware radix
-  ownership through the top-level `session_id` request field, but Dynamo does
-  not forward `agent_context.session_id` to it yet. Do not pass that value as
-  `session_params.id`; SGLang treats that field as an explicit session lifecycle
-  and rejects IDs that were not created through `open_session`. Session headers
-  remain available for tracing and router affinity.
+- **Session identity**: SGLang has *two* unrelated request fields whose names both say
+  "session", with opposite registration rules, and picking the wrong one is the trap:
+  - **top-level `session_id`** (sglang >= 0.5.15) is radix-native and *self-registering*.
+    When `--enable-session-radix-cache` is on, the scheduler calls
+    `ensure_session_generation`, which opens the session the first time it sees the id,
+    so an id the server has never heard of is fine. With the flag off (the default) the
+    id is stored on the request and nothing reads it.
+  - **`session_params.id`** is an explicit lifecycle handle. A request naming an id that
+    `open_session` did not create is rejected with "session id ... does not exist".
+
+  `agent_session.py` forwards `agent_context.session_id` and
+  `agent_context.parent_session_id` as top-level kwargs of the same name -- never as
+  `session_params.id`. That is why forwarding an arbitrary agent session id is safe:
+  the self-registering field has no "unknown id" failure mode.
+
+  Both kwargs are filtered against the engine signature, so a build declaring neither
+  receives neither -- `parent_session_id` is only consumed by builds implementing parent
+  keepalive. `GenerateReqInput` rejects `session_id` and `session_params` set together;
+  this backend never sends `session_params`, and anything that starts to must suppress
+  `session_id` on those requests. The native `sglang_tito` passthrough is excluded: that
+  body is client-owned, so a native caller sets the fields itself.
 
 For troubleshooting (CuDNN, config.json errors, OOM, disagg connectivity), see
 `docs/backends/sglang/sglang-examples.md#troubleshooting`.
@@ -373,6 +388,7 @@ Checklist for adding a new worker (e.g., a new modality or serving mode):
 ```text
 sglang/
   _compat.py               # SGLang version compat shim (signature probing for async_generate kwargs)
+  agent_session.py         # agent_context session ids -> async_generate kwargs
   __main__.py              # Entry point
   main.py                  # Worker dispatch
   args.py                  # Config parsing (ServerArgs vs SimpleNamespace)

--- a/components/src/dynamo/sglang/agent_session.py
+++ b/components/src/dynamo/sglang/agent_session.py
@@ -1,39 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Forward agent session identity to the SGLang engine.
+"""Forward ``agent_context`` session ids to ``Engine.async_generate``.
 
-The frontend derives agent identity at the HTTP boundary -- from
-``x-dynamo-session-id`` / ``x-dynamo-parent-session-id``, or from the Claude Code,
-Codex and OpenCode header families -- and serializes it on
-``PreprocessedRequest.agent_context``. This module lifts the two session ids back
-out and passes them to ``Engine.async_generate``. No routing plumbing is added on
-the Rust side; the same field feeds TensorRT-LLM's conversation affinity (see
-``dynamo/trtllm/conversation_affinity.py``, which reads ``session_id`` from the same
-place).
+``session_id`` and ``parent_session_id`` are passed as top-level kwargs of the same
+name, filtered against the installed engine's signature so a build receives only
+the kwargs it declares.
 
-``session_id`` is SGLang's passive session-aware radix ownership key (sglang >= 0.5.15).
-It is deliberately *not* ``session_params.id``: the two fields have opposite
-registration rules. ``session_params.id`` is an explicit lifecycle handle and is
-rejected unless ``open_session`` created it, whereas the top-level ``session_id``
-self-registers -- the scheduler calls ``ensure_session_generation``, which opens the
-session the first time it sees the id. So forwarding an arbitrary agent session id
-cannot produce an "unknown session" failure. The scheduler acts on it only under
-``--enable-session-radix-cache`` (off by default); with the flag off the id is stored on
-the request and nothing reads it.
-
-``parent_session_id`` names the session that is blocked waiting on this one. An
-engine that consumes it can keep the parent's prefix hot while it is parked on a
-subagent it spawned, instead of letting it age out and be re-prefilled when the
-subagent returns.
-
-Both are optional ``async_generate`` kwargs, filtered against the installed
-engine's signature: a build declaring neither receives neither, and a build
-declaring only ``session_id`` receives only that.
-
-``GenerateReqInput`` rejects ``session_id`` and ``session_params`` set together. Nothing
-in this backend sends ``session_params``, so the two never collide -- but anything that
-starts sending it must suppress ``session_id`` for those requests.
+Never send them as ``session_params.id``: that field is an explicit lifecycle
+handle SGLang rejects unless ``open_session`` created it, whereas the top-level
+``session_id`` self-registers. ``GenerateReqInput`` also rejects ``session_id``
+together with ``session_params``, so anything in this backend that starts sending
+``session_params`` must suppress ``session_id`` on those requests. The full
+behavior is documented under "Session identity" in ``AGENTS.md``.
 """
 
 from __future__ import annotations

--- a/components/src/dynamo/sglang/agent_session.py
+++ b/components/src/dynamo/sglang/agent_session.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Forward agent session identity to the SGLang engine.
+
+The frontend derives agent identity at the HTTP boundary -- from
+``x-dynamo-session-id`` / ``x-dynamo-parent-session-id``, or from the Claude Code,
+Codex and OpenCode header families -- and serializes it on
+``PreprocessedRequest.agent_context``. This module lifts the two session ids back
+out and passes them to ``Engine.async_generate``. No routing plumbing is added on
+the Rust side; the same field feeds TensorRT-LLM's conversation affinity (see
+``dynamo/trtllm/conversation_affinity.py``, which reads ``session_id`` from the same
+place).
+
+``session_id`` is SGLang's passive session-aware radix ownership key (sglang >= 0.5.15).
+It is deliberately *not* ``session_params.id``: the two fields have opposite
+registration rules. ``session_params.id`` is an explicit lifecycle handle and is
+rejected unless ``open_session`` created it, whereas the top-level ``session_id``
+self-registers -- the scheduler calls ``ensure_session_generation``, which opens the
+session the first time it sees the id. So forwarding an arbitrary agent session id
+cannot produce an "unknown session" failure. The scheduler acts on it only under
+``--enable-session-radix-cache`` (off by default); with the flag off the id is stored on
+the request and nothing reads it.
+
+``parent_session_id`` names the session that is blocked waiting on this one. An
+engine that consumes it can keep the parent's prefix hot while it is parked on a
+subagent it spawned, instead of letting it age out and be re-prefilled when the
+subagent returns.
+
+Both are optional ``async_generate`` kwargs, filtered against the installed
+engine's signature: a build declaring neither receives neither, and a build
+declaring only ``session_id`` receives only that.
+
+``GenerateReqInput`` rejects ``session_id`` and ``session_params`` set together. Nothing
+in this backend sends ``session_params``, so the two never collide -- but anything that
+starts sending it must suppress ``session_id`` for those requests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from dynamo.sglang._compat import filter_supported_async_generate_kwargs
+
+# agent_context fields forwarded verbatim as async_generate kwargs of the same name.
+SESSION_ID_FIELDS = ("session_id", "parent_session_id")
+
+
+def _clean_session_id(value: Any) -> Optional[str]:
+    """Normalize one id; absent, blank and non-string all read as absent."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def session_ids_from_request(request: Mapping[str, Any]) -> dict[str, str]:
+    """Return the well-formed ``agent_context`` session ids, keyed by field name.
+
+    Each field is normalized independently, so a malformed ``session_id`` does not
+    suppress a well-formed ``parent_session_id``. Returns ``{}`` when the request
+    carries no usable agent context.
+    """
+    agent_context = request.get("agent_context")
+    if not isinstance(agent_context, dict):
+        return {}
+
+    session_ids = {}
+    for field in SESSION_ID_FIELDS:
+        session_id = _clean_session_id(agent_context.get(field))
+        if session_id is not None:
+            session_ids[field] = session_id
+    return session_ids
+
+
+def agent_session_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the optional SGLang per-request agent-session arguments."""
+    session_ids = session_ids_from_request(request)
+    if not session_ids:
+        return {}
+    return filter_supported_async_generate_kwargs(engine, session_ids)
+
+
+__all__ = ["SESSION_ID_FIELDS", "agent_session_kwargs", "session_ids_from_request"]

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -26,6 +26,7 @@ from dynamo.sglang._compat import (
     require_reasoning_kwargs,
 )
 from dynamo.sglang._disagg import validate_disagg_parallel_sampling
+from dynamo.sglang.agent_session import agent_session_kwargs
 from dynamo.sglang.args import Config
 from dynamo.sglang.engine_generate import (
     build_native_generate_request,
@@ -545,6 +546,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 lora_path=lora_path,
                 **logprob_kwargs,
                 **priority_kwargs,
+                **agent_session_kwargs(self.engine, request),
             )
             if not self.use_sglang_tokenizer:
                 async for out in self._process_token_stream(
@@ -628,6 +630,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 lora_path=lora_path,
                 **logprob_kwargs,
                 **priority_kwargs,
+                **agent_session_kwargs(self.engine, request),
             )
             if not self.use_sglang_tokenizer:
                 async for out in self._process_token_stream(

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -12,6 +12,7 @@ from dynamo._core import Context
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang._compat import require_reasoning_kwargs
 from dynamo.sglang._disagg import validate_disagg_parallel_sampling
+from dynamo.sglang.agent_session import agent_session_kwargs
 from dynamo.sglang.args import Config
 from dynamo.sglang.engine_generate import (
     build_native_generate_request,
@@ -201,6 +202,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 data_parallel_rank=dp_rank,
                 lora_path=lora_path,
                 **priority_kwargs,
+                **agent_session_kwargs(self.engine, inner_request),
             )
         if inner_request.get(HEALTH_CHECK_KEY):
             # Canary: stream engine output so the Rust canary sees scheduler output.

--- a/components/src/dynamo/sglang/tests/test_sglang_agent_session.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_agent_session.py
@@ -29,23 +29,38 @@ pytestmark = [
 
 _AGENT_CONTEXT = {"session_id": "child-1", "parent_session_id": "root-0"}
 
+# Default for the stub's session kwargs, so a recorded call distinguishes a kwarg
+# the handler omitted from one it passed explicitly (even as None).
+_UNSET = object()
+
 
 class _SessionAwareEngine:
-    """Engine whose async_generate declares both session kwargs."""
+    """Engine whose async_generate declares both session kwargs.
+
+    Each recorded call holds only the session kwargs the handler actually passed.
+    """
 
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
     async def async_generate(
         self,
-        session_id: Optional[str] = None,
-        parent_session_id: Optional[str] = None,
+        session_id: Any = _UNSET,
+        parent_session_id: Any = _UNSET,
         **kwargs: Any,
     ):
-        # **kwargs absorbs the unrelated per-request arguments the handlers pass;
-        # the two session kwargs stay declared so the signature filter is exercised.
+        # **kwargs absorbs the unrelated per-request arguments the handlers pass.
+        # A **kwargs signature makes the compat filter pass every kwarg through, so
+        # the record below is exactly what the handler sent.
         self.calls.append(
-            {"session_id": session_id, "parent_session_id": parent_session_id}
+            {
+                name: value
+                for name, value in (
+                    ("session_id", session_id),
+                    ("parent_session_id", parent_session_id),
+                )
+                if value is not _UNSET
+            }
         )
 
         async def stream():
@@ -253,4 +268,4 @@ async def test_generate_without_agent_context_sends_no_session_kwargs():
     async for _ in handler.generate({}, _context()):  # noqa: B007
         pass
 
-    assert engine.calls == [{"session_id": None, "parent_session_id": None}]
+    assert engine.calls == [{}]

--- a/components/src/dynamo/sglang/tests/test_sglang_agent_session.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_agent_session.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for forwarding agent_context session ids to SGLang.
+
+Engine-independent: every kwarg is filtered against the engine's declared
+``async_generate`` signature, so the stubs below stand in for a session-aware
+build, a build predating ``parent_session_id``, and one predating both.
+"""
+
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from dynamo.common.constants import DisaggregationMode
+from dynamo.sglang.agent_session import agent_session_kwargs, session_ids_from_request
+from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
+
+_AGENT_CONTEXT = {"session_id": "child-1", "parent_session_id": "root-0"}
+
+
+class _SessionAwareEngine:
+    """Engine whose async_generate declares both session kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def async_generate(
+        self,
+        session_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        # **kwargs absorbs the unrelated per-request arguments the handlers pass;
+        # the two session kwargs stay declared so the signature filter is exercised.
+        self.calls.append(
+            {"session_id": session_id, "parent_session_id": parent_session_id}
+        )
+
+        async def stream():
+            yield {"text": "", "output_ids": [], "meta_info": {"id": "sglang-rid"}}
+
+        return stream()
+
+
+class _LegacyEngine:
+    """Engine predating session forwarding: neither kwarg exists."""
+
+    async def async_generate(self, prompt=None):
+        raise NotImplementedError
+
+
+class _ParentUnawareEngine:
+    """Engine with the long-standing session_id but no parent_session_id."""
+
+    async def async_generate(self, prompt=None, session_id: Optional[str] = None):
+        raise NotImplementedError
+
+
+# --------------------------------------------------------------------------
+# session_ids_from_request: normalization of the agent_context payload
+# --------------------------------------------------------------------------
+
+
+def test_session_ids_from_request_returns_both_for_a_subagent_request():
+    assert session_ids_from_request({"agent_context": _AGENT_CONTEXT}) == {
+        "session_id": "child-1",
+        "parent_session_id": "root-0",
+    }
+
+
+def test_session_ids_from_request_root_request_has_no_parent():
+    assert session_ids_from_request({"agent_context": {"session_id": "root-0"}}) == {
+        "session_id": "root-0"
+    }
+
+
+def test_session_ids_from_request_trims_surrounding_whitespace():
+    assert session_ids_from_request(
+        {"agent_context": {"session_id": " child-1 ", "parent_session_id": " root-0 "}}
+    ) == {"session_id": "child-1", "parent_session_id": "root-0"}
+
+
+@pytest.mark.parametrize(
+    "request_payload",
+    [
+        {},
+        {"agent_context": None},
+        {"agent_context": "not-a-dict"},
+        {"agent_context": {}},
+        {"agent_context": {"session_id": ""}},
+        {"agent_context": {"session_id": "   "}},
+        {"agent_context": {"session_id": 123}},
+    ],
+)
+def test_session_ids_from_request_absent_or_malformed(request_payload):
+    assert session_ids_from_request(request_payload) == {}
+
+
+def test_session_ids_from_request_normalizes_each_field_independently():
+    """A malformed session_id must not suppress the parent keepalive hint."""
+    assert session_ids_from_request(
+        {"agent_context": {"session_id": None, "parent_session_id": "root-0"}}
+    ) == {"parent_session_id": "root-0"}
+
+
+# --------------------------------------------------------------------------
+# agent_session_kwargs: filtering against the engine signature
+# --------------------------------------------------------------------------
+
+
+def test_session_aware_engine_receives_both_ids():
+    assert agent_session_kwargs(
+        _SessionAwareEngine(), {"agent_context": _AGENT_CONTEXT}
+    ) == {"session_id": "child-1", "parent_session_id": "root-0"}
+
+
+def test_engine_without_the_kwargs_receives_nothing():
+    assert (
+        agent_session_kwargs(_LegacyEngine(), {"agent_context": _AGENT_CONTEXT}) == {}
+    )
+
+
+def test_engine_receives_only_the_kwargs_it_declares():
+    assert agent_session_kwargs(
+        _ParentUnawareEngine(), {"agent_context": _AGENT_CONTEXT}
+    ) == {"session_id": "child-1"}
+
+
+def test_request_without_agent_context_sends_nothing_to_a_capable_engine():
+    assert agent_session_kwargs(_SessionAwareEngine(), {}) == {}
+
+
+# --------------------------------------------------------------------------
+# Handler wiring: the ids reach engine.async_generate on every LLM path
+# --------------------------------------------------------------------------
+
+
+def _stub_generate_dependencies(handler: Any) -> None:
+    """Neutralize the per-request helpers unrelated to session forwarding."""
+    handler._get_input_param = lambda request: {"input_ids": [1, 2, 3]}
+    handler._resolve_lora = lambda request: None
+    handler._priority_kwargs = lambda priority: {}
+    handler.enable_trace = False
+
+
+def _new_decode_handler(engine: Any, serving_mode: DisaggregationMode):
+    handler = DecodeWorkerHandler.__new__(DecodeWorkerHandler)
+    handler.engine = engine
+    handler.serving_mode = serving_mode
+    handler.use_sglang_tokenizer = False
+    handler._first_token_source = None
+    handler._enable_frontend_decoding = False
+    handler._mm_hashes_supported = False
+    handler._routed_experts_kwargs = {}
+    _stub_generate_dependencies(handler)
+    handler._build_sampling_params = lambda request: {"max_new_tokens": 1}
+    handler._build_logprob_kwargs = lambda request: {}
+    handler._metadata_uploader_from_request = lambda request: None
+
+    async def passthrough(stream, context, *args, **kwargs):
+        async for chunk in stream:
+            yield chunk
+
+    handler._process_token_stream = passthrough
+    return handler
+
+
+def _new_prefill_handler(engine: Any):
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = engine
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 8998
+    handler._generate_bootstrap_room = lambda: 42
+    _stub_generate_dependencies(handler)
+    return handler
+
+
+def _context():
+    return SimpleNamespace(
+        id=lambda: "request-id",
+        trace_id="trace-id",
+        trace_headers=lambda: None,
+        is_stopped=lambda: False,
+        notify_first_token=lambda: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregated_generate_forwards_both_session_ids():
+    engine = _SessionAwareEngine()
+    handler = _new_decode_handler(engine, DisaggregationMode.AGGREGATED)
+
+    async for _ in handler.generate(
+        {"agent_context": _AGENT_CONTEXT}, _context()
+    ):  # noqa: B007
+        pass
+
+    assert engine.calls == [{"session_id": "child-1", "parent_session_id": "root-0"}]
+
+
+@pytest.mark.asyncio
+async def test_disaggregated_decode_generate_forwards_both_session_ids():
+    engine = _SessionAwareEngine()
+    handler = _new_decode_handler(engine, DisaggregationMode.DECODE)
+    request = {
+        "agent_context": _AGENT_CONTEXT,
+        "bootstrap_info": {
+            "bootstrap_host": "127.0.0.1",
+            "bootstrap_port": 8998,
+            "bootstrap_room": 42,
+        },
+    }
+
+    async for _ in handler.generate(request, _context()):  # noqa: B007
+        pass
+
+    assert engine.calls == [{"session_id": "child-1", "parent_session_id": "root-0"}]
+
+
+@pytest.mark.asyncio
+async def test_prefill_generate_reads_the_inner_disagg_request():
+    """agent_context rides the inner PreprocessedRequest, not the disagg envelope."""
+    engine = _SessionAwareEngine()
+    handler = _new_prefill_handler(engine)
+    request = {
+        "request": {"agent_context": _AGENT_CONTEXT},
+        "sampling_params": {"max_new_tokens": 16},
+    }
+
+    async for _ in handler.generate(request, _context()):  # noqa: B007
+        break
+
+    assert engine.calls == [{"session_id": "child-1", "parent_session_id": "root-0"}]
+
+
+@pytest.mark.asyncio
+async def test_generate_without_agent_context_sends_no_session_kwargs():
+    engine = _SessionAwareEngine()
+    handler = _new_decode_handler(engine, DisaggregationMode.AGGREGATED)
+
+    async for _ in handler.generate({}, _context()):  # noqa: B007
+        pass
+
+    assert engine.calls == [{"session_id": None, "parent_session_id": None}]


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Forward `session_id` and `parent_session_id` to sglang engine as `agent_context`.
They are currently inert but will become useful in https://github.com/sgl-project/sglang/pull/38681, which optimizes prefix cache usage with the information.

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved agent session identity across SGLang generation requests, including aggregated, disaggregated, and prefill workflows.
  * Supported parent session identifiers when provided through request context.
  * Automatically limited session information to values supported by the selected engine.

* **Bug Fixes**
  * Invalid, blank, missing, or improperly formatted session context no longer disrupts request processing.

* **Documentation**
  * Clarified session identity behavior, lifecycle handling, forwarding rules, and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->