### PR TITLE
ci: add GB300 runner validation lanes to the PR workflow

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: 'Path to the HF home directory on the runner. When set, the HF_HOME environment variable is set to this path.'
     required: false
     default: '/models'
+  models_dir:
+    description: 'Pre-populated model-cache directory passed to pytest as --models-dir. Empty keeps the existing online pre-download behavior.'
+    required: false
+    default: ''
   gpu_tests:
     description: 'Is this a GPU test job?'
     required: false
@@ -90,6 +94,7 @@ runs:
         MAX_VRAM_GIB: ${{ inputs.max_vram_gib }}
         NVME_DIR: ${{ inputs.nvme_dir }}
         REQUESTED_HF_HOME: ${{ inputs.hf_home }}
+        MODELS_DIR: ${{ inputs.models_dir }}
         GPU_TESTS: ${{ inputs.gpu_tests }}
         RUN_ID: ${{ github.run_id }}
         # Required by the ddtrace GitHub provider to link test sessions to the job.
@@ -193,6 +198,12 @@ runs:
         fi
         echo "HF_HOME=${HF_HOME}" >> $GITHUB_ENV
 
+        MODELS_DIR_OPT=""
+        if [[ -n "${MODELS_DIR}" ]]; then
+          MODELS_DIR_OPT="--models-dir=${MODELS_DIR}"
+          echo "📚 Using pre-populated model cache: ${MODELS_DIR}"
+        fi
+
         # HOME must stay at GITHUB_WORKSPACE: ARC, upload-artifact, and checkout require it.
         # The ARC runner uid (1001) may have no /etc/passwd entry, causing the shell
         # to set HOME=/ by default. Pin HOME to GITHUB_WORKSPACE so downstream code
@@ -213,7 +224,7 @@ runs:
         # Determine pytest command based on dry_run mode
         if [[ "${DRY_RUN}" == "true" ]]; then
           echo "🔍 Running pytest in dry-run mode (collect-only, no GPU required)"
-          PYTEST_CMD="python -m pytest -v --collect-only -m \"${PYTEST_MARKS}\""
+          PYTEST_CMD="python -m pytest ${MODELS_DIR_OPT} -v --collect-only -m \"${PYTEST_MARKS}\""
         else
           echo "🚀 Running pytest in normal mode"
           # Determine parallelization based on parallel_mode input
@@ -259,7 +270,7 @@ runs:
             export PYTHONPATH="${CONTAINER_WORKSPACE}/components/src:${CONTAINER_WORKSPACE}/lib/bindings/python/src${PYTHONPATH:+:${PYTHONPATH}}"
           fi
 
-          PYTEST_CMD="python -m pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=${WORK_DIR}/pytest_temp -o cache_dir=${WORK_DIR}/.pytest_cache --junitxml=${TEST_RESULTS_DIR}/${PYTEST_XML_FILE} --alluredir=${TEST_RESULTS_DIR}/allure-results --durations=10 ${COVERAGE_FLAGS} -m \"${PYTEST_MARKS}\""
+          PYTEST_CMD="python -m pytest ${MODELS_DIR_OPT} ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=${WORK_DIR}/pytest_temp -o cache_dir=${WORK_DIR}/.pytest_cache --junitxml=${TEST_RESULTS_DIR}/${PYTEST_XML_FILE} --alluredir=${TEST_RESULTS_DIR}/allure-results --durations=10 ${COVERAGE_FLAGS} -m \"${PYTEST_MARKS}\""
         fi
 
         echo "▶️ Executing (cwd=${CONTAINER_WORKSPACE}): ${PYTEST_CMD}"

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -198,10 +198,18 @@ runs:
         fi
         echo "HF_HOME=${HF_HOME}" >> $GITHUB_ENV
 
+        # --models-dir puts the session fully offline (HF_HUB_OFFLINE=1) and skips the
+        # predownload fixtures, so only pass it when the mount actually holds an HF
+        # cache. The HF_HOME probe above can create ${MODELS_DIR} empty, which would
+        # satisfy pytest's is_dir() check and then fail every model load offline.
         MODELS_DIR_OPT=""
         if [[ -n "${MODELS_DIR}" ]]; then
