### PR TITLE
fix(kv-router): restore server-selected buffer-first recovery

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
@@ -68,7 +68,7 @@ When the router queries a worker, the local indexer can return six response vari
 |----------|------|--------------|
 | `Events` | Requested start is available in the buffer | Returns retained events and a real-event watermark |
 | `TreeDump` | Initial/full recovery or retained events cannot cover the request | Returns a full RadixTree snapshot as synthetic events plus the latest real-event watermark |
-| `TreeDumpFailed` | The worker cannot construct an exact snapshot and the client opted into explicit failure | Returns the failure and watermark so the router can reset the rank and continue in degraded mode |
+| `TreeDumpFailed` | The worker cannot construct an exact snapshot and the client opted into explicit failure | Reports a non-authoritative failure; the router retries within its existing bounds and preserves state and cursor if no snapshot becomes available |
 | `TooNew` | Requested range begins after the newest available event | Reports the available watermark without applying state |
 | `InvalidRange` | The requested end precedes the start | Rejects the malformed range |
 | `Error` | The worker query itself fails | Returns a serialized query error |
@@ -88,9 +88,13 @@ if last_seq >= 0 and seq > last_seq + 1:
 ```
 
 **Dynamo** (from `lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs`):
-The router tracks an admission cursor per worker and data-parallel rank. Discovering and activating a source with a recovery target starts an initial full recovery immediately; live events arriving during recovery are admitted or buffered according to the rank state. A later gap buffers the live event, resets that rank, and requests a full snapshot with both range bounds unset. This deliberately favors a current, self-contained snapshot over trying to splice a bounded missing range into potentially stale state.
+The router tracks an admission cursor per worker and data-parallel rank. Discovering and activating a source with a recovery target starts an initial full recovery immediately; live events arriving during recovery are admitted or buffered according to the rank state. A later gap buffers the live event and requests events from the next expected ID (`start_event_id=Some(expected)`, `end_event_id=None`), preserving the existing rank and cursor.
 
-On success, the router transactionally replaces the rank from `TreeDump`, advances to the worker's real-event watermark, then drains buffered live events. If snapshot construction or transport fails, the router resets or fences the affected rank as appropriate and continues with degraded live-event processing. A later gap or source change can trigger another recovery.
+The worker selects the recovery response when handling the query: retained history produces `Events`; expired or unavailable history requires `TreeDump`. Buffered events update the existing index, while a successful tree dump transactionally replaces the rank. The client does not preselect snapshot recovery for an ordinary gap.
+
+After applying the response, the router sorts and deduplicates its local pending events, discards those covered by the response watermark, and admits the remaining suffix in order. Missing IDs, including events evicted from the bounded pending buffer, produce a structured warning; the router continues through the gaps and finishes recovery without another catch-up RPC. This can leave stale or missing advisory cache hints. The cursor advances only after successful queue admission, and source fencing and clear ordering still apply.
+
+Snapshot construction failures preserve existing state and cursor after bounded retries. Other query failures retain degraded live-event processing; admission failures fence the rank. A later independent live-stream gap or source change can trigger another recovery.
 
 ## When to Use Which
 

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -396,6 +396,11 @@ impl LocalKvIndexer {
             });
         }
 
+        // NOTE: KV RECOVERY CONTRACT: Decide Events versus TreeDump here, against history
+        // retained when the query is handled. A client's ordinary range request does not
+        // guarantee buffered replay: expired/unavailable history falls back to a snapshot.
+        // See test_local_indexer_get_events_in_id_range_all_cases and
+        // test_local_indexer_buffer_response_starts_at_last_all_domain_clear.
         let buffer = self.event_buffer.lock().unwrap();
         let (first_id, last_id) = if buffer.is_empty() {
             (None, None)

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::recovery_lane::{RECOVERY_CONCURRENCY_LIMIT, RecoveryLane};
 use super::target::{IndexerRecoveryTarget, RecoveryResetReason, RecoveryTarget};
-use super::worker_query_state::{LiveEventAction, PendingDrainPlan, RankState, RecoveryKey};
+use super::worker_query_state::{LiveEventAction, RankState, RecoveryKey};
 use super::worker_query_transport::{RuntimeWorkerQueryTransport, WorkerQueryTransport};
 use crate::discovery::{
     KvEventSource, KvSourceId, KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus,
@@ -662,18 +662,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
                 LiveEventAction::Recover {
                     start_event_id,
                     end_event_id,
-                    reset,
                 } => {
-                    if reset {
-                        self.cancel_recovery(key).await;
-                        if let Err(error) = self
-                            .reset_rank_or_fence(key, &binding.source_id, &mut slot)
-                            .await
-                        {
-                            tracing::error!(%error, worker_id = key.0, dp_rank = key.1, "Failed to clear KV state before gap recovery; rank remains fenced");
-                            return;
-                        }
-                    }
                     self.spawn_recovery(key, binding.clone(), start_event_id, end_event_id)
                         .await
                 }
@@ -778,38 +767,6 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         self.recovery_lane.insert(key, cancel, handle);
     }
 
-    fn schedule_recovery_after_current(
-        self: &Arc<Self>,
-        key: RecoveryKey,
-        binding: Arc<SourceBinding>,
-        start_event_id: u64,
-    ) {
-        let Some(target) = binding.recovery_target().cloned() else {
-            return;
-        };
-        let client = self.clone();
-        tokio::spawn(async move {
-            let Some(slot) = client.slots.get(&key).map(|entry| entry.clone()) else {
-                return;
-            };
-            let slot = slot.lock().await;
-            if binding.lifetime.is_cancelled()
-                || !slot.rank.recovery_inflight
-                || !slot
-                    .active
-                    .as_ref()
-                    .is_some_and(|active| Arc::ptr_eq(active, &binding))
-            {
-                return;
-            }
-            client.cancel_recovery(key).await;
-            if binding.lifetime.is_cancelled() {
-                return;
-            }
-            client.launch_recovery(key, binding, target, Some(start_event_id), None);
-        });
-    }
-
     async fn finish_recovery(
         self: Arc<Self>,
         key: RecoveryKey,
@@ -833,6 +790,10 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
             return false;
         }
 
+        // NOTE: KV RECOVERY CONTRACT: The server selects the response. Events updates the
+        // existing index; only a successful TreeDump replaces the rank. Do not move a reset
+        // ahead of this decision. See retained_gap_replays_without_reset and
+        // expired_gap_uses_server_selected_snapshot.
         let (recovered_events, recovered_cursor) = match result {
             Ok(WorkerKvQueryResponse::Events {
                 events,
@@ -931,16 +892,30 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
             }
         };
 
-        // See RankState::cursor for the admission-based cursor contract. Planning against a clone
-        // preserves the old cursor and buffer until the complete recovery group is admitted.
+        // NOTE: KV RECOVERY CONTRACT: Catch up from the local pending buffer only. Warn and
+        // continue through missing IDs, including buffer overflow; never recursively query
+        // tail holes. This intentionally permits stale/missing advisory hints without relaxing
+        // source fencing or clear ordering. See local_catchup_warns_through_gaps_without_rpc.
+        // Plan against a clone so the cursor advances only after the entire group's admission
+        // (see RankState::cursor). The state-agent also uses this drain helper independently.
         let mut rank_after_admission = slot.rank.clone();
-        rank_after_admission.begin_successful_recovery_drain(recovered_cursor);
-        let PendingDrainPlan {
-            events: buffered_tail,
-            cursor,
-            next_recovery_start,
-        } = rank_after_admission.plan_pending_drain();
-        rank_after_admission.commit_pending_drain(cursor, next_recovery_start);
+        let recovered_through = recovered_cursor.last_applied_id().unwrap_or(0);
+        let tail_watermark = rank_after_admission
+            .pending_live_watermark()
+            .unwrap_or(recovered_through)
+            .max(recovered_through);
+        let buffered_tail = rank_after_admission.drain_advisory_tail_after(recovered_through);
+        let mut last_available = recovered_through;
+        for event in &buffered_tail {
+            self.warn_skipped_recovery_ids(
+                &binding.source_id,
+                last_available,
+                event.event.event_id - 1,
+            );
+            last_available = event.event.event_id;
+        }
+        // Arrival-order eviction can drop the highest observed ID before an older suffix.
+        self.warn_skipped_recovery_ids(&binding.source_id, last_available, tail_watermark);
 
         if let Err(error) = self
             .admit_events(
@@ -954,11 +929,19 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
             return true;
         }
         slot.rank = rank_after_admission;
-        drop(slot);
-        if let Some(start_event_id) = next_recovery_start {
-            self.schedule_recovery_after_current(key, binding, start_event_id);
-        }
         true
+    }
+
+    fn warn_skipped_recovery_ids(&self, source: &KvSourceId, after: u64, through: u64) {
+        if through > after {
+            tracing::warn!(
+                ?source,
+                skipped_start = after + 1,
+                skipped_end = through,
+                skipped_count = through - after,
+                "KV recovery local catch-up skipped event IDs; continuing with advisory hints"
+            );
+        }
     }
 
     async fn finish_degraded_locked(
@@ -1102,11 +1085,11 @@ mod tests {
             CacheOwnerId, CacheSemanticsId, DcId, IdentitySource, IndexerDomainId, PoolId,
             RoutingScopeId, StableDpSlotId,
         },
-        indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics},
+        indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, LocalKvIndexer},
         protocols::{
-            DpRank, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-            KvCacheStoredBlockData, LocalBlockHash, ResidencyDomain, StorageTier, WorkerId,
-            WorkerWithDpRank,
+            DpRank, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData,
+            KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, ResidencyDomain, StorageTier,
+            WorkerId, WorkerWithDpRank,
         },
     };
     use dynamo_runtime::{
@@ -1157,6 +1140,8 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingTarget {
         calls: Arc<Mutex<Vec<TargetCall>>>,
+        indexer: Option<IndexerRecoveryTarget>,
+        reject_event_id: Option<u64>,
     }
 
     #[derive(Clone)]
@@ -1190,34 +1175,51 @@ mod tests {
                 .lock()
                 .await
                 .push(TargetCall::Admit(publisher_id, event.event.event_id));
+            anyhow::ensure!(
+                self.reject_event_id != Some(event.event.event_id),
+                "injected queue admission failure"
+            );
+            if let Some(indexer) = &self.indexer {
+                return indexer.admit_event(publisher_id, event).await;
+            }
             Ok(())
         }
 
         async fn replace_rank(
             &self,
             publisher_id: PublisherId,
-            _worker_id: WorkerId,
-            _dp_rank: DpRank,
-            _events: Vec<RouterEvent>,
+            worker_id: WorkerId,
+            dp_rank: DpRank,
+            events: Vec<RouterEvent>,
         ) -> anyhow::Result<()> {
             self.calls
                 .lock()
                 .await
                 .push(TargetCall::Replace(publisher_id));
+            if let Some(indexer) = &self.indexer {
+                return indexer
+                    .replace_rank(publisher_id, worker_id, dp_rank, events)
+                    .await;
+            }
             Ok(())
         }
 
         async fn reset_rank(
             &self,
             publisher_id: PublisherId,
-            _worker_id: WorkerId,
-            _dp_rank: DpRank,
+            worker_id: WorkerId,
+            dp_rank: DpRank,
             reason: RecoveryResetReason,
         ) -> anyhow::Result<()> {
             self.calls
                 .lock()
                 .await
                 .push(TargetCall::Reset(publisher_id, reason));
+            if let Some(indexer) = &self.indexer {
+                return indexer
+                    .reset_rank(publisher_id, worker_id, dp_rank, reason)
+                    .await;
+            }
             Ok(())
         }
     }
@@ -1282,6 +1284,82 @@ mod tests {
                 .pop()
                 .context("missing mock recovery response")
         }
+    }
+
+    struct LocalIndexerTransport {
+        indexer: LocalKvIndexer,
+        requests: Mutex<Vec<(Option<u64>, Option<u64>)>>,
+        snapshots: Mutex<Vec<bool>>,
+        response_ready: Notify,
+        release_response: Semaphore,
+    }
+
+    impl LocalIndexerTransport {
+        fn new(buffer_size: usize) -> Self {
+            Self {
+                indexer: LocalKvIndexer::new(
+                    CancellationToken::new(),
+                    4,
+                    Arc::new(KvIndexerMetrics::new_unregistered()),
+                    buffer_size,
+                ),
+                requests: Mutex::new(Vec::new()),
+                snapshots: Mutex::new(Vec::new()),
+                response_ready: Notify::new(),
+                release_response: Semaphore::new(0),
+            }
+        }
+
+        async fn wait_for_response(&self) {
+            tokio::time::timeout(Duration::from_secs(5), self.response_ready.notified())
+                .await
+                .expect("worker should answer the recovery query");
+        }
+    }
+
+    #[async_trait]
+    impl WorkerQueryTransport for LocalIndexerTransport {
+        async fn query_worker(
+            &self,
+            worker_id: WorkerId,
+            dp_rank: DpRank,
+            _target: Instance,
+            start_event_id: Option<u64>,
+            end_event_id: Option<u64>,
+        ) -> Result<WorkerKvQueryResponse> {
+            assert_eq!((worker_id, dp_rank), (42, 4));
+            self.requests
+                .lock()
+                .await
+                .push((start_event_id, end_event_id));
+            // Use production classification, then hold delivery so tests can inject live arrivals.
+            let response = self
+                .indexer
+                .get_events_in_id_range(start_event_id, end_event_id)
+                .await;
+            self.snapshots
+                .lock()
+                .await
+                .push(matches!(response, WorkerKvQueryResponse::TreeDump { .. }));
+            self.response_ready.notify_one();
+            self.release_response.acquire().await.unwrap().forget();
+            Ok(response)
+        }
+    }
+
+    async fn finish_local_response(
+        client: &Arc<WorkerQueryClient<RecordingTarget>>,
+        transport: &LocalIndexerTransport,
+    ) {
+        let slot = client.slots.get(&(42, 4)).unwrap().clone();
+        transport.release_response.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while slot.lock().await.rank.recovery_inflight {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("recovery should finish using only the local tail");
     }
 
     #[derive(Default)]
@@ -2380,8 +2458,15 @@ mod tests {
         client.shutdown().await;
     }
 
-    #[tokio::test]
-    async fn gap_recovery_resets_before_full_snapshot_and_ordered_live_drain() {
+    async fn start_local_recovery(
+        buffer_size: usize,
+        reject_event_id: Option<u64>,
+    ) -> (
+        Arc<WorkerQueryClient<RecordingTarget>>,
+        Arc<LocalIndexerTransport>,
+        KvIndexer,
+        RecordingTarget,
+    ) {
         let serving = EndpointId::from("test.router.generate");
         let kv_endpoint = EndpointId::from("test.router.kv");
         let worker = WorkerWithDpRank::new(42, 4);
@@ -2395,60 +2480,263 @@ mod tests {
         );
         let (_tx, rx) = watch::channel(view.clone());
         let (kv_indexer, indexer) = indexer();
-        let transport = Arc::new(MockTransport::default());
-        *transport.release.lock().await = Some(Arc::new(Notify::new()));
-        let client = WorkerQueryClient::new_for_test(indexer, rx, transport);
-        client.reconcile_view(view).await;
-        let binding = client.publisher_bindings.get(&100).unwrap().binding.clone();
-
-        client.handle_live_batch(100, vec![store(1)]).await;
-        client
-            .clone()
-            .finish_recovery(
-                (worker.worker_id, worker.dp_rank),
-                binding.clone(),
-                CancellationToken::new(),
-                Ok(WorkerKvQueryResponse::TreeDump {
-                    events: vec![store(1)],
-                    last_event_id: 1,
-                    reset_scope: ResetScope::All,
-                }),
-            )
-            .await;
-        assert!(contains_block(&kv_indexer.dump_events().await.unwrap(), 1));
-
-        client.handle_live_batch(100, vec![store(3)]).await;
-        client.handle_live_batch(100, vec![store(4)]).await;
-        let slot = client
-            .slots
-            .get(&(worker.worker_id, worker.dp_rank))
-            .unwrap()
-            .clone();
-        assert_eq!(slot.lock().await.rank.last_admitted_id(), Some(1));
-        assert!(kv_indexer.dump_events().await.unwrap().is_empty());
-
-        client
-            .clone()
-            .finish_recovery(
-                (worker.worker_id, worker.dp_rank),
-                binding,
-                CancellationToken::new(),
-                Ok(WorkerKvQueryResponse::TreeDump {
-                    events: vec![store(1), store(2)],
-                    last_event_id: 2,
-                    reset_scope: ResetScope::All,
-                }),
-            )
-            .await;
-
-        let events = kv_indexer.dump_events().await.unwrap();
-        for block in 1..=4 {
-            assert!(contains_block(&events, block));
+        let transport = Arc::new(LocalIndexerTransport::new(buffer_size));
+        for event in [store(1), store(2)] {
+            transport
+                .indexer
+                .apply_event_with_buffer(event)
+                .await
+                .unwrap();
         }
-        let slot = slot.lock().await;
-        assert_eq!(slot.rank.last_admitted_id(), Some(4));
-        assert!(!slot.rank.recovery_inflight);
-        drop(slot);
+        let target = RecordingTarget {
+            indexer: Some(IndexerRecoveryTarget::new(indexer)),
+            reject_event_id,
+            ..Default::default()
+        };
+        let client = WorkerQueryClient::new_target_for_test(target.clone(), rx, transport.clone());
+        client.reconcile_view(view).await;
+        transport.wait_for_response().await;
+        finish_local_response(&client, &transport).await;
+        assert_eq!(*transport.requests.lock().await, vec![(None, None)]);
+        assert_eq!(*transport.snapshots.lock().await, vec![true]);
+        assert_eq!(*target.calls.lock().await, vec![TargetCall::Replace(100)]);
+        target.calls.lock().await.clear();
+        (client, transport, kv_indexer, target)
+    }
+
+    fn dependent_store(event_id: u64, parent: u64) -> RouterEvent {
+        let mut event = store(event_id);
+        let KvCacheEventData::Stored(data) = &mut event.event.data else {
+            unreachable!();
+        };
+        data.parent_hash = Some(ExternalSequenceBlockHash(parent));
+        event
+    }
+
+    async fn assert_gap_recovery(buffer_size: usize, expect_snapshot: bool) {
+        let (client, transport, kv_indexer, target) = start_local_recovery(buffer_size, None).await;
+        let mut remove = store(3);
+        remove.event.data = KvCacheEventData::Removed(KvCacheRemoveData {
+            block_hashes: vec![ExternalSequenceBlockHash(2)],
+        });
+        for event in [remove, dependent_store(4, 1), dependent_store(5, 4)] {
+            transport
+                .indexer
+                .apply_event_with_buffer(event)
+                .await
+                .unwrap();
+        }
+
+        client
+            .handle_live_batch(100, vec![dependent_store(5, 4)])
+            .await;
+        transport.wait_for_response().await;
+        assert_eq!(
+            *transport.requests.lock().await,
+            vec![(None, None), (Some(3), None)]
+        );
+        assert_eq!(
+            *transport.snapshots.lock().await,
+            vec![true, expect_snapshot]
+        );
+        assert!(
+            target.calls.lock().await.is_empty(),
+            "gap must not pre-clear the rank"
+        );
+        let before = kv_indexer.dump_events().await.unwrap();
+        assert!(contains_block(&before, 1));
+        assert!(contains_block(&before, 2));
+        let slot = client.slots.get(&(42, 4)).unwrap().clone();
+        assert_eq!(slot.lock().await.rank.last_admitted_id(), Some(2));
+
+        // The response covers 5. Out-of-order and duplicate arrivals must replay as 6, 7.
+        client
+            .handle_live_batch(
+                100,
+                vec![
+                    dependent_store(7, 6),
+                    dependent_store(6, 5),
+                    dependent_store(7, 6),
+                    dependent_store(5, 4),
+                    dependent_store(4, 1),
+                ],
+            )
+            .await;
+        finish_local_response(&client, &transport).await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        for block in [1, 4, 5, 6, 7] {
+            assert!(
+                contains_block(&events, block),
+                "missing dependent block {block}"
+            );
+        }
+        assert!(
+            !contains_block(&events, 2),
+            "missed remove must be recovered"
+        );
+        let mut expected_calls = if expect_snapshot {
+            vec![TargetCall::Replace(100)]
+        } else {
+            (3..=5).map(|id| TargetCall::Admit(100, id)).collect()
+        };
+        expected_calls.extend([TargetCall::Admit(100, 6), TargetCall::Admit(100, 7)]);
+        assert_eq!(*target.calls.lock().await, expected_calls);
+        assert_eq!(slot.lock().await.rank.last_admitted_id(), Some(7));
+        assert!(!slot.lock().await.rank.recovery_inflight);
+        assert_eq!(transport.requests.lock().await.len(), 2);
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn retained_gap_replays_without_reset() {
+        assert_gap_recovery(16, false).await;
+    }
+
+    #[tokio::test]
+    async fn expired_gap_uses_server_selected_snapshot() {
+        assert_gap_recovery(2, true).await;
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn local_catchup_warns_through_gaps_without_rpc() {
+        let logs = CapturedLogs::default();
+        let writer = logs.clone();
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .without_time()
+                .with_ansi(false)
+                .with_max_level(tracing::Level::WARN)
+                .with_writer(move || writer.clone())
+                .finish(),
+        );
+        for (pending, expected_tail, final_cursor, skipped_end) in [
+            (vec![7, 6, 7, 4], vec![6, 7], 7, 5),
+            // Arrival-order eviction drops 5 and 6 beyond the response watermark of 4.
+            ((5..=1030).collect(), (7..=1030).collect(), 1030, 6),
+            // Even the highest observed event can be evicted by older duplicate arrivals.
+            ([vec![2000], vec![6; 1024]].concat(), vec![6], 6, 5),
+        ] {
+            logs.0.lock().unwrap().clear();
+            let (client, transport, kv_indexer, target) = start_local_recovery(16, None).await;
+            for id in [3, 4] {
+                transport
+                    .indexer
+                    .apply_event_with_buffer(store(id))
+                    .await
+                    .unwrap();
+            }
+            client.handle_live_batch(100, vec![store(4)]).await;
+            transport.wait_for_response().await;
+            client
+                .handle_live_batch(100, pending.into_iter().map(store).collect())
+                .await;
+            finish_local_response(&client, &transport).await;
+
+            let expected_calls: Vec<_> = [3, 4]
+                .into_iter()
+                .chain(expected_tail.iter().copied())
+                .map(|id| TargetCall::Admit(100, id))
+                .collect();
+            assert_eq!(*target.calls.lock().await, expected_calls);
+            let events = kv_indexer.dump_events().await.unwrap();
+            for block in expected_tail {
+                assert!(contains_block(&events, block));
+            }
+            let slot = client.slots.get(&(42, 4)).unwrap().clone();
+            assert_eq!(
+                slot.lock().await.rank.last_admitted_id(),
+                Some(final_cursor)
+            );
+            assert!(!slot.lock().await.rank.recovery_inflight);
+            assert_eq!(transport.requests.lock().await.len(), 2);
+            let captured = String::from_utf8(logs.0.lock().unwrap().clone()).unwrap();
+            assert!(
+                captured.contains("KV recovery local catch-up skipped event IDs"),
+                "{captured}"
+            );
+            assert!(captured.contains("publisher_id: 100"), "{captured}");
+            assert!(captured.contains("skipped_start=5"), "{captured}");
+            assert!(
+                captured.contains(&format!("skipped_end={skipped_end}")),
+                "{captured}"
+            );
+            if final_cursor == 6 {
+                assert!(
+                    captured.contains("skipped_start=7 skipped_end=2000 skipped_count=1994"),
+                    "{captured}"
+                );
+            }
+
+            if final_cursor == 7 {
+                // A later independent live gap still issues the ordinary next-ID request.
+                for id in 5..=9 {
+                    transport
+                        .indexer
+                        .apply_event_with_buffer(store(id))
+                        .await
+                        .unwrap();
+                }
+                client.handle_live_batch(100, vec![store(9)]).await;
+                transport.wait_for_response().await;
+                finish_local_response(&client, &transport).await;
+                assert_eq!(
+                    *transport.requests.lock().await,
+                    vec![(None, None), (Some(3), None), (Some(8), None),]
+                );
+                assert_eq!(slot.lock().await.rank.last_admitted_id(), Some(9));
+            }
+            client.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn buffered_recovery_admission_failure_preserves_cursor_and_fences_rank() {
+        let (client, transport, kv_indexer, target) = start_local_recovery(16, Some(6)).await;
+        for id in [3, 4] {
+            transport
+                .indexer
+                .apply_event_with_buffer(store(id))
+                .await
+                .unwrap();
+        }
+        client.handle_live_batch(100, vec![store(4)]).await;
+        transport.wait_for_response().await;
+        client
+            .handle_live_batch(100, vec![store(6), store(5)])
+            .await;
+        finish_local_response(&client, &transport).await;
+
+        assert_eq!(
+            *target.calls.lock().await,
+            (3..=6)
+                .map(|id| TargetCall::Admit(100, id))
+                .collect::<Vec<_>>()
+        );
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert!(
+            contains_block(&events, 5),
+            "earlier admissions may have succeeded"
+        );
+        assert!(!contains_block(&events, 6));
+        let slot = client.slots.get(&(42, 4)).unwrap().clone();
+        assert_eq!(slot.lock().await.rank.last_admitted_id(), Some(2));
+        assert!(slot.lock().await.pending_reset.is_some());
+        assert!(!slot.lock().await.rank.recovery_inflight);
+        assert_eq!(transport.requests.lock().await.len(), 2);
         client.shutdown().await;
     }
 

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
@@ -13,7 +13,6 @@ use dynamo_kv_router::{
 pub(super) type RecoveryKey = (WorkerId, DpRank);
 
 const RECOVERY_PENDING_LIVE_EVENT_LIMIT: usize = 1024;
-const RECOVERY_PENDING_FAST_PRUNE_MARGIN: usize = 10;
 
 pub(super) enum LiveEventAction {
     Ignore,
@@ -28,17 +27,10 @@ pub(super) enum LiveEventAction {
     Recover {
         start_event_id: Option<u64>,
         end_event_id: Option<u64>,
-        reset: bool,
     },
     ResetDegraded {
         event: RouterEvent,
     },
-}
-
-pub(super) struct PendingDrainPlan {
-    pub(super) events: Vec<RouterEvent>,
-    pub(super) cursor: CursorState,
-    pub(super) next_recovery_start: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -107,16 +99,20 @@ impl RankState {
                 LiveEventAction::Recover {
                     start_event_id: None,
                     end_event_id: None,
-                    reset: false,
                 }
             }
-            CursorObservation::Gap { .. } if recoverable => {
+            CursorObservation::Gap { expected, .. } if recoverable => {
+                // NOTE: KV RECOVERY CONTRACT: Ordinary gaps request the next expected ID
+                // and preserve the existing index/cursor. Only the server can decide whether
+                // its retained history supports Events or requires TreeDump; never pre-clear
+                // the rank or request a snapshot here. Initial recovery and source replacement
+                // are separate lifecycle cases. See retained_gap_replays_without_reset and
+                // expired_gap_uses_server_selected_snapshot in worker_query.rs.
                 self.observe_and_buffer(event);
                 self.recovery_inflight = true;
                 LiveEventAction::Recover {
-                    start_event_id: None,
+                    start_event_id: Some(expected),
                     end_event_id: None,
-                    reset: true,
                 }
             }
             CursorObservation::Gap { .. } => LiveEventAction::ResetDegraded { event },
@@ -134,82 +130,14 @@ impl RankState {
         self.clear_max_seen_if_caught_up(event_id);
     }
 
-    pub(super) fn begin_successful_recovery_drain(&mut self, cursor: CursorState) {
-        self.cursor = cursor;
-        self.recovery_inflight = true;
+    pub(super) fn pending_live_watermark(&self) -> Option<u64> {
+        self.max_seen_live_id
     }
 
     pub(super) fn discard_recovery_before_clear(&mut self) {
         self.recovery_inflight = false;
         self.pending_live_events.clear();
         self.max_seen_live_id = None;
-    }
-
-    pub(super) fn plan_pending_drain(&mut self) -> PendingDrainPlan {
-        let mut last_admitted_id = self.last_admitted_id().unwrap_or(0);
-        let mut cursor = self.cursor;
-        self.pending_live_events
-            .make_contiguous()
-            .sort_unstable_by_key(|event| event.event.event_id);
-        self.fast_prune_stale_pending_prefix(last_admitted_id);
-        let mut events = Vec::new();
-
-        loop {
-            let Some(front_event_id) = self
-                .pending_live_events
-                .front()
-                .map(|event| event.event.event_id)
-            else {
-                self.clear_max_seen_if_caught_up(last_admitted_id);
-                if self
-                    .max_seen_live_id
-                    .is_some_and(|max_seen| max_seen > last_admitted_id)
-                {
-                    return PendingDrainPlan {
-                        events,
-                        cursor,
-                        next_recovery_start: Some(last_admitted_id.saturating_add(1)),
-                    };
-                }
-                return PendingDrainPlan {
-                    events,
-                    cursor,
-                    next_recovery_start: None,
-                };
-            };
-
-            if front_event_id <= last_admitted_id {
-                self.pending_live_events.pop_front();
-                continue;
-            }
-
-            let expected = last_admitted_id.saturating_add(1);
-            if front_event_id != expected {
-                return PendingDrainPlan {
-                    events,
-                    cursor,
-                    next_recovery_start: Some(expected),
-                };
-            }
-
-            let event = self
-                .pending_live_events
-                .pop_front()
-                .expect("front event exists while draining pending live events");
-            last_admitted_id = front_event_id;
-            cursor = cursor.advance_to(front_event_id);
-            events.push(event);
-        }
-    }
-
-    pub(super) fn commit_pending_drain(
-        &mut self,
-        cursor: CursorState,
-        next_recovery_start: Option<u64>,
-    ) {
-        self.cursor = cursor;
-        self.clear_max_seen_if_caught_up(self.last_admitted_id().unwrap_or(0));
-        self.recovery_inflight = next_recovery_start.is_some();
     }
 
     pub(super) fn finish_failed_recovery(&mut self) {
@@ -235,10 +163,11 @@ impl RankState {
         self.observe_and_buffer(event);
     }
 
-    /// Drain the buffered suffix after an advisory source snapshot.
+    /// Drain the buffered suffix after an advisory recovery response.
     ///
-    /// Unlike worker gap recovery, this preserves the state-agent stream's
-    /// accepted warn-and-continue behavior across missing event IDs.
+    /// Missing IDs do not block the suffix. Worker-query recovery calls this on a
+    /// clone and commits it only after queue admission; state-agent recovery owns
+    /// its own admission and fencing policy.
     pub(super) fn drain_advisory_tail_after(&mut self, recovered_through: u64) -> Vec<RouterEvent> {
         self.cursor = CursorState::Initial.advance_to(recovered_through);
         let events = self.take_failed_recovery_degraded();
@@ -279,20 +208,6 @@ impl RankState {
             .is_some_and(|max_seen| max_seen <= last_admitted_id)
         {
             self.max_seen_live_id = None;
-        }
-    }
-
-    fn fast_prune_stale_pending_prefix(&mut self, last_admitted_id: u64) {
-        if self.pending_live_events.len() <= RECOVERY_PENDING_FAST_PRUNE_MARGIN {
-            return;
-        }
-        let split_at = self.pending_live_events.len() - RECOVERY_PENDING_FAST_PRUNE_MARGIN;
-        if self
-            .pending_live_events
-            .get(split_at)
-            .is_some_and(|event| event.event.event_id <= last_admitted_id)
-        {
-            self.pending_live_events.drain(..split_at);
         }
     }
 }
@@ -342,7 +257,6 @@ mod tests {
             LiveEventAction::Recover {
                 start_event_id: None,
                 end_event_id: None,
-                reset: false,
             }
         ));
         assert!(state.recovery_inflight);
@@ -360,9 +274,8 @@ mod tests {
         assert!(matches!(
             state.observe_live_event(store(4), true),
             LiveEventAction::Recover {
-                start_event_id: None,
+                start_event_id: Some(2),
                 end_event_id: None,
-                reset: true,
             }
         ));
         assert!(matches!(
@@ -371,19 +284,13 @@ mod tests {
         ));
         assert_eq!(state.last_admitted_id(), Some(1));
 
-        state.begin_successful_recovery_drain(CursorState::Initial.advance_to(2));
-        let plan = state.plan_pending_drain();
+        let tail = state.drain_advisory_tail_after(2);
         assert_eq!(
-            plan.events
-                .iter()
+            tail.iter()
                 .map(|event| event.event.event_id)
                 .collect::<Vec<_>>(),
             vec![3, 4]
         );
-        assert_eq!(plan.cursor.last_applied_id(), Some(4));
-        assert_eq!(plan.next_recovery_start, None);
-        assert_eq!(state.last_admitted_id(), Some(2));
-        state.commit_pending_drain(plan.cursor, plan.next_recovery_start);
         assert_eq!(state.last_admitted_id(), Some(4));
         assert!(!state.recovery_inflight);
     }
@@ -417,7 +324,10 @@ mod tests {
         state.commit_live_admission(1);
         assert!(matches!(
             state.observe_live_event(store(4), true),
-            LiveEventAction::Recover { reset: true, .. }
+            LiveEventAction::Recover {
+                start_event_id: Some(2),
+                ..
+            }
         ));
 
         let mut worker_clear = store(5);


### PR DESCRIPTION
## Summary

An ordinary KV event gap currently clears the router's rank and requests a full snapshot, bypassing the worker's retained event buffer. Restore the intended contract: request the next expected event ID while preserving the index and cursor, and let the worker select buffered `Events` or a `TreeDump` using its current retained history.

Catch up from the router's bounded local buffer after the response: sort, deduplicate, discard events covered by the watermark, and warn through remaining gaps without another catch-up RPC. Available events advance the cursor only after the complete recovery group is admitted. Source fencing, cancellation, clear ordering, snapshot-failure handling, and state-agent behavior remain intact. Prominent `NOTE: KV RECOVERY CONTRACT` comments at each decision boundary point to behavioral regressions, and the recovery documentation now describes the same contract.

The accepted tradeoff is that skipped tail events can leave stale or missing advisory cache hints. This adds no wire/API/configuration changes, acknowledgements, or stricter delivery guarantees.

## Validation

- Real `LocalKvIndexer` transport regressions prove that the same next-ID request yields buffered replay for retained history and rank replacement for expired history. They verify preserved prefixes, missed removes, dependent stores, concurrent arrivals, warning-and-continue behavior under gaps/overflow, no recursive catch-up RPC, and cursor/source fencing on admission failure.
- 57 targeted Rust tests passed: 36 worker-query/endpoint/state tests, 8 state-agent tests, and 13 local-indexer tests, including retained-range boundaries and all-domain-clear compaction.
  - `cargo test -p dynamo-llm --no-default-features kv_router::indexer::recovery::worker_query --lib`
  - `cargo test -p dynamo-llm --no-default-features kv_router::indexer::recovery::state_agent --lib`
  - `cargo test -p dynamo-kv-router test_local_indexer --lib`
- Scoped Rust formatting, docs lint, `fern check`, and commit hooks passed. `fern docs broken-links` reports one pre-existing link error at `pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx:254` pointing to `/dynamo/recipes/model-recipes/deepseek-v4-pro`; that page is unchanged by this PR.
- No GPU benchmark was run; acceptance is the recovery behavior and RPC-count regressions above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from missing event ranges by replaying retained events when available, while using snapshots only when necessary.
  * Preserved ranking state and progress during recovery instead of resetting to full snapshot recovery.
  * Improved handling of recovery failures, including retries, degraded operation, and fencing where appropriate.
  * Reconciled buffered events after recovery and clearly reported skipped event IDs.

* **Documentation**
  * Updated recovery guidance to explain event-range replay, snapshot fallback, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->