### PR TITLE
docs(observability): stop promising that a missing S3 bucket fails startup

### DIFF
--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -321,7 +321,7 @@ See [Forward Pass Metrics Trace Reference](forward-pass-metrics-traces.mdx) for 
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_BUCKET" type="string">
-  Destination bucket for the `s3` sink. Required when `DYN_REQUEST_TRACE_SINKS` includes `s3`; startup fails if unset.
+  Destination bucket for the `s3` sink. Required when `DYN_REQUEST_TRACE_SINKS` includes `s3`. When it is unset, the `s3` sink fails to initialize: Dynamo logs a warning carrying the underlying error, starts no sink from that `DYN_REQUEST_TRACE_SINKS` list, and keeps serving. Startup does not fail. See [Sink Behavior](request-traces.mdx#sink-behavior).
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_REGION" type="string">

--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -15,7 +15,7 @@ one or more sinks. For the capture and replay workflow, see
 | --- | --- | --- | --- |
 | `DYN_REQUEST_TRACE` | unset | Truthy value | Master switch. When enabled and `DYN_REQUEST_TRACE_RECORDS` is unset, emits `request_end,tool`. |
 | `DYN_REQUEST_TRACE_RECORDS` | `request_end,tool` | `request_end`, `request_payload`, `tool` | Comma-separated record types. Setting the variable enables only the listed types. |
-| `DYN_REQUEST_TRACE_SINKS` | `file` | `file`, `stderr`, `nats`, `otel` | Comma-separated sinks. |
+| `DYN_REQUEST_TRACE_SINKS` | `file` | `file`, `stderr`, `nats`, `otel`, `s3` | Comma-separated sinks. |
 | `DYN_REQUEST_TRACE_FILE_PATH` | `/tmp/dynamo-request-trace` | Path or prefix | Literal path for `jsonl`; segment prefix for `jsonl_gz`. |
 | `DYN_REQUEST_TRACE_FILE_FORMAT` | `jsonl_gz` | `jsonl`, `jsonl_gz` | File encoding and rotation mode. |
 | `DYN_REQUEST_TRACE_CAPACITY` | `1024` | Positive integer | Best-effort in-process broadcast capacity. |
@@ -25,6 +25,11 @@ one or more sinks. For the capture and replay workflow, see
 | `DYN_REQUEST_TRACE_FILE_FLUSH_INTERVAL_MS` | `1000` | Integer milliseconds | Periodic file flush interval. |
 | `DYN_REQUEST_TRACE_FILE_ROLL_BYTES` | `268435456` | Positive integer bytes | Gzip roll threshold in uncompressed bytes. |
 | `DYN_REQUEST_TRACE_FILE_ROLL_LINES` | unset | Positive integer records | Optional gzip roll threshold in records. |
+| `DYN_REQUEST_TRACE_S3_BUCKET` | unset | Bucket name | Destination bucket for the `s3` sink. Required when `DYN_REQUEST_TRACE_SINKS` includes `s3`. |
+| `DYN_REQUEST_TRACE_S3_REGION` | unset | Region name | Region override for the `s3` sink. When unset, the client uses `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1`. |
+| `DYN_REQUEST_TRACE_S3_PREFIX` | unset | Object key prefix | Key prefix for the `s3` sink. When unset, records land at the bucket root. |
+| `DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES` | `67108864` | Positive integer bytes | Batch roll threshold for the `s3` sink in uncompressed bytes. |
+| `DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS` | `10000` | Integer milliseconds | Periodic flush interval for the `s3` sink in milliseconds. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` | unset | ZMQ bind address | Optional PULL endpoint for harness tool events. Configure it on only one process. |
 | `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_TOPIC` | `agent-tool-events` | ZMQ topic | First-frame topic filter. |
 | `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` | unset | Header names | Comma- or whitespace-separated allowlist captured only on `request_payload` rows. Values are unredacted. |
@@ -34,6 +39,14 @@ Legacy `jsonl` and `jsonl_gz` sink values, `DYN_REQUEST_TRACE_OUTPUT_PATH`, and
 not wire-compatibility aliases. Prefer `DYN_REQUEST_TRACE_*` for new deployments.
 
 ## Sink Behavior
+
+Request trace initialization is best effort. Sinks are built in one group, so if any sink in
+`DYN_REQUEST_TRACE_SINKS` cannot be constructed — a missing `DYN_REQUEST_TRACE_S3_BUCKET`, an
+unreachable NATS server, or an `s3` sink on a build without the `request-trace-s3` feature — Dynamo
+logs `Request trace initialization failed; continuing without trace sink` with the underlying error,
+starts no sink from that list, and continues serving. Startup does not fail, so detect this from the
+logs rather than from process exit: a successful group logs `Request trace sinks ready` with the
+sink count.
 
 The `otel` sink maps each row to one OTLP `LogRecord` in scope `dynamo.request_trace`. It resolves
 transport settings in this order:


### PR DESCRIPTION
Source issue: [DYN-4382](https://linear.app/nvidia/issue/DYN-4382).

## Overview:

The request-trace reference promised that Dynamo fails to start when `DYN_REQUEST_TRACE_SINKS` includes `s3` and `DYN_REQUEST_TRACE_S3_BUCKET` is unset. It does not: `initialize_input` in `lib/llm/src/entrypoint/input.rs` logs `Request trace initialization failed; continuing without trace sink` and the frontend keeps serving. Request tracing is best effort by design, so this change corrects the two reference pages rather than the code. No Rust or Python file is touched.

## Details:

In `docs/fern/pages/reference/observability/environment-variables.mdx`, the `DYN_REQUEST_TRACE_S3_BUCKET` field replaces `startup fails if unset` with the real outcome: the `s3` sink fails to initialize, Dynamo logs a warning carrying the underlying error, no sink from that `DYN_REQUEST_TRACE_SINKS` list starts, and serving continues.

In `docs/fern/pages/reference/observability/request-traces.mdx`, `s3` joins the accepted values of the `DYN_REQUEST_TRACE_SINKS` row, the five `DYN_REQUEST_TRACE_S3_*` variables gain table rows carrying the defaults from `lib/llm/src/request_trace/config.rs`, and a new paragraph in `## Sink Behavior` states the initialization contract once for every sink: sinks are built as one group, so a single unusable sink stops the whole list — including a valid `stderr` sink — and the log line, not process exit, is how to detect it.

## Where should the reviewer start?

The new `## Sink Behavior` paragraph in `request-traces.mdx`, read against `parse_sinks_from_env` in `lib/llm/src/request_trace/sink.rs`.

## Validation

```bash
pre-commit run --files docs/fern/pages/reference/observability/environment-variables.mdx \
                       docs/fern/pages/reference/observability/request-traces.mdx
python3 docs/fern/scripts/docs_lint.py
```

Both exit `0`, the second ending in `Docs lint passed: 0 errors.` A frontend started with `DYN_REQUEST_TRACE_SINKS=stderr,s3` and no bucket set logged one `Request trace initialization failed` line, no `Request trace sinks ready` line, and continued to serve requests.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that an unset S3 request-trace bucket logs a warning and allows the service to continue starting.
  - Documented S3 request-trace sink configuration, including bucket, region, prefix, batching, and flush settings.
  - Documented best-effort sink initialization behavior and related logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->