### PR TITLE
feat(llm): add native DeepSeek V4.1 frontend support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,9 +2863,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
+version = "0.5.3"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -2880,9 +2879,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
+version = "5.4.3"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2897,9 +2895,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a5b79eefdfd2bb2c01f3a187f9367db598db58a4cf17550d20f79c97656b66"
+version = "5.1.2"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3070,9 +3067,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821c767e896f1f225b6411a5ce41dba7f114c2c97db862a13fd962195665075e"
+version = "1.8.1"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -7455,7 +7451,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7475,7 +7471,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ aisimulate-core = { version = "=0.1.0-dev.2" }
 dynamo-runtime = { path = "lib/runtime", version = "1.5.0" }
 dynamo-llm = { path = "lib/llm", version = "1.5.0" }
 dynamo-rl = { path = "lib/rl", version = "1.5.0" }
-dynamo-tokenizers = { version = "=1.8.0" }
-dynamo-renderer = { version = "=5.1.0" }
+dynamo-tokenizers = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }
+dynamo-renderer = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }
 dynamo-tokens = { path = "lib/tokens", version = "1.5.0" }
 dynamo-truthy = { path = "lib/truthy", version = "1.5.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.5.0" }
@@ -71,13 +71,10 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
-dynamo-protocols = { version = "=5.4.1" }
+dynamo-protocols = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }
 dynamo-parsers = { version = "8.1.0" }
 
-# Published on crates.io. To see all available versions:
-#   web:          https://crates.io/crates/dynamo-parsers-v2/versions
-#   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.3.2" }
+dynamo-parsers-v2 = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.5.0" }
 dynamo-sidecar-common = { path = "lib/sidecar/common", version = "1.5.0" }
 fastokens = { version = "0.2.0" }
@@ -218,3 +215,6 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
+
+[patch.crates-io]
+dynamo-protocols = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2347,9 +2347,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
+version = "0.5.3"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -2364,9 +2363,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
+version = "5.4.3"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2427,9 +2425,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a5b79eefdfd2bb2c01f3a187f9367db598db58a4cf17550d20f79c97656b66"
+version = "5.1.2"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2573,9 +2570,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821c767e896f1f225b6411a5ce41dba7f114c2c97db862a13fd962195665075e"
+version = "1.8.1"
+source = "git+https://github.com/abatilo/frontend-crates.git?rev=7b440444c9a296032386642bf6109bb700128632#7b440444c9a296032386642bf6109bb700128632"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -138,3 +138,6 @@ tracing-subscriber = { version = "0.3", features = ["registry"] }
 inherits = "release"
 debug = true
 strip = false
+
+[patch.crates-io]
+dynamo-protocols = { git = "https://github.com/abatilo/frontend-crates.git", rev = "7b440444c9a296032386642bf6109bb700128632" }

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -6,10 +6,7 @@ use dynamo_parsers::reasoning::get_available_reasoning_parsers;
 use dynamo_parsers::tool_calling::parsers::get_available_tool_parsers;
 use pyo3::prelude::*;
 
