### PR TITLE
fix(epp): return 431 for oversized metadata headers and carry typed MetadataHeaderError

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -51,7 +51,7 @@ pub(crate) fn requested_policy_class(
 ) -> Result<Option<String>, PickError> {
     let metadata =
         extract_metadata_from_header_pairs(headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
-            .map_err(|e| PickError::MetadataHeadersInvalid(e.to_string()))?;
+            .map_err(PickError::MetadataHeadersTooLarge)?;
     Ok(metadata.get("policy-class").cloned())
 }
 
@@ -540,6 +540,23 @@ mod tests {
         // No metadata header → no policy class.
         let headers: Vec<(String, String)> = vec![("x-request-id".to_string(), "r1".to_string())];
         assert_eq!(requested_policy_class(&headers).unwrap(), None);
+    }
+
+    #[test]
+    fn requested_policy_class_preserves_typed_limit_error() {
+        use dynamo_llm::http::service::metadata::MetadataHeaderError;
+
+        let headers: Vec<(String, String)> = (0..65)
+            .map(|i| (format!("x-dynamo-meta-key-{i:02}"), "v".to_string()))
+            .collect();
+        let err = requested_policy_class(&headers).expect_err("65 metadata entries must fail");
+        assert!(
+            matches!(
+                err,
+                PickError::MetadataHeadersTooLarge(MetadataHeaderError::TooManyEntries { .. })
+            ),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
+use dynamo_llm::http::service::metadata::MetadataHeaderError;
 
 /// A model server pod endpoint available for serving requests.
 #[derive(Debug, Clone)]
@@ -158,11 +159,10 @@ pub enum PickError {
     /// Malformed client input (unparseable body, or a 4xx from the renderer) → 400.
     #[error("invalid request: {0}")]
     InvalidRequest(String),
-    /// Metadata headers exceeded the frontend's entry/size limits → 400. The
-    /// frontend rejects these requests too; the EPP surfaces the same client
-    /// error rather than silently dropping the metadata.
-    #[error("metadata headers invalid: {0}")]
-    MetadataHeadersInvalid(String),
+    /// Metadata headers exceeded the frontend's entry/size limits → 431, the
+    /// same status the frontend returns.
+    #[error("metadata headers too large: {0}")]
+    MetadataHeadersTooLarge(MetadataHeaderError),
     /// The upstream tokenization service could not be reached → 503.
     #[error("tokenization service unavailable")]
     TokenizerUnavailable,

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -945,9 +945,9 @@ impl ExtProcError {
                 status_code: StatusCode::BadRequest,
                 message: msg,
             },
-            PickError::MetadataHeadersInvalid(msg) => Self {
-                status_code: StatusCode::BadRequest,
-                message: msg,
+            PickError::MetadataHeadersTooLarge(err) => Self {
+                status_code: StatusCode::RequestHeaderFieldsTooLarge,
+                message: err.to_string(),
             },
             // Upstream tokenizer failures are not client errors: preserve their
             // semantics so clients retry appropriately. `e.to_string()` is the
@@ -1593,13 +1593,11 @@ mod tests {
         assert_eq!(err.status_code, StatusCode::ServiceUnavailable);
     }
 
-    /// Metadata headers over the frontend's limits map to a client 400, not a
-    /// retryable 503: the frontend rejects these requests too.
     #[test]
-    fn metadata_headers_invalid_maps_to_400() {
-        let err = ExtProcError::from_pick_error(PickError::MetadataHeadersInvalid(
-            "metadata headers exceed the limit of 64 entries".to_string(),
+    fn metadata_headers_too_large_maps_to_431() {
+        let err = ExtProcError::from_pick_error(PickError::MetadataHeadersTooLarge(
+            dynamo_llm::http::service::metadata::MetadataHeaderError::TooManyEntries { limit: 64 },
         ));
-        assert_eq!(err.status_code, StatusCode::BadRequest);
+        assert_eq!(err.status_code, StatusCode::RequestHeaderFieldsTooLarge);
     }
 }


### PR DESCRIPTION
## Overview:

Follow-up to the standalone-EPP scheduling-metadata propagation change, addressing a review nit([#13595](https://github.com/ai-dynamo/dynamo/pull/13595#discussion_r3937469164)): the pick-error boundary flattened `MetadataHeaderError` to a string and mapped oversized metadata headers to 400, while the integrated frontend returns 431 for the same failure. 

This change carries the typed error through `PickError` and returns `RequestHeaderFieldsTooLarge` (431), keeping the
standalone EPP and the integrated frontend consistent for this client error.

## Details:

- `PickError::MetadataHeadersInvalid(String)` →  `MetadataHeadersTooLarge(MetadataHeaderError)`. The two limit kinds  (`TooManyEntries`, `TooLarge`) now stay distinguishable.

- `epp_router::requested_policy_class` propagates the typed error unchanged  (no `to_string()` at the boundary).

- `server.rs::from_pick_error` maps it to `StatusCode::RequestHeaderFieldsTooLarge` (431)

- Update and add a new test.

## Validation

- `cargo test -p dynamo-ext-proc --lib` — 155 passed, 0 failed

- `cargo clippy -p dynamo-ext-proc` — no warnings.


## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with too many metadata headers now return HTTP 431 (“Request Header Fields Too Large”).
  * Error details for oversized metadata headers are preserved and presented more accurately.
  * Added coverage to verify handling of metadata requests exceeding the allowed entry limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->