### PR TITLE
fix(vllm): [cherry-pick 1.5.0] start the omni stage router on a host with no accelerator (#14359)

### DIFF
--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -7,6 +7,9 @@ import argparse
 import dataclasses
 import logging
 import os
+import re
+import sys
+from types import SimpleNamespace
 from typing import Optional
 
 import huggingface_hub
@@ -23,7 +26,11 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeArgGroup,
     DynamoRuntimeConfig,
 )
-from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    env_or_default,
+)
 from dynamo.common.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
@@ -451,6 +458,78 @@ class OmniConfig(DynamoRuntimeConfig):
             )
 
 
+def _wants_stage_router(argv: list[str]) -> bool:
+    """Detect router mode before vLLM parser construction infers a device.
+
+    Match argparse precedence through the first ``--``; an explicit stage ID
+    keeps the full engine path.
+    """
+    options = argv[: argv.index("--")] if "--" in argv else argv
+    if any(
+        token == "--stage-id" or token.startswith("--stage-id=") for token in options
+    ):
+        return False
+    for token in reversed(options):
+        if token == "--omni-router":
+            return True
+        if token == "--no-omni-router":
+            return False
+    return bool(env_or_default("DYN_OMNI_ROUTER", False))
+
+
+# Everything from the leading "--" up to the first "." -- the option name, but
+# not the key of a dotted value such as --json-arg.key_1.
+_OPTION_NAME = re.compile(r"(?<=^--)[^.]*")
+
+
+def _normalize_engine_option_names(argv: list[str]) -> list[str]:
+    """Rewrite ``--served_model_name`` to ``--served-model-name``, as vLLM does.
+
+    ``FlexibleArgumentParser`` accepts either spelling, but only through
+    ``parse_args``, which rewrites underscores to dashes in the option name
+    before parsing. ``parse_known_args`` -- which the stage router calls so that
+    a stage worker's engine flags stay non-fatal -- does not. Without this, the
+    underscore spelling would bind on the stage-worker path and be reported as
+    unrecognized on the router path, silently dropping the requested value.
+    """
+    normalized = []
+    for token in argv:
+        if not token.startswith("--"):
+            normalized.append(token)
+            continue
+        name, sep, value = token.partition("=")
+        name = _OPTION_NAME.sub(lambda match: match.group(0).replace("_", "-"), name)
+        normalized.append(f"{name}{sep}{value}" if sep else name)
+    return normalized
+
+
+def _add_stage_router_engine_args(parser: argparse.ArgumentParser) -> None:
+    """Register the only engine options the stage router itself reads.
+
+    Each one mirrors the corresponding action from
+    ``OmniEngineArgs.add_cli_args`` -- same flag, same ``nargs``, same default
+    -- so router argv that parsed before parses the same way now. Nothing here
+    instantiates a vLLM config dataclass, so device detection is never reached.
+    """
+    parser.add_argument("--model", type=str, default=OmniEngineArgs.model)
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        nargs="+",
+        default=None,
+        dest="served_model_name",
+    )
+    parser.add_argument(
+        "--trust-remote-code", action=argparse.BooleanOptionalAction, default=False
+    )
+    parser.add_argument("--revision", type=str, default=None)
+    parser.add_argument(
+        "--disable-log-stats",
+        action="store_true",
+        default=OmniEngineArgs.disable_log_stats,
+    )
+
+
 def parse_omni_args() -> OmniConfig:
     """Parse command-line arguments for the vLLM-Omni backend."""
     dynamo_runtime_argspec = DynamoRuntimeArgGroup()
@@ -468,8 +547,12 @@ def parse_omni_args() -> OmniConfig:
     vg = parser.add_argument_group(
         "vLLM-Omni Engine Options. Please refer to vLLM-Omni documentation for more details."
     )
+    stage_router = _wants_stage_router(sys.argv[1:])
     vllm_parser = FlexibleArgumentParser(add_help=False)
-    OmniEngineArgs.add_cli_args(vllm_parser)
+    if stage_router:
+        _add_stage_router_engine_args(vllm_parser)
+    else:
+        OmniEngineArgs.add_cli_args(vllm_parser)
 
     for action in vllm_parser._actions:
         if not action.option_strings:
@@ -482,7 +565,20 @@ def parse_omni_args() -> OmniConfig:
     if config.endpoint is None:
         config.endpoint = "generate"
 
