### PR TITLE
fix(operator): stop the topology label controller reconciling pods silently

### DIFF
--- a/deploy/operator/internal/controller/topology_label_controller.go
+++ b/deploy/operator/internal/controller/topology_label_controller.go
@@ -55,9 +55,8 @@ func (r *TopologyLabelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	// Every terminal path below logs, so that an absence of records for a pod means
-	// this controller never reconciled it rather than that it reconciled and had
-	// nothing to do.
+	// Every terminal path below logs, so no record for a pod means this
+	// controller never reconciled it rather than reconciled and did nothing.
 	if len(copyTargets) == 0 {
 		logger.Info("Pod needs no topology label copy",
 			"pod", req.NamespacedName, "node", pod.Spec.NodeName)

--- a/deploy/operator/internal/controller/topology_label_controller.go
+++ b/deploy/operator/internal/controller/topology_label_controller.go
@@ -55,7 +55,12 @@ func (r *TopologyLabelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	// Every terminal path below logs, so that an absence of records for a pod means
+	// this controller never reconciled it rather than that it reconciled and had
+	// nothing to do.
 	if len(copyTargets) == 0 {
+		logger.Info("Pod needs no topology label copy",
+			"pod", req.NamespacedName, "node", pod.Spec.NodeName)
 		return ctrl.Result{}, nil
 	}
 
@@ -87,6 +92,9 @@ func (r *TopologyLabelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		patchedLabels++
 	}
 	if patchedLabels == 0 {
+		logger.Info("No topology labels copied to pod",
+			"pod", req.NamespacedName, "node", pod.Spec.NodeName,
+			"copyTargets", len(copyTargets))
 		return ctrl.Result{}, nil
 	}
 
@@ -102,6 +110,7 @@ func (r *TopologyLabelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 func (r *TopologyLabelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("topology-label").
 		For(&corev1.Pod{}).
 		WithEventFilter(predicate.And(
 			commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig),

--- a/deploy/operator/internal/controller/topology_label_controller_test.go
+++ b/deploy/operator/internal/controller/topology_label_controller_test.go
@@ -316,6 +316,7 @@ func TestTopologyLabelReconciler_LogsEveryTerminalPath(t *testing.T) {
 		podLabels         map[string]string
 		nodeLabels        map[string]string
 		wantMessages      []string
+		wantCountFields   map[string]map[string]int64
 		absentMessages    []string
 		wantPodLabelValue string
 	}{
@@ -328,16 +329,22 @@ func TestTopologyLabelReconciler_LogsEveryTerminalPath(t *testing.T) {
 			wantPodLabelValue: "us-east-1a",
 		},
 		{
-			name:              "node without the source label records that nothing was copied",
-			nodeLabels:        map[string]string{},
-			wantMessages:      []string{"Node missing topology label, skipping", "No topology labels copied to pod"},
+			name:         "node without the source label records that nothing was copied",
+			nodeLabels:   map[string]string{},
+			wantMessages: []string{"Node missing topology label, skipping", "No topology labels copied to pod"},
+			wantCountFields: map[string]map[string]int64{
+				"No topology labels copied to pod": {"copyTargets": 1},
+			},
 			absentMessages:    []string{"Copied node topology label to pod", "Pod needs no topology label copy"},
 			wantPodLabelValue: "",
 		},
 		{
-			name:              "successful copy still records the unchanged success line",
-			nodeLabels:        map[string]string{labelKey: "us-east-1a"},
-			wantMessages:      []string{"Copied node topology label to pod"},
+			name:         "successful copy still records the unchanged success line",
+			nodeLabels:   map[string]string{labelKey: "us-east-1a"},
+			wantMessages: []string{"Copied node topology label to pod"},
+			wantCountFields: map[string]map[string]int64{
+				"Copied node topology label to pod": {"labels": 1},
+			},
 			absentMessages:    []string{"Pod needs no topology label copy", "No topology labels copied to pod"},
 			wantPodLabelValue: "us-east-1a",
 		},
@@ -373,13 +380,16 @@ func TestTopologyLabelReconciler_LogsEveryTerminalPath(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, ctrl.Result{}, result)
 
-			t.Log("each expected message is recorded exactly once and names the pod and the node")
+			t.Log("each expected message is recorded exactly once, names the pod and the node, and carries its own counts")
 			for _, message := range tt.wantMessages {
 				entries := observed.FilterMessage(message).All()
 				require.Len(t, entries, 1, "message %q", message)
 				fields := entries[0].ContextMap()
 				assert.Contains(t, fmt.Sprintf("%v", fields["pod"]), podName, "message %q", message)
 				assert.Equal(t, nodeName, fields["node"], "message %q", message)
+				for field, want := range tt.wantCountFields[message] {
+					assert.Equal(t, want, fields[field], "message %q field %q", message, field)
+				}
 			}
 
 			t.Log("no message belonging to another terminal path is recorded")

--- a/deploy/operator/internal/controller/topology_label_controller_test.go
+++ b/deploy/operator/internal/controller/topology_label_controller_test.go
@@ -301,10 +301,8 @@ func TestTopologyLabelReconciler_SkipsNonDynamoComponentPod(t *testing.T) {
 	assert.NotContains(t, unchanged.Labels, "topology.kubernetes.io/zone")
 }
 
-// TestTopologyLabelReconciler_LogsEveryTerminalPath pins the property an operator
-// relies on when reading the controller-manager log: every terminal path of
-// Reconcile leaves a record, so an absence of records means this controller did
-// not run rather than that it ran and chose to do nothing.
+// TestTopologyLabelReconciler_LogsEveryTerminalPath pins that every terminal path
+// of Reconcile logs, so silence means the controller never ran on that pod.
 func TestTopologyLabelReconciler_LogsEveryTerminalPath(t *testing.T) {
 	const (
 		labelKey     = "topology.kubernetes.io/zone"

--- a/deploy/operator/internal/controller/topology_label_controller_test.go
+++ b/deploy/operator/internal/controller/topology_label_controller_test.go
@@ -7,13 +7,18 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 )
@@ -293,6 +299,106 @@ func TestTopologyLabelReconciler_SkipsNonDynamoComponentPod(t *testing.T) {
 	var unchanged corev1.Pod
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &unchanged))
 	assert.NotContains(t, unchanged.Labels, "topology.kubernetes.io/zone")
+}
+
+// TestTopologyLabelReconciler_LogsEveryTerminalPath pins the property an operator
+// relies on when reading the controller-manager log: every terminal path of
+// Reconcile leaves a record, so an absence of records means this controller did
+// not run rather than that it ran and chose to do nothing.
+func TestTopologyLabelReconciler_LogsEveryTerminalPath(t *testing.T) {
+	const (
+		labelKey     = "topology.kubernetes.io/zone"
+		podName      = "worker-abc"
+		podNamespace = "default"
+		nodeName     = "node-1"
+	)
+
+	tests := []struct {
+		name              string
+		podLabels         map[string]string
+		nodeLabels        map[string]string
+		wantMessages      []string
+		absentMessages    []string
+		wantPodLabelValue string
+	}{
+		{
+			name:              "pod already carrying the label records that nothing needed copying",
+			podLabels:         map[string]string{labelKey: "us-east-1a"},
+			nodeLabels:        map[string]string{labelKey: "us-east-1b"},
+			wantMessages:      []string{"Pod needs no topology label copy"},
+			absentMessages:    []string{"Copied node topology label to pod", "No topology labels copied to pod"},
+			wantPodLabelValue: "us-east-1a",
+		},
+		{
+			name:              "node without the source label records that nothing was copied",
+			nodeLabels:        map[string]string{},
+			wantMessages:      []string{"Node missing topology label, skipping", "No topology labels copied to pod"},
+			absentMessages:    []string{"Copied node topology label to pod", "Pod needs no topology label copy"},
+			wantPodLabelValue: "",
+		},
+		{
+			name:              "successful copy still records the unchanged success line",
+			nodeLabels:        map[string]string{labelKey: "us-east-1a"},
+			wantMessages:      []string{"Copied node topology label to pod"},
+			absentMessages:    []string{"Pod needs no topology label copy", "No topology labels copied to pod"},
+			wantPodLabelValue: "us-east-1a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("build the node and the annotated, scheduled worker pod for this case")
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: tt.nodeLabels},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						consts.KubeAnnotationTopologyLabelKey: labelKey,
+					},
+					Labels: dynamoComponentPodLabels(tt.podLabels),
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			}
+
+			t.Log("reconcile with a capturing logger installed in the reconcile context")
+			cl := fake.NewClientBuilder().WithObjects(node, pod).Build()
+			r := &TopologyLabelReconciler{Client: cl, NodeReader: cl}
+			core, observed := observer.New(zapcore.InfoLevel)
+			ctx := log.IntoContext(context.Background(), zapr.NewLogger(zap.New(core)))
+
+			result, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: podName, Namespace: podNamespace},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			t.Log("each expected message is recorded exactly once and names the pod and the node")
+			for _, message := range tt.wantMessages {
+				entries := observed.FilterMessage(message).All()
+				require.Len(t, entries, 1, "message %q", message)
+				fields := entries[0].ContextMap()
+				assert.Contains(t, fmt.Sprintf("%v", fields["pod"]), podName, "message %q", message)
+				assert.Equal(t, nodeName, fields["node"], "message %q", message)
+			}
+
+			t.Log("no message belonging to another terminal path is recorded")
+			for _, message := range tt.absentMessages {
+				assert.Empty(t, observed.FilterMessage(message).All(), "message %q", message)
+			}
+
+			t.Log("the pod's topology label reflects this case's expected copy outcome")
+			var reconciled corev1.Pod
+			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podName, Namespace: podNamespace}, &reconciled))
+			if tt.wantPodLabelValue == "" {
+				assert.NotContains(t, reconciled.Labels, labelKey)
+			} else {
+				assert.Equal(t, tt.wantPodLabelValue, reconciled.Labels[labelKey])
+			}
+		})
+	}
 }
 
 const (


### PR DESCRIPTION
Source issue: [DYN-4387](https://linear.app/nvidia/issue/DYN-4387).

## Overview:

`TopologyLabelReconciler` copies a node's topology label onto matching worker pods, and logs a line when it does. Its two other exits — the pod already carries every label it needs, and nothing was copied — returned with no output at all. Reading the controller-manager log, an operator could not tell "this controller looked at the pod and correctly had nothing to do" apart from "this controller never saw the pod". This change makes every exit leave a record.

## Details:

Both silent returns in `Reconcile` now log the pod and the node: `Pod needs no topology label copy` when there is nothing to copy, and `No topology labels copied to pod`, with the number of candidate labels, when the copy found no source value on the node. `SetupWithManager` gains `Named("topology-label")`, so controller-runtime's own reconcile and error records carry this controller's name instead of the generic `pod` it derives from `For(&corev1.Pod{})`; `topology-label` is already the name used for this controller's event recorder in `internal/controller/setup.go`.

What is copied, and when, is unchanged, and the existing `Copied node topology label to pod` line is untouched.

Validation: in `deploy/operator`, `go test ./internal/controller ./internal/webhook/validation -count=1` passes, as does `go vet ./internal/controller/...`.

## Where should the reviewer start?

`deploy/operator/internal/controller/topology_label_controller.go` — three added lines. Then `TestTopologyLabelReconciler_LogsEveryTerminalPath` in `topology_label_controller_test.go`, a table test that drives `Reconcile` through all three exits with a capturing logger and asserts on the messages an operator would see, plus the pod's resulting label.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Added informational logging for topology-label processing outcomes, including cases where no labels need copying or node labels are unavailable.
  - Logs now distinguish between skipped processing and successful topology-label copying, making reconciliation results easier to understand.

- **Tests**
  - Expanded coverage for terminal reconciliation scenarios, including existing pod labels, missing node labels, and successful label copying.
  - Added validation for structured log messages, context details, and resulting pod labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->