### PR TITLE
fix(frontend): backport chat logprobs fixes to release/1.5.0

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -97,31 +97,34 @@ impl DeltaGenerator {
             .collect::<Vec<f32>>();
 
         let return_as_ids = self.state.options().return_tokens_as_token_ids;
-        let content = top_logprobs.map(|top_logprobs| {
-            toks.iter()
-                .zip(tok_lps)
-                .zip(top_logprobs)
-                .map(|(((t, tid), lp), top_lps)| {
-                    let token_str = if return_as_ids {
-                        format!("token_id:{}", tid)
-                    } else {
-                        t.clone()
-                    };
-                    let converted =
-                        convert_backend_top_logprobs(&top_lps, t, *tid, lp, return_as_ids);
-                    dynamo_protocols::types::ChatCompletionTokenLogprob {
-                        token: token_str.clone(),
-                        logprob: lp,
-                        token_id: Some(*tid),
-                        bytes: token_to_utf8_bytes(&token_str),
-                        top_logprobs: converted,
-                    }
-                })
-                .collect()
-        });
+        let content = toks
+            .iter()
+            .zip(tok_lps)
+            .enumerate()
+            .map(|(index, ((t, tid), lp))| {
+                let top_lps = top_logprobs
+                    .as_ref()
+                    .and_then(|positions| positions.get(index))
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let token_str = if return_as_ids {
+                    format!("token_id:{}", tid)
+                } else {
+                    t.clone()
+                };
+                let converted = convert_backend_top_logprobs(top_lps, t, *tid, lp, return_as_ids);
+                dynamo_protocols::types::ChatCompletionTokenLogprob {
+                    token: token_str.clone(),
+                    logprob: lp,
+                    token_id: Some(*tid),
+                    bytes: token_to_utf8_bytes(&token_str),
+                    top_logprobs: converted,
+                }
+            })
+            .collect();
 
         Some(dynamo_protocols::types::ChatChoiceLogprobs {
-            content,
+            content: Some(content),
             refusal: None,
         })
     }
@@ -543,6 +546,31 @@ mod tests {
             response_json["choices"][0]["logprobs"]["content"][0]["token_id"],
             1
         );
+    }
+
+    #[test]
+    fn test_chat_logprobs_without_top_logprobs_include_sampled_token() {
+        let mut request = create_test_request();
+        request.inner.logprobs = Some(true);
+        let mut generator = request.response_generator("req-sampled-logprob".to_string());
+        let mut output = final_backend_output();
+        output.log_probs = Some(vec![-0.5]);
+        output.top_logprobs = None;
+
+        let response = generator
+            .choice_from_postprocessor(output)
+            .expect("choice generation");
+
+        let content = response.inner.choices[0]
+            .logprobs
+            .as_ref()
+            .expect("logprobs")
+            .content
+            .as_ref()
+            .expect("logprob content");
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0].token_id, Some(1));
+        assert_eq!(content[0].logprob, -0.5);
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -33,7 +33,9 @@ impl NvCreateChatCompletionRequest {
             enable_logprobs,
             self.nvext(),
         );
-        DeltaGenerator::new(self.inner.model.clone(), options, request_id)
+        let mut generator = DeltaGenerator::new(self.inner.model.clone(), options, request_id);
+        generator.suppress_top_logprobs = self.inner.top_logprobs == Some(0);
+        generator
     }
 }
 
@@ -45,6 +47,7 @@ pub struct DeltaGenerator {
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Choice indices for which the assistant role has already been emitted.
     emitted_role_choices: HashSet<u32>,
+    suppress_top_logprobs: bool,
 }
 
 impl DeltaGenerator {
@@ -58,6 +61,7 @@ impl DeltaGenerator {
             ),
             service_tier: None,
             emitted_role_choices: HashSet::new(),
+            suppress_top_logprobs: false,
         }
     }
 
@@ -112,7 +116,13 @@ impl DeltaGenerator {
                 } else {
                     t.clone()
                 };