-    vllm_args = vllm_parser.parse_args(unknown)
+    if stage_router:
+        if "--config" in unknown:
+            unknown = vllm_parser._pull_args_from_config(unknown)
+        vllm_args, ignored = vllm_parser.parse_known_args(
+            _normalize_engine_option_names(unknown)
+        )
+        if ignored:
+            logger.warning(
+                "Stage router ignored %d unrecognized engine argument tokens; "
+                "the router does not build an engine.",
+                len(ignored),
+            )
+    else:
+        vllm_args = vllm_parser.parse_args(unknown)
     config.model = vllm_args.model
 
     # Resolve repo id to local snapshot path under HF_HUB_OFFLINE so
@@ -510,7 +606,20 @@ def parse_omni_args() -> OmniConfig:
                 config.model,
             )
 
-    engine_args = OmniEngineArgs.from_cli_args(vllm_args)
+    if stage_router:
+        # OmniConfig.engine_args has no class-level default, so leaving it unset
+        # makes main.worker() fail before it reaches the router dispatch.
+        engine_args = SimpleNamespace(
+            # The parsed repo id, not the snapshot path config.model may have
+            # been rewritten to above; the non-router path leaves this the same.
+            model=vllm_args.model,
+            served_model_name=vllm_args.served_model_name,
+            trust_remote_code=vllm_args.trust_remote_code,
+            revision=vllm_args.revision,
+            disable_log_stats=vllm_args.disable_log_stats,
+        )
+    else:
+        engine_args = OmniEngineArgs.from_cli_args(vllm_args)
 
     if getattr(engine_args, "served_model_name", None) is not None:
         served = engine_args.served_model_name

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -1,18 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for OmniConfig validation."""
+"""Unit tests for OmniConfig validation and omni argument parsing."""
 
+import contextlib
 import dataclasses
+import logging
+import sys
 from types import SimpleNamespace
 
 import pytest
 
 try:
+    import vllm.platforms as vllm_platforms
+    from vllm.engine.arg_utils import _compute_kwargs
+    from vllm.platforms.interface import UnspecifiedPlatform
+
+    from dynamo.vllm import main as vllm_main
     from dynamo.vllm.omni.args import (
+        FlexibleArgumentParser,
         OmniConfig,
         OmniDiffusionKwargs,
+        OmniEngineArgs,
         OmniParallelKwargs,
+        parse_omni_args,
     )
 except ImportError:
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
@@ -167,6 +178,228 @@ def test_omni_router_with_stage_configs_path_valid(tmp_path):
         omni_router=True, stage_configs_path=str(tmp_path / "stages.yaml")
     )
     config.validate()
+
+
+# --- parse_omni_args() on a host with no accelerator ---
+
+_PLATFORM_UNSET = object()
+
+
+@contextlib.contextmanager
+def _no_accelerator():
+    """Pin the platform a host with no accelerator resolves to.
+
+    Every builtin plugin declines there and vLLM falls back to
+    ``UnspecifiedPlatform``, whose ``device_type`` is the empty string -- the
+    state ``DeviceConfig.__post_init__`` raises on. Restores exactly the way
+    ``vllm_cpu_platform_when_no_accelerator`` does: *delete* the module-dict
+    entry when there was none, so the PEP 562 lazy ``__getattr__`` in
+    ``vllm.platforms`` is re-armed for later tests on this worker.
+    """
+    previous = vllm_platforms.__dict__.get("current_platform", _PLATFORM_UNSET)
+    # Cached parser defaults include DeviceConfig from the previous platform.
+    _compute_kwargs.cache_clear()
+    vllm_platforms.current_platform = UnspecifiedPlatform()
+    try:
+        yield
+    finally:
+        _compute_kwargs.cache_clear()
+        if previous is _PLATFORM_UNSET:
+            del vllm_platforms.current_platform
+        else:
+            vllm_platforms.current_platform = previous
+
+
+def _router_argv(tmp_path, *extra):
+    return [
+        "dynamo.vllm.omni",
+        "--stage-configs-path",
+        str(tmp_path / "stages.yaml"),
+        "--model",
+        "test-model",
+        *extra,
+    ]
+
+
+def test_stage_router_parses_without_an_accelerator(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--omni-router"))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+    assert config.engine_args.model == "test-model"
+    assert config.engine_args.trust_remote_code is False
+
+
+def test_stage_router_selected_by_environment_parses_without_an_accelerator(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+
+
+def test_stage_router_ignores_engine_options_without_logging_values(
+    monkeypatch, tmp_path, caplog
+):
+    secret = "secret-token-value"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(
+            tmp_path,
+            "--omni-router",
+            "--hf-token",
+            secret,
+        ),
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+    assert "Stage router ignored 2 unrecognized engine argument tokens" in caplog.text
+    assert secret not in caplog.text
+
+
+def test_stage_router_honors_negated_flag_over_environment(monkeypatch, tmp_path):
+    # --no-omni-router must win over a truthy DYN_OMNI_ROUTER; losing that
+    # would route an engine-building worker onto the reduced parser.
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--no-omni-router"))
+
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
+        parse_omni_args()
+
+
+@pytest.mark.parametrize("warm_cache", [False, True])
+def test_stage_worker_still_requires_an_accelerator(monkeypatch, tmp_path, warm_cache):
+    _compute_kwargs.cache_clear()
+    if warm_cache:
+        OmniEngineArgs.add_cli_args(FlexibleArgumentParser(add_help=False))
+    # Negative control: --stage-id builds an engine, so it must keep failing
+    # loudly here rather than being swept up by the router's reduced parser.
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--stage-id", "0"))
+
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
+        parse_omni_args()
+
+
+def test_stage_router_ignores_stage_id_after_end_of_options(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys, "argv", _router_argv(tmp_path, "--omni-router", "--", "--stage-id", "0")
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.stage_id is None
+    assert config.model == "test-model"
+
+
+def test_stage_router_ignores_negated_flag_after_end_of_options(monkeypatch, tmp_path):
+    monkeypatch.setenv("DYN_OMNI_ROUTER", "true")
+    monkeypatch.setattr(sys, "argv", _router_argv(tmp_path, "--", "--no-omni-router"))
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.omni_router is True
+    assert config.model == "test-model"
+
+
+def test_stage_id_keeps_the_full_parser_alongside_omni_router(monkeypatch, tmp_path):
+    # --stage-id outranks --omni-router in the pre-scan, so this argv must still
+    # build the engine parser. The device error is what observes that choice:
+    # the reduced router parser resolves no device, so it would run on to the
+    # mutual-exclusion ValueError instead -- a result this argv also produces
+    # when the pre-scan is wrong, which is why it is asserted elsewhere.
+    monkeypatch.setattr(
+        sys, "argv", _router_argv(tmp_path, "--stage-id", "0", "--omni-router")
+    )
+
+    with _no_accelerator(), pytest.raises(RuntimeError, match="Failed to infer device"):
+        parse_omni_args()
+
+
+def test_stage_router_accepts_underscore_option_names(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(tmp_path, "--omni-router", "--served_model_name", "public-alias"),
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.served_model_name == "public-alias"
+    assert config.engine_args.served_model_name == ["public-alias"]
+
+
+def test_stage_router_loads_engine_options_from_config(monkeypatch, tmp_path):
+    config_path = tmp_path / "router.yaml"
+    config_path.write_text(
+        "model: config-model\n"
+        "served-model-name: [public-alias]\n"
+        "trust-remote-code: true\n"
+        "revision: test-revision\n"
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dynamo.vllm.omni",
+            "--stage-configs-path",
+            str(tmp_path / "stages.yaml"),
+            "--omni-router",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    assert config.model == "config-model"
+    assert config.served_model_name == "public-alias"
+    assert config.engine_args.served_model_name == ["public-alias"]
+    assert config.engine_args.trust_remote_code is True
+    assert config.engine_args.revision == "test-revision"
+
+
+def test_stage_router_honors_disable_log_stats(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _router_argv(tmp_path, "--omni-router", "--disable-log-stats"),
+    )
+
+    with _no_accelerator():
+        config = parse_omni_args()
+
+    registered: list[dict] = []
+    monkeypatch.setattr(
+        vllm_main,
+        "register_engine_metrics_callback",
+        lambda **kwargs: registered.append(kwargs),
+    )
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+
+    vllm_main.setup_metrics_collection(
+        config, SimpleNamespace(), logging.getLogger(__name__)
+    )
+
+    assert config.engine_args.disable_log_stats is True
+    assert not registered
 
 
 # --- vllm_omni API compatibility guards ---


### PR DESCRIPTION
Cherry-pick of #14359 to `release/1.5.0`.

This backport allows the omni stage router to parse its arguments and start on hosts without an accelerator, while preserving full engine parsing for stage workers.

Signed-off cherry-pick with `-x --signoff`.

Validation:
- Applied cleanly with no conflicts.
- Remote Git tree exactly matches the locally verified cherry-pick tree (`300a91823d0bc0f963193395706e6ed34390a420`).
- `git diff --check HEAD^ HEAD` passed.
- Focused unit tests were not run because Python lacks `pytest` in this environment.
- Focused pre-commit checks were not run because `pre-commit` is unavailable.