### PR TITLE
fix(discovery): report workers excluded from the routable set

### DIFF
--- a/lib/llm/src/discovery/runtime_configs.rs
+++ b/lib/llm/src/discovery/runtime_configs.rs
@@ -257,16 +257,6 @@ mod tests {
         }
     }
 
-    /// Regression test for the "WorkerSet churn" leak this fix closes:
-    /// `base_runtime_config_watch`'s task must exit when its `lifecycle` token
-    /// cancels, even on a quiescent stream that never emits an event again.
-    ///
-    /// Before this fix the task's only exit paths were the stream ending or a
-    /// failed `tx.send` — and `tx.send` runs only when a discovery event
-    /// changes `configs`, so on a quiescent endpoint (the state a retired
-    /// WorkerSet's discovery stream is normally left in) neither path ever
-    /// fires. The task then outlived every dropped reference to its receiver
-    /// and leaked until process shutdown.
     /// A worker registered on the endpoint but with no base model runtime config is
     /// silently absent from the routable set, and the request that later fails carries no
     /// hint of which of the two discovery sources was missing it. It must be reported.
@@ -345,6 +335,16 @@ mod tests {
         assert!(excluded.is_empty());
     }
 
+    /// Regression test for the "WorkerSet churn" leak this fix closes:
+    /// `base_runtime_config_watch`'s task must exit when its `lifecycle` token
+    /// cancels, even on a quiescent stream that never emits an event again.
+    ///
+    /// Before this fix the task's only exit paths were the stream ending or a
+    /// failed `tx.send` — and `tx.send` runs only when a discovery event
+    /// changes `configs`, so on a quiescent endpoint (the state a retired
+    /// WorkerSet's discovery stream is normally left in) neither path ever
+    /// fires. The task then outlived every dropped reference to its receiver
+    /// and leaked until process shutdown.
     #[tokio::test]
     async fn base_runtime_config_watch_exits_on_lifecycle_cancellation_with_no_stream_activity() {
         // `_tx` stays alive for the whole test, so the stream never ends on its

--- a/lib/llm/src/discovery/runtime_configs.rs
+++ b/lib/llm/src/discovery/runtime_configs.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use futures::StreamExt;
 use tokio::sync::watch;
@@ -60,6 +60,15 @@ fn base_runtime_config_watch(
                         }
                     };
                     if id.model_suffix.is_some() || card.lora.is_some() {
+                        tracing::debug!(
+                            instance_id = id.instance_id,
+                            reason = if id.model_suffix.is_some() {
+                                "model_suffix"
+                            } else {
+                                "lora"
+                            },
+                            "Skipping non-base model card; it defines no base runtime config"
+                        );
                         continue;
                     }
                     if let Err(error) = card.runtime_config.data_parallel_rank_range() {
@@ -111,6 +120,32 @@ fn base_runtime_config_watch(
     rx
 }
 
+/// The single predicate deciding which workers a router may route to.
+///
+/// Returns the admitted workers — present in both the endpoint's availability set and the
+/// base model runtime configs — and, separately, the instance ids that were available but
+/// carried no base runtime config. The excluded half exists because a worker dropped here
+/// leaves no trace of its own: the failure surfaces later, in another crate, as
+/// `KvSchedulerError::NoEndpoints`, with nothing naming which side of this join was empty.
+fn join_available_instances_with_configs(
+    instances: &HashSet<WorkerId>,
+    configs: &HashMap<WorkerId, ModelRuntimeConfig>,
+) -> (HashMap<WorkerId, ModelRuntimeConfig>, BTreeSet<WorkerId>) {
+    let mut admitted = HashMap::new();
+    let mut excluded = BTreeSet::new();
+    for id in instances {
+        match configs.get(id) {
+            Some(config) => {
+                admitted.insert(*id, config.clone());
+            }
+            None => {
+                excluded.insert(*id);
+            }
+        }
+    }
+    (admitted, excluded)
+}
+
 /// Join instance availability and config discovery into a single watch.
 ///
 /// Only includes workers that have BOTH an instance registration AND a runtime config.
@@ -154,6 +189,9 @@ pub async fn runtime_config_watch(
     let (tx, rx) = watch::channel(HashMap::new());
 
     tokio::spawn(async move {
+        // Remembered across ticks so the warning below fires on a transition into a new
+        // exclusion set, not on every recomputation of an unchanged one.
+        let mut reported_exclusions = BTreeSet::new();
         loop {
             tokio::select! {
                 _ = cancel_token.cancelled() => break,
@@ -170,10 +208,18 @@ pub async fn runtime_config_watch(
                 .collect();
             let configs = configs_rx.borrow_and_update().clone();
 
-            let ready: HashMap<WorkerId, ModelRuntimeConfig> = instances
-                .into_iter()
-                .filter_map(|id| configs.get(&id).map(|cfg| (id, cfg.clone())))
-                .collect();
+            let (ready, excluded) = join_available_instances_with_configs(&instances, &configs);
+
+            if excluded != reported_exclusions {
+                if !excluded.is_empty() {
+                    tracing::warn!(
+                        endpoint = %eid,
+                        excluded_instance_ids = ?excluded,
+                        "Discovered instances have no base model runtime config and cannot be routed"
+                    );
+                }
+                reported_exclusions = excluded;
+            }
 
             // Only send if the joined result actually changed, to avoid waking
             // downstream consumers (wait_for, changed) on no-op recomputations.
@@ -221,6 +267,84 @@ mod tests {
     /// WorkerSet's discovery stream is normally left in) neither path ever
     /// fires. The task then outlived every dropped reference to its receiver
     /// and leaked until process shutdown.
+    /// A worker registered on the endpoint but with no base model runtime config is
+    /// silently absent from the routable set, and the request that later fails carries no
+    /// hint of which of the two discovery sources was missing it. It must be reported.
+    #[test]
+    fn available_instances_without_a_runtime_config_are_reported_as_excluded() {
+        let instances = HashSet::from([7, 8]);
+        let configs = HashMap::from([(7, ModelRuntimeConfig::default())]);
+
+        let (admitted, excluded) = join_available_instances_with_configs(&instances, &configs);
+
+        assert_eq!(admitted.keys().copied().collect::<HashSet<_>>(), [7].into());
+        assert_eq!(excluded, BTreeSet::from([8]));
+    }
+
+    /// The reported deployment's worker shape: no `--kv_events_config`, so the card
+    /// advertises `kv_event_publishing_enabled: Some(false)` and no `router_config`.
+    /// KV-event capability must never gate admission — such a worker is routable and
+    /// simply scores zero KV overlap.
+    #[test]
+    fn a_worker_that_publishes_no_kv_events_is_still_admitted() {
+        let mut card = ModelDeploymentCard::default();
+        card.runtime_config.kv_event_publishing_enabled = Some(false);
+        assert!(card.router_config.is_none(), "bare worker advertises none");
+        let instances = HashSet::from([0x1a0dcb6265db46]);
+        let configs = HashMap::from([(0x1a0dcb6265db46, card.runtime_config)]);
+
+        let (admitted, excluded) = join_available_instances_with_configs(&instances, &configs);
+
+        assert_eq!(
+            admitted
+                .get(&0x1a0dcb6265db46)
+                .unwrap()
+                .kv_event_publishing_enabled,
+            Some(false)
+        );
+        assert!(excluded.is_empty());
+    }
+
+    /// The join must hand the scheduler the worker's advertised capacity untouched;
+    /// flattening it to defaults would silently corrupt KV-aware scoring.
+    #[test]
+    fn admitted_configs_keep_their_kv_aware_scoring_inputs() {
+        let config = ModelRuntimeConfig {
+            kv_event_publishing_enabled: Some(true),
+            total_kv_blocks: Some(8192),
+            data_parallel_start_rank: 2,
+            data_parallel_size: 4,
+            ..Default::default()
+        };
+        let instances = HashSet::from([11]);
+        let configs = HashMap::from([(11, config)]);
+
+        let (admitted, excluded) = join_available_instances_with_configs(&instances, &configs);
+
+        let admitted = admitted.get(&11).unwrap();
+        assert_eq!(admitted.kv_event_publishing_enabled, Some(true));
+        assert_eq!(admitted.total_kv_blocks, Some(8192));
+        assert_eq!(admitted.data_parallel_start_rank, 2);
+        assert_eq!(admitted.data_parallel_size, 4);
+        assert!(excluded.is_empty());
+    }
+
+    /// The instance side drives the join: a leftover card for a worker that is no longer
+    /// available is neither routable nor an exclusion worth reporting.
+    #[test]
+    fn a_config_without_an_available_instance_is_neither_admitted_nor_reported() {
+        let instances = HashSet::from([7]);
+        let configs = HashMap::from([
+            (7, ModelRuntimeConfig::default()),
+            (12, ModelRuntimeConfig::default()),
+        ]);
+
+        let (admitted, excluded) = join_available_instances_with_configs(&instances, &configs);
+
+        assert_eq!(admitted.keys().copied().collect::<HashSet<_>>(), [7].into());
+        assert!(excluded.is_empty());
+    }
+
     #[tokio::test]
     async fn base_runtime_config_watch_exits_on_lifecycle_cancellation_with_no_stream_activity() {
         // `_tx` stays alive for the whole test, so the stream never ends on its


### PR DESCRIPTION
Source issue: [DYN-4236](https://linear.app/nvidia/issue/DYN-4236).

## Overview:

A vLLM worker started without `--kv_events_config` is registered by discovery, yet every request routed to its pool fails with `no endpoints available to route work`. The reported cause — that KV-event capability had become an admission requirement — does not hold for this worker shape: `KvSourceMembership` is handed only to the indexer's subscriber and never reaches the scheduler, and `kv_event_source_mode` is read after a worker is selected, to pick a transfer-hint source. Such a worker is admitted and simply scores zero KV overlap.

The real gap is that discovery says nothing when it drops a worker. **This does not restore routing for the reported deployment.** It makes the exclusion visible, so one re-run of that scenario names the branch to investigate.

## Details:

`lib/llm/src/discovery/runtime_configs.rs` holds the discovery-time admission predicate: a worker reaches the router's candidate set only if it appears in both the endpoint availability watch and the base model-card watch. The old `filter_map` kept the survivors and discarded any record of the rest.

This extracts that join into `join_available_instances_with_configs`, which also returns the instance ids that were available but carried no base runtime config, and logs one `WARN` naming the endpoint and those ids. The warning fires only when the excluded set changes, because `lib/kv-router/src/scheduling/queue.rs` borrows this watch on every selection. The previously silent `model_suffix` / `lora` guard now emits a `debug!` naming the instance and which reason applied.

Which workers are admitted does not change.

Reading the new warning: its presence means the instance was available and its base card was missing or dropped. Its absence rules out that branch only — hard availability, taints, and a mismatched router `--endpoint` all produce this failure with no warning — so please report the warning's presence or absence together with the router's resolved `--endpoint`.

## Where should the reviewer start?

`join_available_instances_with_configs` and its call site in `runtime_config_watch`, then the four new tests in the same file.

## Validation

- `cargo fmt --all --check`, `cargo check --workspace --all-targets`, `cargo check --manifest-path lib/bindings/python/Cargo.toml --all-targets`, and `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — all exit `0`.
- `cargo test -p dynamo-llm --lib discovery::runtime_configs` — `8 passed; 0 failed`. Against the pre-change join semantics the new exclusion test fails on its assertion (`left: {}`, `right: {8}`).
- `cargo test -p dynamo-kv-router --lib scheduling` — `189 passed; 0 failed`, so the scheduler's candidate-set and eligibility tests are unaffected.
- `pytest -m "gpu_0 and integration and router" tests/router/test_router_e2e_with_mockers.py::test_mocker_kv_event_publisher_disabled_diagnostic` — the `[aggregated]` case passes: a real router and mocker workers with KV event publishing disabled return HTTP 200. The `[disaggregated]` case times out after 120 s, and fails identically at the branch point `ea39f8063` without this change.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime configuration now correctly excludes unavailable workers.
  - Configurations with disabled key-value event admission are handled consistently.
  - Key-value-aware configuration fields are preserved when configurations are combined.
  - Configurations for workers that are no longer available are ignored.

- **Diagnostics**
  - Added clearer warnings when workers are excluded or non-base model configurations are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->