### PR TITLE
fix(recipes): enable Kimi K3 metadata self-hosting

### DIFF
--- a/recipes/kimi-k3/sglang/agg-gb200-agentic/deploy.yaml
+++ b/recipes/kimi-k3/sglang/agg-gb200-agentic/deploy.yaml
@@ -121,6 +121,8 @@ spec:
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
                   value: "1"
+                - name: DYN_SELF_HOST_METADATA
+                  value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache
                 - name: DYN_FORWARDPASS_METRIC_PORT

--- a/recipes/kimi-k3/sglang/agg-gb300-agentic/deploy.yaml
+++ b/recipes/kimi-k3/sglang/agg-gb300-agentic/deploy.yaml
@@ -112,6 +112,8 @@ spec:
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
                   value: "1"
+                - name: DYN_SELF_HOST_METADATA
+                  value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache
                 - name: DYN_FORWARDPASS_METRIC_PORT

--- a/recipes/kimi-k3/sglang/disagg-gb200-agentic/deploy.yaml
+++ b/recipes/kimi-k3/sglang/disagg-gb200-agentic/deploy.yaml
@@ -160,6 +160,8 @@ spec:
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
                   value: "1"
+                - name: DYN_SELF_HOST_METADATA
+                  value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache
                 - name: DYN_FORWARDPASS_METRIC_PORT
@@ -249,6 +251,8 @@ spec:
                 - name: HF_HUB_OFFLINE
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: DYN_SELF_HOST_METADATA
                   value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache

--- a/recipes/kimi-k3/sglang/disagg-gb300-agentic/deploy.yaml
+++ b/recipes/kimi-k3/sglang/disagg-gb300-agentic/deploy.yaml
@@ -152,6 +152,8 @@ spec:
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
                   value: "1"
+                - name: DYN_SELF_HOST_METADATA
+                  value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache
                 - name: DYN_FORWARDPASS_METRIC_PORT
@@ -251,6 +253,8 @@ spec:
                 - name: HF_HUB_OFFLINE
                   value: "1"
                 - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: DYN_SELF_HOST_METADATA
                   value: "1"
                 - name: HF_HOME
                   value: /shared-model-cache

--- a/recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml
+++ b/recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml
@@ -135,6 +135,8 @@ spec:
             value: "1"
           - name: TRANSFORMERS_OFFLINE
             value: "1"
+          - name: DYN_SELF_HOST_METADATA
+            value: "1"
           - name: HF_HOME
             value: /shared-model-cache
           - name: VLLM_ENGINE_READY_TIMEOUT_S

--- a/recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml
+++ b/recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml
@@ -135,6 +135,8 @@ spec:
             value: "1"
           - name: TRANSFORMERS_OFFLINE
             value: "1"
+          - name: DYN_SELF_HOST_METADATA
+            value: "1"
           - name: VLLM_USE_NCCL_SYMM_MEM
             value: "0"
           - name: DYN_REQUEST_PLANE

--- a/recipes/kimi-k3/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/kimi-k3/vllm/agg-h200-agentic/deploy.yaml
@@ -103,6 +103,8 @@ spec:
             value: "1"
           - name: TRANSFORMERS_OFFLINE
             value: "1"
+          - name: DYN_SELF_HOST_METADATA
+            value: "1"
           - name: VLLM_USE_NCCL_SYMM_MEM
             value: "0"
           - name: VLLM_ALLREDUCE_USE_SYMM_MEM

--- a/recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml
+++ b/recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml
@@ -126,6 +126,8 @@ spec:
             value: "1"
           - name: TRANSFORMERS_OFFLINE
             value: "1"
+          - name: DYN_SELF_HOST_METADATA
+            value: "1"
           - name: DYN_REQUEST_PLANE
             value: tcp
           - name: PYTORCH_CUDA_ALLOC_CONF
@@ -259,6 +261,8 @@ spec:
           - name: HF_HUB_OFFLINE
             value: "1"
           - name: TRANSFORMERS_OFFLINE
+            value: "1"
+          - name: DYN_SELF_HOST_METADATA
             value: "1"
           - name: DYN_REQUEST_PLANE
             value: tcp


### PR DESCRIPTION
## Summary

- Set `DYN_SELF_HOST_METADATA=1` on every Kimi K3 worker role.
- Keep frontend containers unchanged.

## Validation

- Covered by recipe CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Updates**
  - Enabled dynamic self-host metadata for Kimi K3 agentic deployments using SGLang and vLLM.
  - Applied the setting across supported GB200, GB300, and H200 configurations.
  - Updated worker-based deployments, including both Prefill and Decode workers in disaggregated setups.
  - This ensures deployment components expose the required self-host metadata during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->