-          MODELS_DIR_OPT="--models-dir=${MODELS_DIR}"
-          echo "📚 Using pre-populated model cache: ${MODELS_DIR}"
+          if [[ -d "${MODELS_DIR}/hub" ]] || compgen -G "${MODELS_DIR}/models--*" > /dev/null; then
+            MODELS_DIR_OPT="--models-dir=${MODELS_DIR}"
+            echo "📚 Using pre-populated model cache: ${MODELS_DIR}"
+          else
+            echo "⚠️  Model cache '${MODELS_DIR}' holds no HF cache entries; falling back to online pre-download"
+          fi
         fi
 
         # HOME must stay at GITHUB_WORKSPACE: ARC, upload-artifact, and checkout require it.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -832,7 +832,7 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: vllm
@@ -901,7 +901,7 @@ jobs:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files, sglang-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: sglang
@@ -970,7 +970,7 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
+    uses: $/.github/workflows/shared-test.yml
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: trtllm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -842,6 +842,7 @@ jobs:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["arm64"]'
+      models_dir: /models
       enable_coverage: true
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'
@@ -910,6 +911,7 @@ jobs:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["arm64"]'
+      models_dir: /models
       enable_coverage: true
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'
@@ -978,6 +980,7 @@ jobs:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["arm64"]'
+      models_dir: /models
       enable_coverage: true
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -140,19 +140,19 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
-      - vllm-gb200-test
+      - vllm-gb300-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
       - sglang-test
       - sglang-multi-gpu-test
-      - sglang-gb200-test
+      - sglang-gb300-test
       - sglang-copy-to-acr
       - trtllm-build
       - trtllm-dev-build
       - trtllm-test
       - trtllm-multi-gpu-test
-      - trtllm-gb200-test
+      - trtllm-gb300-test
       - trtllm-copy-to-acr
       - vllm-efa-build
       - sglang-efa-build
@@ -827,8 +827,8 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
-  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
-  vllm-gb200-test:
+  # TODO: remove after GB300 validation and move this lane to nightly-ci.yml.
+  vllm-gb300-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
@@ -836,9 +836,9 @@ jobs:
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: vllm
-      test_type: GB200 Test
-      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
-      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      test_type: GB300 Test
+      # GB300 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-gb300-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["arm64"]'
@@ -849,8 +849,8 @@ jobs:
       gpu_test_markers: vllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
-      # Admit large-memory profiles while retaining headroom below GB200 capacity.
-      gpu_parallel_max_vram_gib: '180'
+      # Admit large-memory profiles while retaining headroom below GB300 capacity.
+      gpu_parallel_max_vram_gib: '280'
     secrets: inherit
 
   sglang-test:
@@ -896,8 +896,8 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
-  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
-  sglang-gb200-test:
+  # TODO: remove after GB300 validation and move this lane to nightly-ci.yml.
+  sglang-gb300-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files, sglang-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
@@ -905,9 +905,9 @@ jobs:
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: sglang
-      test_type: GB200 Test
-      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
-      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      test_type: GB300 Test
+      # GB300 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-gb300-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["arm64"]'
@@ -918,8 +918,8 @@ jobs:
       gpu_test_markers: sglang and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
-      # Admit large-memory profiles while retaining headroom below GB200 capacity.
-      gpu_parallel_max_vram_gib: '180'
+      # Admit large-memory profiles while retaining headroom below GB300 capacity.
+      gpu_parallel_max_vram_gib: '280'
     secrets: inherit
 
   trtllm-test:
@@ -965,8 +965,8 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
-  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
-  trtllm-gb200-test:
+  # TODO: remove after GB300 validation and move this lane to nightly-ci.yml.
+  trtllm-gb300-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
@@ -974,9 +974,9 @@ jobs:
     with:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: trtllm
-      test_type: GB200 Test
-      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
-      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      test_type: GB300 Test
+      # GB300 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-gb300-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.1"]'
       platform: '["arm64"]'
@@ -987,8 +987,8 @@ jobs:
       gpu_test_markers: trtllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
-      # Admit large-memory profiles while retaining headroom below GB200 capacity.
-      gpu_parallel_max_vram_gib: '180'
+      # Admit large-memory profiles while retaining headroom below GB300 capacity.
+      gpu_parallel_max_vram_gib: '280'
     secrets: inherit
 
   planner-test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -844,7 +844,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      gpu_platforms: '["arm64"]'