-/// Append the muse unified family names, skipping any already present. fc's v1
-/// registries dropped muse, so it lives only in dynamo's `UNIFIED_FAMILIES`;
-/// `unified_family` routes to the unified pass when EITHER the tool-call or the
-/// reasoning parser is a muse name, so both name lists must accept muse.
+/// Unified-only families are absent from the legacy parser registries.
 fn with_unified_families(mut names: Vec<&'static str>) -> Vec<&'static str> {
     for &name in unified_family_names() {
         if !names.contains(&name) {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -430,6 +430,7 @@ where
 
         card.download_config(self.local_model_path.as_deref())
             .await?;
+        card.runtime_config = card.frontend_runtime_config()?;
 
         validate_selector_worker_role(card, self.require_typed_worker_role)?;
 

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -560,6 +560,16 @@ fn validate_kv_transfer_domain(domain: &str) -> Result<(), ValidationError> {
 }
 
 fn validate_model_runtime_config(config: &ModelRuntimeConfig) -> Result<(), ValidationError> {
+    let parsers = [
+        config.tool_call_parser.as_deref(),
+        config.reasoning_parser.as_deref(),
+    ];
+    if parsers.contains(&Some("deepseek_v41")) && parsers != [Some("deepseek_v41"); 2] {
+        return Err(validation_error(
+            "incompatible_parser_pair",
+            "deepseek_v41 requires both tool_call_parser and reasoning_parser to be deepseek_v41",
+        ));
+    }
     if config.data_parallel_size == 0 {
         return Err(validation_error(
             "invalid_data_parallel_size",
@@ -1333,10 +1343,29 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_v41_rejects_conflicting_parser_pairs() {
+        for (tool, reasoning, valid) in [
+            (Some("deepseek_v41"), None, false),
+            (None, Some("deepseek_v41"), false),
+            (Some("deepseek_v41"), Some("deepseek_v41"), true),
+            (Some("deepseek_v41"), Some("qwen3"), false),
+            (Some("qwen3_coder"), Some("deepseek_v41"), false),
+        ] {
+            let config = ModelRuntimeConfig {
+                tool_call_parser: tool.map(str::to_string),
+                reasoning_parser: reasoning.map(str::to_string),
+                ..Default::default()
+            };
+            assert_eq!(validate_model_runtime_config(&config).is_ok(), valid);
+        }
+    }
+
+    #[test]
     fn test_validate_config_checks_tool_call_parser() {
         let validate = |parser: &str| {
             ModelRuntimeConfig {
                 tool_call_parser: Some(parser.to_string()),
+                reasoning_parser: (parser == "deepseek_v41").then(|| parser.to_string()),
                 ..Default::default()
             }
             .validate_config()

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -990,6 +990,27 @@ pub struct LoraInfo {
 }
 
 impl ModelDeploymentCard {
+    pub(crate) fn frontend_runtime_config(&self) -> Result<ModelRuntimeConfig> {
+        let mut config = self.runtime_config.clone();
+        let parsers = [
+            config.tool_call_parser.as_deref(),
+            config.reasoning_parser.as_deref(),
+        ];
+        anyhow::ensure!(
+            !parsers.contains(&Some("deepseek_v41")) || parsers == [Some("deepseek_v41"); 2],
+            "deepseek_v41 requires both tool_call_parser and reasoning_parser to be deepseek_v41"
+        );
+        if parsers == [None; 2]
+            && (self.model_type.supports_chat() || self.model_type.supports_completions())
+            && let Some(info) = &self.model_info
+            && info.get_model_info()?.model_type() == "deepseek_v41"
+        {
+            config.tool_call_parser = Some("deepseek_v41".into());
+            config.reasoning_parser = Some("deepseek_v41".into());
+        }
+        Ok(config)
+    }
+
     /// Number of typed metadata slots (`model_info`, `tokenizer`,
     /// `prompt_formatter`, `chat_template_file`, `gen_config`). Used as
     /// a capacity hint for [`Self::iter_metadata_files`].
@@ -2389,6 +2410,61 @@ mod tests {
     use super::{HFConfig, ModelDeploymentCard};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn frontend_v41_parser_pairs_validate_without_model_files() {
+        for (tool, reasoning, valid) in [
+            (None, None, true),
+            (Some("qwen3_coder"), Some("qwen3"), true),
+            (Some("deepseek_v41"), Some("deepseek_v41"), true),
+            (Some("deepseek_v41"), None, false),
+            (None, Some("deepseek_v41"), false),
+            (Some("deepseek_v41"), Some("qwen3"), false),
+        ] {
+            let mut card = ModelDeploymentCard::with_name_only("test");
+            card.runtime_config.tool_call_parser = tool.map(str::to_string);
+            card.runtime_config.reasoning_parser = reasoning.map(str::to_string);
+            let result = card.frontend_runtime_config();
+            assert_eq!(result.is_ok(), valid);
+            if let Ok(config) = result {
+                assert_eq!(config.tool_call_parser.as_deref(), tool);
+                assert_eq!(config.reasoning_parser.as_deref(), reasoning);
+            }
+        }
+    }
+
+    #[test]
+    fn frontend_v41_options_survive_metadata_removal_without_changing_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{"architectures":[],"model_type":"deepseek_v41","eos_token_id":2}"#,
+        )
+        .unwrap();
+        let mut original = ModelDeploymentCard::with_name_only("v41");
+        original.model_type = crate::model_type::ModelType::Chat;
+        original.model_info = Some(super::ModelInfoType::from_disk(dir.path()).unwrap());
+        let mut prepared = original.clone();
+        prepared.runtime_config = prepared.frontend_runtime_config().unwrap();
+        assert!(original.runtime_config.tool_call_parser.is_none());
+        assert!(original.runtime_config.reasoning_parser.is_none());
+        assert_eq!(prepared.mdcsum(), original.mdcsum());
+        let set =
+            crate::discovery::WorkerSet::new("test".into(), prepared.mdcsum().into(), prepared);
+        dir.close().unwrap();
+        let mut embedding = original;
+        embedding.model_type = crate::model_type::ModelType::Embedding;
+        assert!(
+            embedding
+                .frontend_runtime_config()
+                .unwrap()
+                .tool_call_parser
+                .is_none()
+        );
+        let options = set.parsing_options();
+        assert_eq!(options.tool_call_parser.as_deref(), Some("deepseek_v41"));
+        assert_eq!(options.reasoning_parser.as_deref(), Some("deepseek_v41"));
+    }
 
     #[test]
     fn tokenizer_cache_token_observer_records_per_model_totals() {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -178,7 +178,7 @@ fn validate_legacy_jail_nvext_choice_count(
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum ToolProcessingRoute {
     MuseUnified(String),
-    QwenUnified(&'static str),
+    Unified(&'static str),
     ParserV2(String),
     LegacyJail(Option<String>),
     PassThrough,
@@ -1954,9 +1954,9 @@ impl OpenAIPreprocessor {
             Some("deepseek_v3" | "deepseek_v3_1") => {
                 Self::deepseek_renderer_reasoning_enabled(chat_template_args, false)
             }
-            Some("deepseek_v3_2" | "deepseek_v4" | "deepseek-v4" | "deepseekv4") => {
-                Self::deepseek_renderer_reasoning_enabled(chat_template_args, true)
-            }
+            Some(
+                "deepseek_v3_2" | "deepseek_v4" | "deepseek-v4" | "deepseekv4" | "deepseek_v41",
+            ) => Self::deepseek_renderer_reasoning_enabled(chat_template_args, true),
             Some("gemma4" | "gemma-4") => thinking_enabled == Some(true),
 
             // SGLang's Mistral reasoner is active only for a concrete effort.
@@ -2264,7 +2264,8 @@ impl OpenAIPreprocessor {
             );
         };
         let model_info = model_info.get_model_info()?;
-        let tool_call_parser = mdc.runtime_config.tool_call_parser.clone();
+        let runtime_config = mdc.frontend_runtime_config()?;
+        let tool_call_parser = runtime_config.tool_call_parser.clone();
         let normalize_tool_call_args = mdc.runtime_config.tool_call_arguments_format
             == crate::local_model::runtime_config::ToolCallArgumentsFormat::JsonObject
             || mdc.runtime_config.tool_call_parser.as_deref() == Some("glm47");
@@ -2273,8 +2274,6 @@ impl OpenAIPreprocessor {
             tracing::info!(model = %mdc.display_name, lora_name, "LoRA adapter detected in MDC");
         }
 
-        // // Initialize runtime config from the ModelDeploymentCard
-        let runtime_config = mdc.runtime_config.clone();
         let token_budget = match runtime_config
             .get_engine_specific::<TokenBudget>(TOKEN_BUDGET_RUNTIME_KEY)
         {
@@ -4531,7 +4530,7 @@ impl OpenAIPreprocessor {
             self.tool_call_parser.as_deref(),
             self.runtime_config.reasoning_parser.as_deref(),
         ) {
-            return Ok(ToolProcessingRoute::QwenUnified(family));
+            return Ok(ToolProcessingRoute::Unified(family));
         }
 
         let effective_tool_call_parser = self.tool_call_parser.clone().or_else(|| {
@@ -4680,7 +4679,7 @@ impl OpenAIPreprocessor {
             ));
         }
 
-        if let ToolProcessingRoute::QwenUnified(family) = &tool_processing_route {
+        if let ToolProcessingRoute::Unified(family) = &tool_processing_route {
             let tool_definitions = request.inner.tools.as_ref().map(|tools| {
                 tools
                     .iter()
@@ -4846,7 +4845,7 @@ impl OpenAIPreprocessor {
                     ))
                 }
                 ToolProcessingRoute::PassThrough => Box::pin(stream),
-                ToolProcessingRoute::MuseUnified(_) | ToolProcessingRoute::QwenUnified(_) => {
+                ToolProcessingRoute::MuseUnified(_) | ToolProcessingRoute::Unified(_) => {
                     unreachable!("unified routes return before legacy response processing")
                 }
             };
@@ -5875,6 +5874,7 @@ impl OpenAIPreprocessor {
                 | Some("inkling")
                 | Some("muse_glimmer")
                 | Some("muse")
+                | Some("deepseek_v41")
         ) || matches!(
             reasoning_parser,
             Some("gemma4")
@@ -5889,6 +5889,7 @@ impl OpenAIPreprocessor {
                 | Some("inkling")
                 | Some("muse_glimmer")
                 | Some("muse")
+                | Some("deepseek_v41")
         )
     }
 
@@ -6048,6 +6049,7 @@ impl OpenAIPreprocessor {
             reasoning_parser,
             Some(
                 "deepseek_v4"
+                    | "deepseek_v41"
                     | "deepseek-v4"
                     | "deepseekv4"
                     | "glm45"
@@ -6083,7 +6085,9 @@ impl OpenAIPreprocessor {
     ) -> Option<bool> {
         let should_forward = matches!(
             reasoning_parser,
-            Some("minimax_m2" | "minimax_m3" | "minimax-m3" | "kimi_k3" | "kimi-k3")
+            Some(
+                "minimax_m2" | "minimax_m3" | "minimax-m3" | "kimi_k3" | "kimi-k3" | "deepseek_v41"
+            )
         );
         if should_forward
             && Self::prompt_injected_reasoning_start(reasoning_parser, formatted_prompt)
@@ -6140,7 +6144,7 @@ impl OpenAIPreprocessor {
             }
             Some(
                 "deepseek_r1" | "deepseek_v3_2" | "deepseek_v4" | "deepseek-v4" | "deepseekv4"
-                | "minimax_m2",
+                | "deepseek_v41" | "minimax_m2",
             ) => !Self::deepseek_renderer_reasoning_enabled(chat_template_args, true),
             Some("gemma4") | Some("gemma-4") => {
                 dynamo_renderer::thinking_bool_from_args(chat_template_args) != Some(true)
@@ -7376,6 +7380,73 @@ mod tests {
     };
 
     #[test]
+    fn deepseek_v41_defaults_missing_worker_parser_metadata() {
+        let mut mdc = ModelDeploymentCard::load_from_disk(
+            "tests/data/sample-models/mock-llama-3.1-8b-instruct",
+            None,
+        )
+        .unwrap();
+        mdc.model_type = crate::model_type::ModelType::Chat;
+        let model_dir = tempfile::tempdir().unwrap();
+        let mut config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(
+                "tests/data/sample-models/mock-llama-3.1-8b-instruct/config.json",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        config["model_type"] = serde_json::json!("deepseek_v41");
+        std::fs::write(model_dir.path().join("config.json"), config.to_string()).unwrap();
+        mdc.model_info =
+            Some(crate::model_card::ModelInfoType::from_disk(model_dir.path()).unwrap());
+        let preprocessor = OpenAIPreprocessor::new(mdc.clone()).unwrap();
+        assert_eq!(
+            preprocessor.tool_call_parser.as_deref(),
+            Some("deepseek_v41")
+        );
+        assert_eq!(
+            preprocessor.runtime_config.reasoning_parser.as_deref(),
+            Some("deepseek_v41")
+        );
+        mdc.runtime_config.tool_call_parser = Some("qwen3_coder".into());
+        mdc.runtime_config.reasoning_parser = Some("qwen3".into());
+        let explicit = OpenAIPreprocessor::new(mdc).unwrap();
+        assert_eq!(explicit.tool_call_parser.as_deref(), Some("qwen3_coder"));
+        assert_eq!(
+            explicit.runtime_config.reasoning_parser.as_deref(),
+            Some("qwen3")
+        );
+    }
+
+    #[test]
+    fn deepseek_v41_preserves_markers_and_initializes_backend_reasoning() {
+        for (tool, reasoning) in [(Some("deepseek_v41"), None), (None, Some("deepseek_v41"))] {
+            assert!(OpenAIPreprocessor::parser_requires_special_tokens(
+                tool, reasoning
+            ));
+        }
+        assert_eq!(
+            OpenAIPreprocessor::prompt_injected_reasoning_ended_arg(
+                Some("deepseek_v41"),
+                Some("<｜Assistant｜><think>"),
+            ),
+            Some(false)
+        );
+        assert_eq!(
+            OpenAIPreprocessor::prompt_injected_reasoning_ended_arg(
+                Some("deepseek_v41"),
+                Some("<｜Assistant｜></think>"),
+            ),
+            None
+        );
+        let disabled = HashMap::from([("thinking".to_string(), serde_json::json!(false))]);
+        assert!(OpenAIPreprocessor::is_reasoning_disabled_by_request(
+            Some("deepseek_v41"),
+            Some(&disabled)
+        ));
+    }
+
+    #[test]
     fn guided_tool_streaming_release_only_when_guided_json_and_not_rolled_back() {
         assert!(
             OpenAIPreprocessor::guided_tool_streaming_release(true, false),
@@ -7407,7 +7478,7 @@ mod tests {
 
         for route in [
             ToolProcessingRoute::MuseUnified("muse_glimmer".to_string()),
-            ToolProcessingRoute::QwenUnified("qwen3"),
+            ToolProcessingRoute::Unified("qwen3"),
             ToolProcessingRoute::ParserV2("qwen3_coder".to_string()),
             ToolProcessingRoute::PassThrough,
         ] {

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -79,12 +79,9 @@ pub(crate) fn supports_family(family: &str) -> bool {
 /// engine, so it is not accepted.
 pub(crate) const UNIFIED_FAMILIES: &[&str] = &["muse_glimmer", "muse"];
 
-/// The parser names that route through the muse unified pass. Public accessor for
-/// [`UNIFIED_FAMILIES`] so the Python bindings can add muse to the selectable
-/// tool-call and reasoning parser names — fc's v1 registries dropped muse, so this
-/// is the only source of truth for the unified names.
+/// Parser names served exclusively by unified parsers, exposed to configuration and Python.
 pub fn unified_family_names() -> &'static [&'static str] {
-    UNIFIED_FAMILIES
+    &["muse_glimmer", "muse", "deepseek_v41"]
 }
 
 /// The unified family for a request, or `None`. Keyed on EITHER the tool-call or

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Opt-in ordered reasoning, text, and tool-call parsing through one state machine.
+//! Ordered reasoning, text, and tool-call parsing through one state machine.
 //!
-//! Gated behind
+//! Qwen3 is gated behind
 //! [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](dynamo_runtime::config::environment_names::llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2).
 //!
 //! # What this replaces
@@ -67,6 +67,7 @@ use dynamo_protocols::types::ChatCompletionToolChoiceOption;
 /// the same XML grammar; `qwen3` is the canonical registry name and the one the
 /// conformance corpus uses, so it is what this module passes and logs.
 pub(crate) const QWEN3_UNIFIED_FAMILY: &str = "qwen3";
+pub(crate) const DEEPSEEK_V41_UNIFIED_FAMILY: &str = "deepseek_v41";
 
 /// Dynamo's `--dyn-tool-call-parser` name that pairs into [`QWEN3_UNIFIED_FAMILY`].
 const QWEN3_TOOL_CALL_PARSER: &str = "qwen3_coder";
@@ -91,19 +92,16 @@ fn experimental_parsers_v2_enabled() -> bool {
     *ENABLED
 }
 
-/// The unified family this parser pair names, ignoring whether it is switched on.
-///
-/// Both halves must be set and must agree: a unified parser owns reasoning AND tool
-/// calls, so taking over a request configured with only one of them, or with a
-/// reasoning parser from a different family, would silently change what the operator
-/// asked for. Split out from [`selected_family`] so the pairing rule can be tested
-/// without the process-wide env flag.
+/// Both parser names must agree because a unified parser owns reasoning and tool calls.
 pub(crate) fn configured_family(
     tool_call_parser: Option<&str>,
     reasoning_parser: Option<&str>,
 ) -> Option<&'static str> {
     match (tool_call_parser, reasoning_parser) {
         (Some(QWEN3_TOOL_CALL_PARSER), Some(QWEN3_REASONING_PARSER)) => Some(QWEN3_UNIFIED_FAMILY),
+        (Some(DEEPSEEK_V41_UNIFIED_FAMILY), Some(DEEPSEEK_V41_UNIFIED_FAMILY)) => {
+            Some(DEEPSEEK_V41_UNIFIED_FAMILY)
+        }
         _ => None,
     }
 }
@@ -130,7 +128,7 @@ pub(crate) fn selected_family(
     );
     configured.filter(|family| match *family {
         QWEN3_UNIFIED_FAMILY => experimental_parsers_v2_enabled(),
-        // A family with no opt-in flag stays off; adding one here is what turns it on.
+        DEEPSEEK_V41_UNIFIED_FAMILY => true,
         _ => false,
     })
 }
@@ -154,6 +152,7 @@ pub(crate) fn selected_batch_family(
 ) -> Option<&'static str> {
     configured_batch_family(tool_call_parser, reasoning_parser).filter(|family| match *family {
         QWEN3_UNIFIED_FAMILY => experimental_parsers_v2_enabled(),
+        DEEPSEEK_V41_UNIFIED_FAMILY => true,
         _ => false,
     })
 }
@@ -175,9 +174,7 @@ pub(crate) fn stream_prefill(
         // Qwen3's generation prompt ends at the assistant header with no channel open,
         // so the model emits `<think>` itself when it thinks.
         QWEN3_UNIFIED_FAMILY => UnifiedParserStartingState::None,
-        // A family whose non-thinking prompt ends INSIDE the visible response channel
-        // would return `Response` here. None exists yet; an unknown family gets the
-        // conservative answer, which is to assume the model opens its own channels.
+        DEEPSEEK_V41_UNIFIED_FAMILY => UnifiedParserStartingState::Response,
         _ => UnifiedParserStartingState::None,
     }
 }
@@ -231,7 +228,7 @@ fn bare_guided_json_prefill(
 /// neither marker means reasoning never ran for this turn.
 fn detect_prefill(family: &str, content: &str) -> anyhow::Result<UnifiedParserStartingState> {
     match family {
-        QWEN3_UNIFIED_FAMILY => {
+        QWEN3_UNIFIED_FAMILY | DEEPSEEK_V41_UNIFIED_FAMILY => {
             // Compare FIRST-occurrence positions, not mere presence: a prompt that
             // pre-opened reasoning produces a leading `</think>` with no opener before
             // it, but a later `<think>...</think>` pair from the model can still follow
@@ -497,8 +494,7 @@ pub(crate) struct ChoiceState {
     opened_calls: HashSet<usize>,
     /// Whether any tool-call chunk was emitted; flips a terminal `Stop` to `ToolCalls`.
     tool_emitted: bool,
-    /// The parser errored. Later chunks pass through as plain text instead of failing
-    /// the request — a parser bug must not turn a served answer into a 500.
+    /// Parsing failed; the stream adapter selects recovery or a terminal error.
     failed: bool,
 }
 
@@ -560,7 +556,7 @@ impl ChoiceState {
                 tracing::warn!(
                     error = %error,
                     family = self.family,
-                    "unified parser push failed; falling back to plain text for this choice"
+                    "unified parser push failed"
                 );
                 output.events.extend(self.give_up(text));
                 output.events
@@ -581,7 +577,7 @@ impl ChoiceState {
                 tracing::warn!(
                     error = %error,
                     family = self.family,
-                    "unified parser finish failed; recovering buffered text"
+                    "unified parser finish failed"
                 );
                 self.give_up("")
             }
@@ -1054,7 +1050,12 @@ where
                 // A usage-only chunk. OpenAI stream ordering requires every choice's
                 // terminal finish_reason to precede it, so flush first.
                 if let Some(template) = &template {
-                    for choice in finish_unterminated_choices(&mut states, &mut records) {
+                    let choices = finish_unterminated_choices(&mut states, &mut records);
+                    if family == DEEPSEEK_V41_UNIFIED_FAMILY && states.values().any(|state| state.failed) {
+                        yield Annotated::from_error("DeepSeek V4.1 output parsing failed");
+                        return;
+                    }
+                    for choice in choices {
                         yield response_with_choice(template, choice);
                     }
                 }
@@ -1107,6 +1108,10 @@ where
                                 original.finish_reason
                             };
                         let deltas = state.finish();
+                        if family == DEEPSEEK_V41_UNIFIED_FAMILY && state.failed {
+                            yield Annotated::from_error("DeepSeek V4.1 output parsing failed");
+                            return;
+                        }
                         emitted.extend(state.choices_for(
                             &empty_choice(original.index),
                             deltas,
@@ -1193,6 +1198,10 @@ where
                     records.entry(original.index).or_default().finished = true;
                 }
 
+                if family == DEEPSEEK_V41_UNIFIED_FAMILY && state.failed {
+                    yield Annotated::from_error("DeepSeek V4.1 output parsing failed");
+                    return;
+                }
                 let mut parsed = state.choices_for(&original, deltas, true, terminal);
                 if parsed.is_empty() {
                     // A marker-only chunk produced no deltas. Keep it as an empty
@@ -1238,7 +1247,12 @@ where
 
         // Backstop: the stream ended without a terminating chunk for some choice.
         if let Some(template) = &template {
-            for choice in finish_unterminated_choices(&mut states, &mut records) {
+            let choices = finish_unterminated_choices(&mut states, &mut records);
+            if family == DEEPSEEK_V41_UNIFIED_FAMILY && states.values().any(|state| state.failed) {
+                yield Annotated::from_error("DeepSeek V4.1 output parsing failed");
+                return;
+            }
+            for choice in choices {
                 yield response_with_choice(template, choice);
             }
         }
@@ -1417,6 +1431,163 @@ mod tests {
     }
 
     // --- selected_family / configured_family -------------------------------------
+
+    #[test]
+    fn deepseek_v41_uses_native_parsing_without_an_experimental_flag() {
+        let pair = (Some("deepseek_v41"), Some("deepseek_v41"));
+        assert_eq!(configured_family(pair.0, pair.1), Some("deepseek_v41"));
+        assert_eq!(selected_family(pair.0, pair.1), Some("deepseek_v41"));
+        assert_eq!(selected_batch_family(pair.0, pair.1), Some("deepseek_v41"));
+        assert_eq!(configured_family(Some("deepseek_v41"), Some("qwen3")), None);
+        assert_eq!(configured_family(Some("deepseek_v41"), None), None);
+        assert_eq!(configured_family(None, Some("deepseek_v41")), None);
+    }
+
+    #[tokio::test]
+    async fn deepseek_v41_preserves_calls_across_utf8_chunk_boundaries() {
+        let call = concat!(
+            "<｜DSML｜ calls><｜DSML｜ invoke name=\"get_weather\">",
+            "<｜DSML｜ parameter name=\"city\" string=\"true\">東京</｜DSML｜ parameter>",
+            "</｜DSML｜ invoke></｜DSML｜ calls>"
+        );
+        for (prefix, prefill, reasoning) in [
+            ("", UnifiedParserStartingState::Response, ""),
+            (
+                "plan</think>",
+                UnifiedParserStartingState::Reasoning,
+                "plan",
+            ),
+            (
+                "<think>plan</think>",
+                UnifiedParserStartingState::None,
+                "plan",
+            ),
+        ] {
+            let input = format!("{prefix}{call}");
+            let batch = parse_complete(
+                DEEPSEEK_V41_UNIFIED_FAMILY,
+                &input,
+                &GuidedToolConstraint::None,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(batch.reasoning, reasoning);
+            assert_eq!(batch.tool_calls.len(), 1);
+            assert_eq!(batch.tool_calls[0].function.arguments, r#"{"city":"東京"}"#);
+            for split in input.char_indices().map(|(index, _)| index) {
+                let (first, second) = input.split_at(split);
+                let responses = apply_stream(
+                    stream::iter([chunk(first, false), chunk(second, true)]),
+                    Some(weather_tools()),
+                    None,
+                    false,
+                    prefill,
+                    DEEPSEEK_V41_UNIFIED_FAMILY,
+                )
+                .collect::<Vec<_>>()
+                .await;
+                let mut expected = Vec::new();
+                if !reasoning.is_empty() {
+                    expected.push(LogicalEvent::Reasoning(reasoning.to_string()));
+                }
+                expected.push(LogicalEvent::Tool {
+                    index: 0,
+                    name: Some("get_weather".to_string()),
+                    arguments: r#"{"city":"東京"}"#.to_string(),
+                });
+                let mut actual = logical_events(&responses);
+                for event in &mut actual {
+                    if let LogicalEvent::Tool { arguments, .. } = event {
+                        *arguments = serde_json::from_str::<serde_json::Value>(arguments)
+                            .unwrap()
+                            .to_string();
+                    }
+                }
+                assert_eq!(actual, expected, "split={split}");
+                assert_eq!(
+                    collect_choices(&responses).last().unwrap().finish_reason,
+                    Some(FinishReason::ToolCalls)
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn deepseek_v41_rejects_malformed_closed_arguments() {
+        let text = concat!(
+            "<｜DSML｜ calls><｜DSML｜ invoke name=\"get_weather\">",
+            "<｜DSML｜ parameter name=\"count\" string=\"false\">not-json</｜DSML｜ parameter>",
+            "</｜DSML｜ invoke></｜DSML｜ calls>"
+        );
+        let responses = apply_stream(
+            stream::iter([chunk(text, true)]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::Response,
+            DEEPSEEK_V41_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        assert!(responses.iter().any(Annotated::is_error));
+        assert!(logical_events(&responses).is_empty());
+        assert!(collect_choices(&responses).is_empty());
+    }
+
+    #[tokio::test]
+    async fn deepseek_v41_preserves_length_for_incomplete_calls() {
+        let text = concat!(
+            "<｜DSML｜ calls><｜DSML｜ invoke name=\"get_weather\">",
+            "<｜DSML｜ parameter name=\"count\" string=\"false\">1"
+        );
+        let mut terminal = chunk(text, true);
+        terminal.data.as_mut().unwrap().inner.choices[0].finish_reason = Some(FinishReason::Length);
+        let responses = apply_stream(
+            stream::iter([terminal]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::Response,
+            DEEPSEEK_V41_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        assert!(!responses.iter().any(Annotated::is_error));
+        assert_eq!(
+            collect_choices(&responses).last().unwrap().finish_reason,
+            Some(FinishReason::Length)
+        );
+    }
+
+    #[test]
+    fn deepseek_v41_plain_text_and_guided_calls_use_the_same_decoder() {
+        for text in ["Hello.", "2 < 3", "partial <｜DSML", "Visible café 東京"] {
+            let parsed = parse_complete(
+                DEEPSEEK_V41_UNIFIED_FAMILY,
+                text,
+                &GuidedToolConstraint::None,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(parsed.text, text);
+            assert!(parsed.reasoning.is_empty());
+            assert!(parsed.tool_calls.is_empty());
+        }
+        let parsed = parse_complete(
+            DEEPSEEK_V41_UNIFIED_FAMILY,
+            r#"{"city":"Tokyo"}"#,
+            &GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            },
+            &weather_tools(),
+        )
+        .unwrap();
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(
+            parsed.tool_calls[0].function.arguments,
+            r#"{"city":"Tokyo"}"#
+        );
+    }
 
     #[test]
     fn pairs_only_qwen3_coder_with_qwen3() {
@@ -1685,6 +1856,7 @@ mod tests {
             tool_index,
             name: name.map(str::to_string),
             arguments: arguments.to_string(),
+            complete: true,
         })
     }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -373,25 +373,6 @@ fn convert_input_content_to_text(content: &[InputContent]) -> String {
         .join("")
 }
 
-/// Counterpart to `convert_input_content_to_text` for upstream's
-/// `InputContent`. Reachable only via `FunctionCallOutput::Content`, which is
-/// not Dynamo-owned and therefore carries upstream variants. The sibling
-/// `EasyInputContent::ContentList` is Dynamo-owned and routed through
-/// `convert_input_content_to_text` / `convert_input_content_to_user_content`.
-fn convert_upstream_input_content_to_text(
-    content: &[dynamo_protocols::types::responses::UpstreamInputContent],
-) -> String {
-    use dynamo_protocols::types::responses::UpstreamInputContent;
-    content
-        .iter()
-        .filter_map(|p| match p {
-            UpstreamInputContent::InputText(t) => Some(t.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
 /// Accumulator for consecutive assistant-side items (OutputMessage, FunctionCall,
 /// Reasoning, assistant EasyMessage). Chat Completions represents an assistant
 /// turn as a single message carrying `content`, `tool_calls`, and
@@ -559,9 +540,7 @@ fn convert_input_items_to_messages(
                     std::mem::take(&mut pending).flush_into(&mut messages);
                     let output_text = match &fco.output {
                         FunctionCallOutput::Text(text) => text.clone(),
-                        FunctionCallOutput::Content(parts) => {
-                            convert_upstream_input_content_to_text(parts)
-                        }
+                        FunctionCallOutput::Content(parts) => convert_input_content_to_text(parts),
                     };
                     messages.push(ChatCompletionRequestMessage::Tool(
                         ChatCompletionRequestToolMessage {

--- a/lib/llm/tests/deepseek_v41_renderer.rs
+++ b/lib/llm/tests/deepseek_v41_renderer.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
+use dynamo_renderer::{OAIPromptFormatter, deepseek::v41::DeepSeekV41Formatter};
+use serde_json::{Value, json};
+
+fn render(fields: Value) -> anyhow::Result<String> {
+    let mut payload =
+        json!({"model":"deepseek-v4.1", "messages":[{"role":"user", "content":"Hello"}]});
+    payload
+        .as_object_mut()
+        .unwrap()
+        .extend(fields.as_object().unwrap().clone());
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_value(payload)?;
+    request.normalize_reasoning_template_args()?;
+    DeepSeekV41Formatter.render(&request)
+}
+
+#[test]
+fn normalized_effort_matches_the_reference_encoder_for_both_request_fields() {
+    assert!(render(json!({})).unwrap().contains("Reasoning Effort: 75 "));
+    assert!(render(json!({"reasoning_effort":"xhigh"})).is_err());
+    for field in ["chat_template_args", "chat_template_kwargs"] {
+        for (effort, budget) in [("low", 50), ("high", 75), ("max", 100)] {
+            for fields in [
+                json!({"reasoning_effort":effort}),
+                json!({(field):{"reasoning_effort":effort}}),
+            ] {
+                let output = render(fields).unwrap();
+                assert!(output.contains(&format!("Reasoning Effort: {budget} ")));
+                assert!(output.ends_with("<think>"));
+            }
+        }
+        assert!(
+            render(json!({(field):{"reasoning_effort":37}}))
+                .unwrap()
+                .contains("Reasoning Effort: 37 ")
+        );
+        assert!(
+            render(json!({"reasoning_effort":"low",(field):{"reasoning_effort":37}}))
+                .unwrap()
+                .contains("Reasoning Effort: 50 ")
+        );
+        for fields in [
+            json!({"reasoning_effort":"none"}),
+            json!({(field):{"reasoning_effort":"none"}}),
+            json!({(field):{"thinking":false}}),
+        ] {
+            let output = render(fields).unwrap();
+            assert!(!output.contains("Reasoning Effort:"));
+            assert!(output.ends_with("</think>"));
+        }
+        for invalid in [
+            json!(0),
+            json!(101),
+            json!(true),
+            json!(1.5),
+            json!("xhigh"),
+        ] {
+            assert!(render(json!({(field):{"reasoning_effort":invalid}})).is_err());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add native DeepSeek V4.1 frontend support. Model metadata selects the V4.1 renderer and unified reasoning/tool parser. Discovery and preprocessing share the parser settings and preserve partial DSML markers.

This PR remains a draft until [frontend-crates #224](https://github.com/ai-dynamo/frontend-crates/pull/224) merges and the required crates are released. The four frontend crates are pinned to `7b440444c9a296032386642bf6109bb700128632` in both the Rust and Python binding workspaces. Replace this interim Git revision with published crate versions before marking this PR ready.

Reasoning effort follows the [updated reference encoder](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/dba1be0a40aa45a94ad051997016db3960a90277/encoding/encoding.py#L444): `low=50`, `high=75`, `max=100`, and omitted effort defaults to 75. `xhigh` is rejected. Explicit integers from 1 through 100 remain supported.

## Validation

Current reasoning-effort update:

- `cargo +1.96.1 test --locked -p dynamo-llm --no-default-features --test deepseek_v41_renderer` passed (1 integration test covering the request fields, named and numeric effort, precedence, disabled thinking, and invalid values).
- Formatting and diff checks passed. Both regenerated lockfiles change only the revision of the four frontend crates; package versions are unchanged.
- The frontend dependency passed 165 renderer tests, including 12 V4.1 integration tests; two existing tests remain ignored.

Earlier validation, before this reasoning-effort update:

- Dynamo LLM library tests: 2,492 passed, 3 ignored. The existing HTTP 413 test failed while reading the response body. The same intermittent connection error reproduces on unchanged upstream commit `f97a17a3ff`.
- Locked LLM and Python binding builds passed. Request normalization and V4.1 renderer integration passed. Formatting passed.
- Linux runtime and Python wheels built with the S3 trace feature.
- Live text, reasoning, streamed tools, tool continuation, structured output, text-only rejection, context limits, and cache reuse passed on H100 and H200 workers.

The earlier broad suite, wheel builds, and live-model checks were not repeated for this update. Full upstream test CI has not run. Other review items remain open, including batch-parser error propagation, the token-input parser-inference guard, conformance coverage, and merge-conflict cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek V4.1 reasoning and tool-call parsing.
  * Added handling for streamed and batched DeepSeek responses, including clearer errors for malformed or incomplete calls.
  * Added DeepSeek V4.1 reasoning-effort configuration, including normalization, disabling, and validation of supported values.

* **Bug Fixes**
  * Runtime settings derived from the frontend are now applied consistently before model validation.
  * Improved input-content conversion for function-call outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->