### PR TITLE
fix(frontend): set TCP_NODELAY on accepted client connections

### DIFF
--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -927,6 +927,19 @@ impl HttpService {
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
             let state = self.state.clone();
+            use axum::serve::ListenerExt;
+            // Clear Nagle on the client-facing socket. Without this a response
+            // streamed one SSE chunk per token writes a small segment and then
+            // waits on the peer's delayed ACK, which Linux floors at HZ/25, so
+            // every streamed response pays a fixed ~40 ms. The internal
+            // transport already sets this on all of its sockets.
+            let listener = listener.tap_io(|tcp_stream| {
+                if let Err(err) = tcp_stream.set_nodelay(true) {
+                    tracing::trace!(
+                        "failed to set TCP_NODELAY on incoming connection: {err:#}"
+                    );
+                }
+            });
             axum::serve(listener, router)
                 .with_graceful_shutdown(async move {
                     observer.cancelled_owned().await;


### PR DESCRIPTION
The HTTP frontend hands a bare `tokio::net::TcpListener` to `axum::serve` and never clears Nagle on the sockets it accepts. A completion streamed one SSE chunk per token writes a small segment, then waits for the peer's ACK before Nagle will release the next one; the peer, having nothing to send, holds that ACK under delayed-ACK. The wait is floored at Linux's `TCP_DELACK_MIN`, defined as `HZ/25` jiffies -- 1/25 s at any `CONFIG_HZ` -- so a streamed response pays a fixed ~40 ms on the client-facing socket.

Dynamo already sets `TCP_NODELAY` on every socket of its internal transport (`lib/runtime/src/pipeline/network/tcp/server.rs`, `.../tcp/client.rs`, `.../egress/tcp_client.rs`) and on none of its external ones. This closes that gap for the listener the client talks to.

Measured on Vera (aarch64, 88 physical cores) against a mock backend, with the frontend, backend and load generator on disjoint core bands, six counterbalanced blocks. Paired at equal offered load between the two blocks that opened at the same dose, 32 output tokens per request:

  in flight    before        after         effect
  128          2,785.8 req/s 13,249.9      4.76x, p50 45 ms -> 9 ms
  256          5,592.3       15,538.4      2.78x, p50 45 ms -> 12 ms
  1,024        11,667.0      17,099.1      1.47x, p50 47 ms -> 12 ms

The untreated p50 is 45-47 ms at every offered load, which is the signature: a fixed per-response wait, not a load-dependent one. Below the knee the untreated rate is just the dose divided by it -- 128/0.045 = 2,844 against 2,785.8 measured, 256/0.045 = 5,689 against 5,592.3 -- so the frontend is doing nothing but waiting on the timer. The gain shrinks with offered load because the closed-loop ceiling rises past the machine's own limit, not because the fix weakens.

The ~40 ms term is a kernel constant and is not aarch64-specific: Turin 128c and Granite Rapids both read 40-50 ms untreated at the same output length, with the same dose-over-latency identity holding to within 8%.

Two arms were built from one binary to check the mechanism rather than the patch's own plumbing: this `tap_io` change, and an `accept4` LD_PRELOAD interposer that sets the same option from outside the process. They agree at every dose -- 13,250/13,359, 15,538/15,469, 17,099/17,245, 17,559/17,299, i.e. 0.99x, 1.00x, 0.99x, 1.02x -- so the effect is the socket option and not anything else the change touches.

Scope is deliberate. Only the client-facing plaintext HTTP listener is tapped. The RL worker discovery listener is left alone: it carries discovery traffic, not token streams. The TLS path is left alone because `axum_server::bind_rustls` owns its own accept loop and does not expose axum's `ListenerExt::tap_io` hook; it would need its own mechanism.