+      gpu_test_platforms: '["arm64"]'
       gpu_test_markers: vllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
@@ -912,7 +912,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      gpu_platforms: '["arm64"]'
+      gpu_test_platforms: '["arm64"]'
       gpu_test_markers: sglang and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
@@ -980,7 +980,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      gpu_platforms: '["arm64"]'
+      gpu_test_platforms: '["arm64"]'
       gpu_test_markers: trtllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -844,7 +844,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      run_arm_gpu_tests: true
+      gpu_platforms: '["arm64"]'
       gpu_test_markers: vllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
@@ -912,7 +912,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      run_arm_gpu_tests: true
+      gpu_platforms: '["arm64"]'
       gpu_test_markers: sglang and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true
@@ -980,7 +980,7 @@ jobs:
       platform: '["arm64"]'
       enable_coverage: true
       run_sanity_check: false
-      run_arm_gpu_tests: true
+      gpu_platforms: '["arm64"]'
       gpu_test_markers: trtllm and (gpu_1 or gpu_2)
       gpu_test_timeout_minutes: 240
       run_gpu_parallel_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -847,7 +847,9 @@ jobs:
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'
       gpu_test_markers: vllm and (gpu_1 or gpu_2)
-      gpu_test_timeout_minutes: 240
+      # Both GPU stages get this budget, so keep 2x it under GitHub's
+      # 360-minute default job timeout; overrunning cancels the job with no results.
+      gpu_test_timeout_minutes: 120
       run_gpu_parallel_tests: true
       # Admit large-memory profiles while retaining headroom below GB300 capacity.
       gpu_parallel_max_vram_gib: '280'
@@ -916,7 +918,9 @@ jobs:
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'
       gpu_test_markers: sglang and (gpu_1 or gpu_2)
-      gpu_test_timeout_minutes: 240
+      # Both GPU stages get this budget, so keep 2x it under GitHub's
+      # 360-minute default job timeout; overrunning cancels the job with no results.
+      gpu_test_timeout_minutes: 120
       run_gpu_parallel_tests: true
       # Admit large-memory profiles while retaining headroom below GB300 capacity.
       gpu_parallel_max_vram_gib: '280'
@@ -985,7 +989,9 @@ jobs:
       run_sanity_check: false
       gpu_test_platforms: '["arm64"]'
       gpu_test_markers: trtllm and (gpu_1 or gpu_2)
-      gpu_test_timeout_minutes: 240
+      # Both GPU stages get this budget, so keep 2x it under GitHub's
+      # 360-minute default job timeout; overrunning cancels the job with no results.
+      gpu_test_timeout_minutes: 120
       run_gpu_parallel_tests: true
       # Admit large-memory profiles while retaining headroom below GB300 capacity.
       gpu_parallel_max_vram_gib: '280'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -837,7 +837,6 @@ jobs:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: vllm
       test_type: GB200 Test
-      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
       # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
       arm_runner: aws-dev-01-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
@@ -906,7 +905,6 @@ jobs:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: sglang
       test_type: GB200 Test
-      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
       # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
       arm_runner: aws-dev-01-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
@@ -975,7 +973,6 @@ jobs:
       dd_flaky_retry_enabled: 'false'
       test_suite_name: trtllm
       test_type: GB200 Test
-      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
       # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
       arm_runner: aws-dev-01-tester-arm-gpu-v2
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -140,16 +140,19 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-gb200-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
       - sglang-test
       - sglang-multi-gpu-test
+      - sglang-gb200-test
       - sglang-copy-to-acr
       - trtllm-build
       - trtllm-dev-build
       - trtllm-test
       - trtllm-multi-gpu-test
+      - trtllm-gb200-test
       - trtllm-copy-to-acr
       - vllm-efa-build
       - sglang-efa-build
@@ -824,6 +827,32 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
+  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
+  vllm-gb200-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm
+      test_type: GB200 Test
+      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
+      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["arm64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      run_arm_gpu_tests: true
+      gpu_test_markers: vllm and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
+      run_gpu_parallel_tests: true
+      # Admit large-memory profiles while retaining headroom below GB200 capacity.
+      gpu_parallel_max_vram_gib: '180'
+    secrets: inherit
+
   sglang-test:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files, sglang-build]