-                let converted = convert_backend_top_logprobs(top_lps, t, *tid, lp, return_as_ids);
+                // Only explicit zero disables alternatives. Preserve the fallback
+                // for positive or omitted counts, even if backend data is missing.
+                let converted = if self.suppress_top_logprobs {
+                    Vec::new()
+                } else {
+                    convert_backend_top_logprobs(top_lps, t, *tid, lp, return_as_ids)
+                };
                 dynamo_protocols::types::ChatCompletionTokenLogprob {
                     token: token_str.clone(),
                     logprob: lp,
@@ -650,6 +660,142 @@ mod tests {
         assert_eq!(usage.prompt_tokens, 5);
         assert_eq!(usage.completion_tokens, 1);
         assert_eq!(usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn test_chat_logprobs_zero_top_ignores_backend_alternatives() {
+        for return_as_ids in [false, true] {
+            let mut request = create_test_request();
+            request.inner.logprobs = Some(true);
+            request.inner.top_logprobs = Some(0);
+            request.return_tokens_as_token_ids = Some(return_as_ids);
+            let generator = request.response_generator("req-logprobs-mixed-top".to_string());
+            let candidate = common::llm_backend::TopLogprob {
+                rank: 1,
+                token_id: 1,
+                token: Some("hello".to_string()),
+                logprob: -0.5,
+                bytes: Some(b"hello".to_vec()),
+            };
+            let tokens = ["hello", " world", "!"];
+            let chosen_logprobs = [-0.5, -0.25, -0.125];
+            let content = generator
+                .create_logprobs(
+                    tokens.iter().map(|token| Some((*token).into())).collect(),
+                    &[1, 2, 3],
+                    Some(chosen_logprobs.to_vec()),
+                    Some(vec![vec![candidate], vec![]]),
+                )
+                .expect("chosen-token logprobs")
+                .content
+                .expect("chosen-token content");
+            assert_eq!(content.len(), tokens.len());
+            for (index, entry) in content.iter().enumerate() {
+                let expected_token = if return_as_ids {
+                    format!("token_id:{}", index + 1)
+                } else {
+                    tokens[index].to_string()
+                };
+                assert_eq!(entry.token, expected_token);
+                assert_eq!(entry.token_id, Some(index as u32 + 1));
+                assert_eq!(entry.logprob, chosen_logprobs[index] as f32);
+                assert_eq!(entry.bytes, token_to_utf8_bytes(&expected_token));
+                assert!(entry.top_logprobs.is_empty());
+            }
+        }
+    }
+
+    fn assert_chat_logprobs_missing_alternatives_keep_fallback(requested_top: Option<u8>) {
+        let candidate = common::llm_backend::TopLogprob {
+            rank: 1,
+            token_id: 1,
+            token: Some("hello".to_string()),
+            logprob: -0.5,
+            bytes: Some(b"hello".to_vec()),
+        };
+        for top_logprobs in [
+            None,
+            Some(vec![]),
+            Some(vec![vec![], vec![], vec![]]),
+            Some(vec![vec![candidate], vec![]]),
+        ] {
+            for return_as_ids in [false, true] {
+                let mut request = create_test_request();
+                request.inner.logprobs = Some(true);
+                request.inner.top_logprobs = requested_top;
+                request.return_tokens_as_token_ids = Some(return_as_ids);
+                let generator = request.response_generator("req-logprobs-fallback".to_string());
+                let tokens = ["hello", " world", "!"];
+                let chosen_logprobs = [-0.5, -0.25, -0.125];
+                let content = generator
+                    .create_logprobs(
+                        tokens.iter().map(|token| Some((*token).into())).collect(),
+                        &[1, 2, 3],
+                        Some(chosen_logprobs.to_vec()),
+                        top_logprobs.clone(),
+                    )
+                    .expect("chosen-token logprobs")
+                    .content
+                    .expect("chosen-token content");
+                assert_eq!(content.len(), tokens.len());
+                for (index, entry) in content.iter().enumerate() {
+                    let expected_token = if return_as_ids {
+                        format!("token_id:{}", index + 1)
+                    } else {
+                        tokens[index].to_string()
+                    };
+                    assert_eq!(entry.token, expected_token);
+                    assert_eq!(entry.token_id, Some(index as u32 + 1));
+                    assert_eq!(entry.logprob, chosen_logprobs[index] as f32);
+                    assert_eq!(entry.bytes, token_to_utf8_bytes(&expected_token));
+                    assert_eq!(entry.top_logprobs.len(), 1);
+                    let fallback = &entry.top_logprobs[0];
+                    assert_eq!(fallback.token, entry.token);
+                    assert_eq!(fallback.logprob, entry.logprob);
+                    assert_eq!(fallback.bytes, entry.bytes);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_chat_logprobs_positive_top_missing_alternatives_keep_fallback() {
+        assert_chat_logprobs_missing_alternatives_keep_fallback(Some(1));
+    }
+
+    #[test]
+    fn test_chat_logprobs_omitted_top_missing_alternatives_keep_fallback() {
+        assert_chat_logprobs_missing_alternatives_keep_fallback(None);
+    }
+
+    #[test]
+    fn test_chat_logprobs_nonempty_alternatives_unchanged() {
+        let mut request = create_test_request();
+        request.inner.logprobs = Some(true);
+        request.inner.top_logprobs = Some(1);
+        let generator = request.response_generator("req-logprobs-top-control".to_string());
+        let candidates = vec![common::llm_backend::TopLogprob {
+            rank: 1,
+            token_id: 2,
+            token: Some("hi".to_string()),
+            logprob: -0.25,
+            bytes: Some(b"hi".to_vec()),
+        }];
+        let expected = convert_backend_top_logprobs(&candidates, "hello", 1, -0.5, false);
+        let logprobs = generator
+            .create_logprobs(
+                vec![Some("hello".into())],
+                &[1],
+                Some(vec![-0.5]),
+                Some(vec![candidates]),
+            )
+            .expect("chosen-token logprobs");
+        let content = logprobs.content.expect("chosen-token content");
+        assert_eq!(content.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&content[0].top_logprobs).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -713,12 +713,7 @@ mod tests {
             logprob: -0.5,
             bytes: Some(b"hello".to_vec()),
         };
-        for top_logprobs in [
-            None,
-            Some(vec![]),
-            Some(vec![vec![], vec![], vec![]]),
-            Some(vec![vec![candidate], vec![]]),
-        ] {
+        for top_logprobs in [None, Some(vec![]), Some(vec![vec![candidate], vec![]])] {
             for return_as_ids in [false, true] {
                 let mut request = create_test_request();
                 request.inner.logprobs = Some(true);

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -52,6 +52,13 @@ use tokio_util::codec::FramedRead;
 mod ports;
 use ports::bind_random_port;
 
+#[allow(dead_code)]
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[allow(dead_code)]
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
 struct CounterEngine {}
 
 #[derive(Default)]
@@ -2314,4 +2321,168 @@ async fn test_classify_and_pooling_validation_errors_are_metered() {
 
     cancel_token.cancel();
     task.await.unwrap().unwrap();
+}
+
+mod zero_top_logprobs {
+    //! CPU HTTP regressions for chosen-token logprobs without top alternatives.
+    //!
+    //! Backend output is injected deterministically; these tests exercise the real
+    //! Rust delta converter, HTTP aggregation, and SSE serialization, not inference.
+
+    use std::time::Duration;
+
+    use dynamo_llm::protocols::{
+        common::{FinishReason, llm_backend::BackendOutput},
+        openai::{DeltaGeneratorExt, chat_completions::NvCreateChatCompletionRequest},
+    };
+    use serde_json::{Value, json};
+
+    use super::http_harness::{HarnessService, MODEL, parse_json_sse};
+    use super::scripted_chat_engine::Script;
+
+    const TOKENS: [(&str, u32, f64); 2] = [("Hello", 42, -0.125), ("!", 99, -0.75)];
+
+    fn request_body(stream: bool) -> Value {
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "Say hello."}],
+            "max_completion_tokens": TOKENS.len(),
+            "stream": stream,
+            "logprobs": true,
+            "top_logprobs": 0,
+        })
+    }
+
+    fn converted_backend_script(body: &Value) -> Script {
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_value(body.clone()).expect("invalid regression request");
+        // Backend preprocessing enables final usage for nonstreaming requests;
+        // the backend always returns chunks for the HTTP handler to aggregate.
+        request.enable_usage_for_nonstreaming(request.inner.stream.unwrap_or(false));
+        let mut generator = request.response_generator("zero-top-regression".to_string());
+        generator.update_isl(3);
+
+        let mut chunks: Script = TOKENS
+            .iter()
+            .enumerate()
+            .map(|(index, &(token, token_id, logprob))| {
+                generator
+                    .choice_from_postprocessor(BackendOutput {
+                        token_ids: vec![token_id],
+                        tokens: vec![Some(token.to_string())],
+                        text: Some(token.to_string()),
+                        cum_log_probs: None,
+                        log_probs: Some(vec![logprob]),
+                        top_logprobs: None,
+                        finish_reason: (index + 1 == TOKENS.len()).then_some(FinishReason::Stop),
+                        stop_reason: None,
+                        index: Some(0),
+                        completion_usage: None,
+                        disaggregated_params: None,
+                        encoder_result: None,
+                        worker_trace_link: None,
+                        engine_data: None,
+                        routing_data: None,
+                    })
+                    .expect("backend output conversion failed")
+            })
+            .collect();
+        if generator.is_usage_enabled() {
+            chunks.push(generator.create_usage_chunk());
+        }
+        chunks
+    }
+
+    fn assert_chosen_logprobs(content: &Value, expected: &[(&str, u32, f64)]) {
+        let entries = content
+            .as_array()
+            .expect("HTTP logprobs.content must contain chosen-token entries, not null");
+        assert_eq!(entries.len(), expected.len());
+        for (entry, &(token, token_id, logprob)) in entries.iter().zip(expected) {
+            assert_eq!(entry["token"], token);
+            assert_eq!(entry["token_id"], token_id);
+            assert_eq!(entry["bytes"], json!(token.as_bytes()));
+            let actual = entry["logprob"]
+                .as_f64()
+                .expect("chosen-token logprob must be numeric");
+            assert!(actual.is_finite());
+            assert_eq!(actual, logprob);
+            assert_eq!(entry["top_logprobs"], json!([]));
+        }
+    }
+
+    async fn assert_http_response(stream: bool) {
+        let body = request_body(stream);
+        // Do not assert on the generated chunks before sending the HTTP request:
+        // the regression must be observable in the actual HTTP response body.
+        let svc = HarnessService::start([converted_backend_script(&body)]).await;
+        let response = svc
+            .client
+            .post(format!("{}/v1/chat/completions", svc.base_url))
+            .timeout(Duration::from_secs(5))
+            .json(&body)
+            .send()
+            .await
+            .expect("POST /v1/chat/completions failed");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let content_type = response.headers()[reqwest::header::CONTENT_TYPE]
+            .to_str()
+            .unwrap()
+            .to_string();
+        let raw = response.text().await.expect("failed to read HTTP response");
+        println!("stream={stream}, top_logprobs=0, HTTP response:\n{raw}");
+
+        if stream {
+            assert!(content_type.starts_with("text/event-stream"));
+            let events = parse_json_sse(&raw).await.expect("invalid SSE response");
+            // The shared message codec consumes the terminal [DONE] sentinel.
+            assert_eq!(raw.matches("data: [DONE]").count(), 1);
+            let chunks: Vec<&Value> = events.iter().map(|event| &event.data).collect();
+            assert_eq!(chunks.len(), TOKENS.len());
+            for (index, chunk) in chunks.iter().enumerate() {
+                assert_eq!(chunk["choices"].as_array().unwrap().len(), 1);
+                let choice = &chunk["choices"][0];
+                assert_eq!(choice["delta"]["content"], TOKENS[index].0);
+                assert_chosen_logprobs(&choice["logprobs"]["content"], &TOKENS[index..=index]);
+            }
+            assert_eq!(
+                chunks.last().unwrap()["choices"][0]["finish_reason"],
+                "stop"
+            );
+        } else {
+            assert!(content_type.starts_with("application/json"));
+            let response: Value = serde_json::from_str(&raw).expect("invalid JSON response");
+            assert_eq!(response["choices"].as_array().unwrap().len(), 1);
+            let choice = &response["choices"][0];
+            assert_eq!(choice["message"]["content"], "Hello!");
+            assert_eq!(choice["finish_reason"], "stop");
+            assert_chosen_logprobs(&choice["logprobs"]["content"], &TOKENS);
+        }
+
+        // The shared harness uses precomputed chunks. Check that the real incoming
+        // request retained the same converter options used to prepare that script.
+        let requests = svc.engine.take_requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].inner.logprobs, Some(true));
+        assert_eq!(requests[0].inner.top_logprobs, Some(0));
+        assert_eq!(requests[0].inner.stream, Some(stream));
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    }
+
+    async fn run_case(stream: bool) {
+        tokio::time::timeout(Duration::from_secs(15), assert_http_response(stream))
+            .await
+            .expect("logprobs HTTP regression timed out");
+    }
+
+    #[tokio::test]
+    async fn nonstreaming_top_zero_preserves_chosen_logprobs() {
+        run_case(false).await;
+    }
+
+    #[tokio::test]
+    async fn streaming_top_zero_preserves_chosen_logprobs() {
+        run_case(true).await;
+    }
 }


### PR DESCRIPTION
## Summary

Backport the two required chat-logprobs fixes to `release/1.5.0` in one PR:

1. The focused sampled-token fix from [#13640](https://github.com/ai-dynamo/dynamo/pull/13640): preserve chosen-token logprobs when backend top-candidate data is absent or shorter than the chosen-token sequence.
2. Our merged [#14510](https://github.com/ai-dynamo/dynamo/pull/14510): honor explicit `logprobs: true, top_logprobs: 0` with chosen-token metadata and empty `top_logprobs: []`.

Positive or omitted top-logprob counts retain the existing sampled-token fallback. Logprobs-disabled requests and missing chosen-token probabilities remain absent.

## Why the previous PR #13640 is required

Both fixes are already on `main`, but release base [`c0ea9ffb9`](https://github.com/ai-dynamo/dynamo/commit/c0ea9ffb9e3c8042aeefd2e261635fce55086796) lacks #13640's converter change. Its old `top_logprobs.map(...)` creates chosen-token content only when backend alternatives exist; `zip(top_logprobs)` also truncates chosen-token entries when that array is short.

#14510 only controls whether alternatives are emitted inside that conversion. It assumes #13640 has already made chosen-token content independent of alternatives. Cherry-picking #14510 alone does not bring earlier main commits with it and therefore leaves the release's original `logprobs.content: null` failure.

This was verified locally on the release base with only #14510 adapted: **44 unit tests passed, 3 failed; both HTTP/SSE regressions failed** and returned `logprobs: {"content": null, "refusal": null}`. With the prerequisite included, all of those regressions pass.

**Only the small logprobs commit from #13640 is included.** Its unrelated RL training-metadata, ThunderAgent proxy, and documentation changes are excluded.

## Cherry-pick provenance and scope

- Prerequisite: [`84ef298ce`](https://github.com/ai-dynamo/dynamo/commit/84ef298ce34bafbbd4c9f2d7c8fd3eb6242f9148), `fix(llm): preserve sampled chat logprobs without top-k`, from #13640. Its `delta.rs` patch matches that file's final change in main squash [`50c6fea10`](https://github.com/ai-dynamo/dynamo/commit/50c6fea10dc132eb41f6e785b211bb9723af81d0). Backported as `9396d20a3`.
- Our fix: main squash [`464ea4f82`](https://github.com/ai-dynamo/dynamo/commit/464ea4f82a0c4eff03f2e993236e2043d4d2ff6a) from #14510. Backported as `7c1b89d96`.
- Two signed, DCO-signed-off cherry-picks plus a signed test-only review cleanup in one PR, suitable for one squash merge.
- Only `lib/llm/src/protocols/openai/chat_completions/delta.rs` and `lib/llm/tests/http-service.rs` change.
- Conflict resolution preserves the release's three existing backend-usage tests and adds the original logprobs regressions; unrelated main-only image tests were not imported.
- No SGLang Python request-mapping, positive-top-logprobs gate, wire-format, or broad main-branch merge changes.

## Related issue

[DIS-2867](https://linear.app/nvidia/issue/DIS-2867/dynamorelease150frontend-sglang-processor-incorrectly-disables): release QA reported null chat logprobs for `logprobs: true, top_logprobs: 0`. This combined backport addresses the Rust response-conversion cause; it does not endorse the original Python request-mapping diagnosis.

Related context: [#12649](https://github.com/ai-dynamo/dynamo/issues/12649).

## Validation

### Live GB300 / SGLang validation — September 10, 2026

Tested the runtime code at [`7c1b89d96`](https://github.com/ai-dynamo/dynamo/commit/7c1b89d96adbbb6c21f1350b350b2e5a67c1b965) with **1× NVIDIA GB300, ARM64, TP=1**, Dynamo 1.5.0, SGLang 0.5.18, and Torch 2.13.0+cu130. Model: `Qwen/Qwen3-0.6B`, pinned revision `c1899de289a04d12100db370d81485cdf75e47ca`.

**The original `logprobs.content: null` failure did not reproduce with the combined backport:** every `logprobs: true, top_logprobs: 0` generation returned 30 chosen-token logprob entries and `top_logprobs: []`.

| Validation | Result |
| --- | --- |
| Rust processor (`--dyn-chat-processor dynamo`): two nonstreaming requests and one streaming request, explicit top=0 | **3/3 passed**; chosen-token probabilities, token IDs, bytes, and empty alternatives verified |
| Python processor (`--dyn-chat-processor sglang`): same explicit-top=0 cases | **3/3 passed**; separate compatibility control that bypasses the fixed Rust postprocessor; token IDs not required on this existing path |
| `logprobs: false`, both processors, streaming and nonstreaming | **4/4 passed**; no logprobs returned |
| Rust nonstreaming top=5 and omitted-top guard controls, override unset | **2/2 passed**; HTTP 400 with the SGLang guard message |

**Overall: 12/14 checks passed (validation exit 1); all 10 generation cases passed.**

Core request (set `stream: true` for the streaming variant):

```json
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Say hello"}],
  "max_tokens": 30,
  "temperature": 0,
  "stream": false,
  "logprobs": true,
  "top_logprobs": 0
}
```

Recorded Rust response: 10 prompt tokens, 30 completion tokens, 30 chosen-logprob entries, `finish_reason: "length"`. First entry (excerpt, not the full response):

```json
{
  "token": "<think>",
  "logprob": -0.00035756393,
  "token_id": 151667,
  "bytes": [60, 116, 104, 105, 110, 107, 62],
  "top_logprobs": []
}
```

**Build/scope caveats:** native exact-source **debug/dev** build using the SGLang CI Rust optional features, not the packaged CI image (ECR authentication was unavailable). This was targeted live GPU contract validation using the repository's process managers, not the entire original QA pytest suite, and not a fresh release-base GPU A/B run. Complete requests, raw JSON/SSE responses, process logs, and the unchanged result summary were retained locally. No source changes were needed for this validation.

### Local CPU regression coverage

Review follow-up [`94ea4becc`](https://github.com/ai-dynamo/dynamo/commit/94ea4becca332d6269b09ef8cdcf59e57a5e143e): removed the redundant full-length empty-alternatives test parameter. Re-ran **48/48 logprobs unit tests and 2/2 HTTP/SSE regressions**, plus targeted `rustfmt --check` and `git diff --check`; all passed. Runtime code and documentation are unchanged from the GPU-tested revision.

Tested locally on macOS ARM64 with repository-pinned Rust 1.96.1 and `--no-default-features --locked`:

- **48/48 logprobs unit tests passed**, including #13640's original sampled-token regression.
- **2/2 targeted HTTP/SSE regressions passed**.
- **19/19 full HTTP service tests passed**, using 8 test threads (includes the two targeted regressions).
- **175/175 chat-completions unit tests passed**, including aggregation and the release's existing usage tests (overlaps the logprobs unit selection).
- Targeted `rustfmt --check` and `git diff --check` passed.

```sh
cargo test -p dynamo-llm --no-default-features --locked \
  --lib --test http-service --no-fail-fast logprobs -- --nocapture
cargo test -p dynamo-llm --no-default-features --locked \
  --test http-service -- --nocapture --test-threads=8
cargo test -p dynamo-llm --no-default-features --locked \
  --lib protocols::openai::chat_completions:: -- --nocapture
```

The local tests above use CPU converters and real HTTP/SSE with deterministic scripted backend output. They are separate from the live GB300/SGLang validation above; neither run is the entire original QA pytest suite.

<details>
<summary>Complete recorded non-streaming responses: standalone #14510 versus combined backport</summary>

Request: `POST /v1/chat/completions`

```json
{
  "model": "harness-model",
  "messages": [{"role": "user", "content": "Say hello."}],
  "max_completion_tokens": 2,
  "stream": false,
  "logprobs": true,
  "top_logprobs": 0
}
```

The test injects chosen tokens `Hello` (ID 42, logprob -0.125) and `!` (ID 99, logprob -0.75), with backend `top_logprobs: None`. These are scripted values, not model-inference measurements.

Before: release base plus only #14510, without the prerequisite:

```json
{
  "id": "chatcmpl-zero-top-regression",
  "choices": [
    {
      "index": 0,
      "message": {
        "content": "Hello!",
        "role": "assistant",
        "reasoning_content": null
      },
      "finish_reason": "stop",
      "logprobs": {
        "content": null,
        "refusal": null
      }
    }
  ],
  "created": 1789054213,
  "model": "harness-model",
  "service_tier": null,
  "system_fingerprint": null,
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 3,
    "completion_tokens": 2,
    "total_tokens": 5
  }
}
```

After: this combined backport at `7c1b89d96`:

```json
{
  "id": "chatcmpl-zero-top-regression",
  "choices": [
    {
      "index": 0,
      "message": {
        "content": "Hello!",
        "role": "assistant",
        "reasoning_content": null
      },
      "finish_reason": "stop",
      "logprobs": {
        "content": [
          {
            "token": "Hello",
            "logprob": -0.125,
            "token_id": 42,
            "bytes": [
              72,
              101,
              108,
              108,
              111
            ],
            "top_logprobs": []
          },
          {
            "token": "!",
            "logprob": -0.75,
            "token_id": 99,
            "bytes": [
              33
            ],
            "top_logprobs": []
          }
        ],
        "refusal": null
      }
    }
  ],
  "created": 1789055796,
  "model": "harness-model",
  "service_tier": null,
  "system_fingerprint": null,
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 3,
    "completion_tokens": 2,
    "total_tokens": 5
  }
}
```

Timestamps differ because these are separate test runs. Both streaming response chunks are also checked for preserved chosen-token metadata and empty alternatives, followed by one `[DONE]` sentinel.

</details>
