### PR TITLE
fix(llm): [cherry-pick 1.5.0] stop unloading one LoRA adapter from disabling chat for every model (#14216)

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -45,6 +45,7 @@ use crate::{
     lora::state_tracker::LoraWorkerProjection,
     lora::{LoraFilter, LoraRoutingTable, LoraStateTracker, load_estimator::LoadEstimator},
     model_card::{LoraInfo, ModelDeploymentCard},
+    model_type::ModelType,
     types::{
         RealtimeBidirectionalEngine,
         generic::tensor::TensorStreamingEngine,
@@ -1212,6 +1213,31 @@ impl ModelManager {
             .filter(|(_, model)| model.has_prefill())
             .map(|(name, _)| name.clone())
             .collect()
+    }
+
+    /// True when at least one registered model still serves `model_type`.
+    ///
+    /// A combined [`ModelType`] is occupied when any of its units is occupied. A unit
+    /// with no backing model list is never occupied; [`ModelType::Prefill`] is such a
+    /// unit, being a cross-version marker rather than a served surface.
+    ///
+    /// This is the only place that maps a [`ModelType`] onto the models behind it, and it
+    /// must stay aligned with endpoint retraction: a unit answered wrongly here either
+    /// disables an endpoint that still has models or leaves one enabled with none.
+    pub fn has_models_of_type(&self, model_type: ModelType) -> bool {
+        (model_type.contains(ModelType::Chat) && !self.list_chat_completions_models().is_empty())
+            || (model_type.contains(ModelType::Completions)
+                && !self.list_completions_models().is_empty())
+            || (model_type.contains(ModelType::Embedding)
+                && !self.list_embeddings_models().is_empty())
+            || (model_type.contains(ModelType::Images) && !self.list_images_models().is_empty())
+            || (model_type.contains(ModelType::Audios) && !self.list_audios_models().is_empty())
+            || (model_type.contains(ModelType::Videos) && !self.list_videos_models().is_empty())
+            || (model_type.contains(ModelType::TensorBased)
+                && !self.list_tensor_models().is_empty())
+            || (model_type.contains(ModelType::Realtime) && !self.list_realtime_models().is_empty())
+            || (model_type.contains(ModelType::Classify) && !self.list_classify_models().is_empty())
+            || (model_type.contains(ModelType::Pooling) && !self.list_pooling_models().is_empty())
     }
 
     pub fn get_embeddings_engine(
@@ -3755,5 +3781,95 @@ mod tests {
             ),
             "incomplete-but-engine-present model must be ModelUnavailable (503), not 404"
         );
+    }
+
+    /// Stand-in engine for registration-only tests; never invoked.
+    struct UncalledEngine;
+
+    #[async_trait::async_trait]
+    impl<Req, Resp>
+        dynamo_runtime::engine::AsyncEngine<
+            dynamo_runtime::pipeline::SingleIn<Req>,
+            dynamo_runtime::pipeline::ManyOut<Resp>,
+            dynamo_runtime::pipeline::Error,
+        > for UncalledEngine
+    where
+        Req: Send + Sync + 'static,
+        Resp: dynamo_runtime::engine::Data,
+    {
+        async fn generate(
+            &self,
+            _request: dynamo_runtime::pipeline::SingleIn<Req>,
+        ) -> Result<dynamo_runtime::pipeline::ManyOut<Resp>, dynamo_runtime::pipeline::Error>
+        {
+            anyhow::bail!("engine is never invoked by this test")
+        }
+    }
+
+    /// Registers one model that occupies `model_type`. Returns false when this test has no
+    /// way to occupy that unit, which is the signal the caller turns into a failure.
+    fn register_model_occupying(manager: &ModelManager, model_type: ModelType) -> bool {
+        let name = "occupancy-probe";
+        let outcome = if model_type == ModelType::Chat {
+            manager.add_chat_completions_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Completions {
+            manager.add_completions_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Embedding {
+            manager.add_embeddings_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Images {
+            manager.add_images_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Audios {
+            manager.add_audios_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Videos {
+            manager.add_videos_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::TensorBased {
+            manager.add_tensor_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Realtime {
+            manager.add_realtime_model(
+                name,
+                "ck",
+                Arc::new(crate::engines::EchoBidirectionalEngine),
+            )
+        } else if model_type == ModelType::Classify {
+            manager.add_classify_model(name, "ck", Arc::new(UncalledEngine))
+        } else if model_type == ModelType::Pooling {
+            manager.add_pooling_model(name, "ck", Arc::new(UncalledEngine))
+        } else {
+            return false;
+        };
+        outcome.expect("registering the occupancy probe model failed");
+        true
+    }
+
+    /// `ModelType` is a `bitflags!` type, so a unit left out of the hand-maintained
+    /// `has_models_of_type` chain draws no exhaustiveness error and is silently reported as
+    /// never occupied. Every unit that maps onto an `EndpointType` must therefore be
+    /// registrable here and answered as occupied once a model of it exists.
+    #[test]
+    fn has_models_of_type_answers_every_endpoint_backed_model_type() {
+        for unit in ModelType::all().units() {
+            // Units that serve no HTTP endpoint carry no such obligation: ModelType::Prefill
+            // is a cross-version marker, and ModelType::TensorBased has no endpoint mapping.
+            if unit.as_endpoint_types_with_anthropic(true).is_empty() {
+                continue;
+            }
+
+            let manager = ModelManager::new();
+            assert!(
+                !manager.has_models_of_type(unit),
+                "{unit:?} must not be reported as occupied in an empty manager"
+            );
+            assert!(
+                register_model_occupying(&manager, unit),
+                "{unit:?} maps onto an HTTP endpoint but this test cannot register a model \
+                 that occupies it; add a branch to register_model_occupying, and a term to \
+                 ModelManager::has_models_of_type if it lacks one"
+            );
+            assert!(
+                manager.has_models_of_type(unit),
+                "ModelManager::has_models_of_type does not answer {unit:?}, so the frontend \
+                 would retract that endpoint while a model of that type is still registered"
+            );
+        }
     }
 }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -245,29 +245,7 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
 
 /// Returns true if no models in the manager support the given model type.
 fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bool {
-    if model_type == ModelType::Chat {
-        manager.list_chat_completions_models().is_empty()
-    } else if model_type == ModelType::Completions {
-        manager.list_completions_models().is_empty()
-    } else if model_type == ModelType::Embedding {
-        manager.list_embeddings_models().is_empty()
-    } else if model_type == ModelType::Images {
-        manager.list_images_models().is_empty()
-    } else if model_type == ModelType::Audios {
-        manager.list_audios_models().is_empty()
-    } else if model_type == ModelType::Videos {
-        manager.list_videos_models().is_empty()
-    } else if model_type == ModelType::TensorBased {
-        manager.list_tensor_models().is_empty()
-    } else if model_type == ModelType::Realtime {
-        manager.list_realtime_models().is_empty()
-    } else if model_type == ModelType::Classify {
-        manager.list_classify_models().is_empty()
-    } else if model_type == ModelType::Pooling {
-        manager.list_pooling_models().is_empty()
-    } else {
-        true
-    }
+    !manager.has_models_of_type(model_type)
 }
 
 fn removed_model_cards(
@@ -1828,6 +1806,26 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
         assert!(is_model_type_list_empty(&mm, ModelType::Classify));
         assert!(is_model_type_list_empty(&mm, ModelType::Pooling));
+    }
+
+    /// `ALL_MODEL_TYPES` is the second hand-maintained list of the same `ModelType` units
+    /// that `ModelManager::has_models_of_type` enumerates, and it is what
+    /// `removed_model_cards` iterates. A unit missing from it is never considered for a
+    /// retraction card, so that unit's endpoint is never retracted even when its last model
+    /// is gone. `ModelType` is a `bitflags!` type, so nothing else catches the omission.
+    #[test]
+    fn all_model_types_covers_every_endpoint_backed_unit() {
+        for unit in ModelType::all().units() {
+            // Units that serve no HTTP endpoint need no retraction card.
+            if unit.as_endpoint_types_with_anthropic(true).is_empty() {
+                continue;
+            }
+            assert!(
+                ALL_MODEL_TYPES.contains(&unit),
+                "{unit:?} maps onto an HTTP endpoint but is missing from ALL_MODEL_TYPES, so \
+                 removed_model_cards would never emit a retraction card for it"
+            );
+        }
     }
 
     #[test]

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     kv_router::WorkerSelectorFactory,
     local_model::runtime_config::{ModelRuntimeConfig, TokenizerBackend},
+    model_type::ModelType,
     namespace::NamespaceFilter,
     types::openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
@@ -398,10 +399,17 @@ fn update_http_endpoints(service: Arc<HttpService>, model_type: ModelUpdate) -> 
             }
         }
         ModelUpdate::Removed(card) => {
-            // Handle all supported endpoint types, not just the first one
-            for endpoint_type in card
+            // Endpoint flags are process-wide and a LoRA adapter card carries its base
+            // model's `model_type`, so only retract units the live catalog has vacated.
+            let manager = service.model_manager();
+            let vacated = card
                 .model_type
-                .as_endpoint_types_with_anthropic(service.anthropic_api_enabled())
+                .units()
+                .into_iter()
+                .filter(|unit| !manager.has_models_of_type(*unit))
+                .fold(ModelType::empty(), |vacated, unit| vacated | unit);
+            for endpoint_type in
+                vacated.as_endpoint_types_with_anthropic(service.anthropic_api_enabled())
             {
                 service.enable_model_endpoint(endpoint_type, false)?;
             }
@@ -427,5 +435,76 @@ fn update_model_metrics(
             // Note: Metrics are typically not removed to preserve historical data
             // This matches the behavior in the polling task
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engines::make_echo_engine;
+    use crate::model_card::{LoraInfo, ModelDeploymentCard};
+    use crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine;
+
+    fn chat_engine() -> OpenAIChatCompletionsStreamingEngine {
+        Arc::new(StreamingEngineAdapter::new(make_echo_engine()))
+    }
+
+    fn chat_card(name: &str) -> ModelDeploymentCard {
+        let mut card = ModelDeploymentCard::with_name_only(name);
+        card.model_type = ModelType::Chat;
+        card
+    }
+
+    /// A LoRA adapter card is a clone of its base model's card, so it carries
+    /// `ModelType::Chat` for a chat model. Because endpoint flags are process-wide,
+    /// treating that removal as "disable chat" answers `404` on
+    /// `/v1/chat/completions` for the base model and every sibling adapter that is
+    /// still registered. The retraction must instead follow the live catalog.
+    #[test]
+    fn unloading_one_adapter_keeps_chat_enabled_for_the_base_model() {
+        let service = Arc::new(HttpService::builder().build().unwrap());
+        let manager = service.model_manager();
+        manager
+            .add_chat_completions_model("base-model", "ck-base", chat_engine())
+            .unwrap();
+        manager
+            .add_chat_completions_model("base-model-adapter", "ck-adapter", chat_engine())
+            .unwrap();
+
+        let base_card = chat_card("base-model");
+        let mut adapter_card = chat_card("base-model-adapter");
+        adapter_card.lora = Some(LoraInfo {
+            name: "base-model-adapter".to_string(),
+            max_gpu_lora_count: None,
+        });
+
+        update_http_endpoints(service.clone(), ModelUpdate::Added(base_card.clone())).unwrap();
+        update_http_endpoints(service.clone(), ModelUpdate::Added(adapter_card.clone())).unwrap();
+        assert!(service.model_endpoint_enabled(EndpointType::Chat));
+        assert!(service.model_endpoint_enabled(EndpointType::Responses));
+
+        // The watcher drops the model from the manager before it emits the removal,
+        // so the frontend observes the post-removal catalog.
+        manager.remove_model("base-model-adapter");
+        update_http_endpoints(service.clone(), ModelUpdate::Removed(adapter_card)).unwrap();
+        assert!(
+            service.model_endpoint_enabled(EndpointType::Chat),
+            "unloading one adapter must leave /v1/chat/completions serving the base model"
+        );
+        assert!(
+            service.model_endpoint_enabled(EndpointType::Responses),
+            "unloading one adapter must leave /v1/responses serving the base model"
+        );
+
+        manager.remove_model("base-model");
+        update_http_endpoints(service.clone(), ModelUpdate::Removed(base_card)).unwrap();
+        assert!(
+            !service.model_endpoint_enabled(EndpointType::Chat),
+            "removing the last chat model must disable /v1/chat/completions"
+        );
+        assert!(
+            !service.model_endpoint_enabled(EndpointType::Responses),
+            "removing the last chat model must disable /v1/responses"
+        );
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -1015,6 +1015,12 @@ impl HttpService {
         );
         Ok(())
     }
+
+    /// Reports whether requests to `endpoint_type` are currently served. A disabled
+    /// endpoint answers `404` for every model.
+    pub fn model_endpoint_enabled(&self, endpoint_type: EndpointType) -> bool {
+        self.state.flags.get(&endpoint_type)
+    }
 }
 
 fn get_graceful_shutdown_timeout() -> usize {


### PR DESCRIPTION
Cherry-pick of #14216 to `release/1.5.0`.

This backport prevents unloading one LoRA adapter from disabling chat endpoints process-wide for its base model and unrelated models.

Signed-off cherry-pick with `-x --signoff`.

Validation:
- Applied cleanly with no conflicts.
- Remote Git tree exactly matches the locally verified cherry-pick tree (`62772afb9a28e0f854691afb509e2850f463ef3b`).
- `git diff --check HEAD^ HEAD` passed.
- Rust formatting, checks, clippy, and tests were not run because `cargo` is unavailable in this environment.