@@ -867,6 +896,32 @@ jobs:
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
+  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
+  sglang-gb200-test:
+    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+    needs: [changed-files, sglang-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: sglang
+      test_type: GB200 Test
+      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
+      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["arm64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      run_arm_gpu_tests: true
+      gpu_test_markers: sglang and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
+      run_gpu_parallel_tests: true
+      # Admit large-memory profiles while retaining headroom below GB200 capacity.
+      gpu_parallel_max_vram_gib: '180'
+    secrets: inherit
+
   trtllm-test:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files, trtllm-build]
@@ -908,6 +963,32 @@ jobs:
       run_sanity_check: false
       gpu_test_markers: pre_merge and trtllm and gpu_2
       gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  # TODO: remove after GB200 validation and move this lane to nightly-ci.yml (DYN-4049).
+  trtllm-gb200-test:
+    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+    needs: [changed-files, trtllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: trtllm
+      test_type: GB200 Test
+      amd_runner: prod-tester-amd-gpu-v2 # Unused for this arm64-only matrix
+      # 2x GB200 ARM64 lane; validates the nightly single- and dual-GPU test pool.
+      arm_runner: aws-dev-01-tester-arm-gpu-v2
+      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.1"]'
+      platform: '["arm64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      run_arm_gpu_tests: true
+      gpu_test_markers: trtllm and (gpu_1 or gpu_2)
+      gpu_test_timeout_minutes: 240
+      run_gpu_parallel_tests: true
+      # Admit large-memory profiles while retaining headroom below GB200 capacity.
+      gpu_parallel_max_vram_gib: '180'
     secrets: inherit
 
   planner-test:

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -16,8 +16,9 @@ on:
         type: string
       amd_runner:
         description: 'Runner to execute tests on (amd64 only)'
-        required: true
+        required: false
         type: string
+        default: 'prod-tester-amd-gpu-v2'
       arm_runner:
         description: 'Runner to execute tests on (arm64 only)'
         required: false

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: '/workspace'
+      models_dir:
+        description: 'Pre-populated model-cache directory passed to pytest as --models-dir'
+        required: false
+        type: string
+        default: ''
       kvbm_mla_backend:
         description: 'KVBM MLA attention backend exported for KVBM tests'
         required: false
@@ -243,6 +248,7 @@ jobs:
           test_type: "pre_merge_cpu"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
+          models_dir: ${{ inputs.models_dir }}
           parallel_mode: ${{ inputs.cpu_parallel_mode }}
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'false'
@@ -274,6 +280,7 @@ jobs:
           test_type: "pre_merge_gpu_parallel"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
+          models_dir: ${{ inputs.models_dir }}
           # parallel_mode=auto + max_vram_gib hands off to the VRAM-aware
           # orchestrator (tests/utils/pytest_parallel_gpu.py via tests/conftest.py)
           parallel_mode: 'auto'
@@ -296,6 +303,7 @@ jobs:
           test_type: "pre_merge_gpu"
           platform_arch: ${{ matrix.platform }}
           hf_token: ${{ secrets.HF_TOKEN }}
+          models_dir: ${{ inputs.models_dir }}
           parallel_mode: 'none'
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'true'

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -94,11 +94,11 @@ on:
         required: false
         type: boolean
         default: true
-      run_arm_gpu_tests:
-        description: 'Whether to run GPU tests for arm64 matrix entries'
+      gpu_platforms:
+        description: 'Platforms whose matrix entries should run GPU tests, as a JSON array'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: '["amd64"]'
       gpu_test_markers:
         description: 'GPU pytest markers. Selects the full GPU pool. When run_gpu_parallel_tests=true, profiled tests run in the parallel stage and are excluded from the sequential stage by appending "and not profiled_vram_gib".'
         required: false
@@ -265,7 +265,7 @@ jobs:
           dd_flaky_retry_enabled: 'false'
       - name: Run GPU tests (parallel)
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
-        if: ${{ inputs.run_gpu_tests && inputs.run_gpu_parallel_tests && (matrix.platform == 'amd64' || (matrix.platform == 'arm64' && inputs.run_arm_gpu_tests)) }}
+        if: ${{ inputs.run_gpu_tests && inputs.run_gpu_parallel_tests && contains(fromJSON(inputs.gpu_platforms), matrix.platform) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
@@ -286,7 +286,7 @@ jobs:
         # but require checkout to have succeeded so an infra/prereq failure (e.g. the
         # container/pod never coming online) skips this step cleanly instead of trying
         # to run the local pytest-local action against an un-checked-out workspace.
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_gpu_tests && (matrix.platform == 'amd64' || (matrix.platform == 'arm64' && inputs.run_arm_gpu_tests)) }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_gpu_tests && contains(fromJSON(inputs.gpu_platforms), matrix.platform) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -18,6 +18,11 @@ on:
         description: 'Runner to execute tests on (amd64 only)'
         required: true
         type: string
+      arm_runner:
+        description: 'Runner to execute tests on (arm64 only)'
+        required: false
+        type: string
+        default: 'prod-tester-arm-v2'
       target_tag_plain:
         description: 'Plain runtime image tag prefix from the build workflow'
         required: true
@@ -88,6 +93,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_arm_gpu_tests:
+        description: 'Whether to run GPU tests for arm64 matrix entries'
+        required: false
+        type: boolean
+        default: false
       gpu_test_markers:
         description: 'GPU pytest markers. Selects the full GPU pool. When run_gpu_parallel_tests=true, profiled tests run in the parallel stage and are excluded from the sequential stage by appending "and not profiled_vram_gib".'
         required: false
@@ -151,7 +161,7 @@ jobs:
         platform: ${{ fromJson(inputs.platform) }}
         cuda_version: ${{ fromJson(inputs.cuda_version) }}
     name: ${{ inputs.test_type }} ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}, ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform == 'amd64' && inputs.amd_runner || 'prod-tester-arm-v2' }}
+    runs-on: ${{ matrix.platform == 'amd64' && inputs.amd_runner || inputs.arm_runner }}
     container:
       image: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ inputs.target_tag_plain }}${{ (matrix.cuda_version != '' && !startsWith(matrix.cuda_version, '13.')) && format('-cuda{0}', startsWith(matrix.cuda_version, '12.') && '12' || matrix.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
@@ -254,7 +264,7 @@ jobs:
           dd_flaky_retry_enabled: 'false'
       - name: Run GPU tests (parallel)
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
-        if: ${{ matrix.platform == 'amd64' && inputs.run_gpu_tests && inputs.run_gpu_parallel_tests }}
+        if: ${{ inputs.run_gpu_tests && inputs.run_gpu_parallel_tests && (matrix.platform == 'amd64' || (matrix.platform == 'arm64' && inputs.run_arm_gpu_tests)) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
@@ -275,7 +285,7 @@ jobs:
         # but require checkout to have succeeded so an infra/prereq failure (e.g. the
         # container/pod never coming online) skips this step cleanly instead of trying
         # to run the local pytest-local action against an un-checked-out workspace.
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && matrix.platform == 'amd64' && inputs.run_gpu_tests }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_gpu_tests && (matrix.platform == 'amd64' || (matrix.platform == 'arm64' && inputs.run_arm_gpu_tests)) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -94,7 +94,7 @@ on:
         required: false
         type: boolean
         default: true
-      gpu_platforms:
+      gpu_test_platforms:
         description: 'Platforms whose matrix entries should run GPU tests, as a JSON array'
         required: false
         type: string
@@ -265,7 +265,7 @@ jobs:
           dd_flaky_retry_enabled: 'false'
       - name: Run GPU tests (parallel)
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
-        if: ${{ inputs.run_gpu_tests && inputs.run_gpu_parallel_tests && contains(fromJSON(inputs.gpu_platforms), matrix.platform) }}
+        if: ${{ inputs.run_gpu_tests && inputs.run_gpu_parallel_tests && contains(fromJSON(inputs.gpu_test_platforms), matrix.platform) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}
@@ -286,7 +286,7 @@ jobs:
         # but require checkout to have succeeded so an infra/prereq failure (e.g. the
         # container/pod never coming online) skips this step cleanly instead of trying
         # to run the local pytest-local action against an un-checked-out workspace.
-        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_gpu_tests && contains(fromJSON(inputs.gpu_platforms), matrix.platform) }}
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_gpu_tests && contains(fromJSON(inputs.gpu_test_platforms), matrix.platform) }}
         uses: $/.github/actions/pytest-local
         with:
           container_workspace: ${{ inputs.container_workspace }}


### PR DESCRIPTION
## Overview:

Adds three temporary pre-merge lanes (`vllm-gb300-test`, `sglang-gb300-test`, `trtllm-gb300-test`) that exercise the `aws-gb300-tester-arm-gpu-v2` ARM64 runner pool against real test workloads, so the pool can be validated before these lanes move to `nightly-ci.yml`. Each lane carries a TODO marking it for that move.

## Details:

Supporting changes in `.github/workflows/shared-test.yml`:

- `arm_runner` is now an input (default `prod-tester-arm-v2`) rather than a hardcoded literal in `runs-on`, so a lane can target a different ARM pool.
- GPU-test gating moves from a hardcoded `matrix.platform == 'amd64'` to `contains(fromJSON(inputs.gpu_test_platforms), matrix.platform)`, defaulting to `'["amd64"]'`. This stays separate from `platform` on purpose: several existing lanes deliberately include `arm64` in `platform` for CPU coverage while running that entry on a GPU-less ARM runner, so GPU gating cannot be derived from `platform`.
- `amd_runner` becomes optional with a default, since the new arm64-only lanes never read it.
- A `models_dir` input is threaded through to the `pytest-local` action as `--models-dir`, letting a lane use a pre-populated model cache instead of downloading models online.

In `.github/actions/pytest-local/action.yml`, `--models-dir` is passed only when the mount actually holds a HuggingFace cache layout — either a `hub/` subdirectory or a `models--*` entry, the two shapes `tests/hf_cache.py` knows how to consume. The `HF_HOME` probe immediately above can create the directory empty, which would satisfy pytest's `is_dir()` check and then fail every model load under `HF_HUB_OFFLINE=1`. The guard falls back to online pre-download with a warning instead.

The GB300 lanes use 120 minutes per GPU stage. Both the parallel and sequential stages each receive `gpu_test_timeout_minutes`, so twice that value must stay under GitHub's 360-minute default job timeout; overrunning it cancels the job mid-stage and reports no results at all.

## Where should the reviewer start?

- `.github/workflows/shared-test.yml` — the two changed `if:` conditions and the `runs-on` expression. Worth confirming the `'["amd64"]'` and `prod-tester-arm-v2` defaults leave every existing caller on its current behavior.
- `.github/workflows/pr.yaml` — the three new lanes, and specifically that they are added to the `backend-status-check` aggregate `needs:` list.

## Validation

- `pre-commit run --files` passes on all three changed files.
- Audited every caller of `shared-test.yml` across `pr.yaml`, `post-merge-ci.yml`, `nightly-ci.yml`, and `dynamo-pipeline.yml`: no existing caller sets the new inputs, so the defaults reproduce today's behavior exactly.
- Exercised the `--models-dir` guard under bash against five cases — `HF_HOME` layout (`hub/`), bare cache (`models--*`), empty directory, junk directory, and missing directory. Only the two real layouts enable the flag; the rest fall back to online pre-download.
- The GB300 lanes themselves are unproven by definition — validating that runner pool is the purpose of this PR.

## Known follow-ups (deliberately not in this PR)

- The lanes select the full `(gpu_1 or gpu_2)` pool without a `pre_merge` filter and are wired into the aggregate `backend-status-check`, making them merge-blocking. Both are accepted while the lanes stay in PR stage and will be resolved when they move to nightly.
- `gpu_parallel_max_vram_gib: '280'` collapses the parallel stage to one test per GPU, since the orchestrator computes `int(budget / 280)` and clamps to 1, while the largest profiled test in the tree is 56 GiB.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added ARM64 GB300 test coverage for vLLM, SGLang, and TRT-LLM across single- and dual-GPU configurations.
  * Expanded shared test workflows to support AMD and ARM runners and configurable GPU test platforms.
  * Added coverage reporting and standardized execution settings for new GPU test lanes.

* **Chores**
  * Added optional support for pre-populated model caches, while preserving online model downloads when no usable cache is available.
  * Made test runner and model-directory settings configurable for different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->