### PR TITLE
fix(kv-router): make standalone indexer cleanup safe

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
@@ -201,6 +201,10 @@ Returns:
 Register a ZMQ endpoint for an instance. Each call creates or reuses the indexer for the given `(model_name, routing_group)` pair.
 Registration is non-blocking: if the worker is not up yet, the listener is accepted in `pending` state and transitions to `active` once the initial ZMQ connection succeeds.
 
+Repeating `/register` for an existing `instance_id` and `dp_rank` returns an error;
+it does not replace the listener or reset its sequence watermark. For worker restarts,
+see [Worker Restarts](#worker-restarts).
+
 ```bash
 # Single model, default routing group
 curl -X POST http://localhost:8090/register \
@@ -489,6 +493,29 @@ the previous listener's `last_seq`. If the first live batch starts above sequenc
 recovers history still retained by the engine. Without a replay endpoint, or when the requested
 range is no longer retained, restart with a healthy indexer in `--peers` to recover its startup
 snapshot, or perform another full resynchronization before relying on the rebuilt worker state.
+
+## Worker Restarts
+
+A ZMQ reconnect does not identify a new worker or cache-event publisher lifetime.
+If the publisher restarts with its sequence reset, an existing listener retains its
+watermark and discards batches at or below it. Previously indexed ownership can also
+remain stale.
+
+On a worker or publisher restart, call `/unregister` and wait for the response before
+calling `/register` with the current worker metadata. For a whole-worker restart,
+omit `dp_rank` from `/unregister` to remove all ranks. Apply this lifecycle change to
+every indexer replica; peer registration does not propagate worker lifecycle changes.
+Serialize lifecycle operations for the same worker.
+
+This sequence requests removal of old cache ownership and starts a fresh sequence
+watermark. It does not certify a complete cache view or provide an atomic boundary
+against in-flight old events. Registration success and listener status `active` do
+not establish that startup events were received or replayed. Recover missing history
+before relying on cache overlap, subject to the limits in
+[Gap Detection and Replay](#gap-detection-and-replay).
+
+The [standalone selector](standalone-selection.md#worker-restarts) has a different
+registration API: updating a schedulable worker reconciles its indexer registration.
 
 ## Limitations
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -125,6 +125,26 @@ both default to `"default"` when omitted.
 `GET /health` is process liveness. `GET /ready` returns `200` only after at
 least one worker is schedulable, otherwise `503` with lifecycle details.
 
+### Worker Restarts
+
+When a worker or its cache-event publisher restarts, update its registration on every
+selector replica. A reconnect at the same address does not reset the existing event
+sequence watermark or invalidate old cache ownership.
+
+With KV events enabled, `POST /workers` for an existing schedulable worker drains it,
+removes its indexer registration, and creates new listeners with fresh sequence
+watermarks. Supply the complete current worker record because this endpoint replaces
+the catalog record. `PATCH /workers/{worker_id}` also reconciles a schedulable worker;
+even an unchanged update can rebuild its cache view, so avoid using registration
+updates as periodic heartbeats. Serialize lifecycle operations for the same worker.
+
+This differs from the standalone indexer's `/register`, which rejects duplicate
+registrations and requires `/unregister` first. See
+[Indexer Worker Restarts](standalone-indexer.md#worker-restarts) for cleanup and
+replay limits. Neither a successful catalog update nor `/ready` certifies a complete
+cache view: missed startup events must still be recovered, and expired replay
+history requires another source of complete state.
+
 ## Selection API
 
 ### `POST /select`

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -1488,11 +1488,6 @@ mod tests {
             self.index.remove_worker(&mut self.worker_blocks, worker_id);
         }
 
-        fn remove_worker_dp_rank(&mut self, worker_id: u64, dp_rank: u32) {
-            self.index
-                .remove_worker_dp_rank(&mut self.worker_blocks, worker_id, dp_rank);
-        }
-
         fn root_workers(&self, local_hash: LocalBlockHash) -> Vec<WorkerWithDpRank> {
             self.index
                 .root_workers(local_hash, &projection(WorkerWithDpRank::new(7, 0)))
@@ -2144,21 +2139,21 @@ mod tests {
     }
 
     #[test]
-    fn start_pos_past_end_returns_zero() {
+    fn exhausted_sequence_returns_zero() {
         let mut index = TestLowerTierIndex::new();
         index
             .apply_event(store_event(23, 0, 0, Some(1100), &[91], &[901]))
             .unwrap();
 
-        let query = local_hashes(&[91]);
-        let mut continuations = FxHashMap::default();
-        continuations.insert(
-            WorkerWithDpRank::new(23, 0),
-            LowerTierContinuation::new(1, ExternalSequenceBlockHash(1100)),
-        );
-
-        let hits = index.query_contiguous_hits(&query, &continuations);
-        assert_eq!(hits.get(&WorkerWithDpRank::new(23, 0)), Some(&0));
+        let worker = WorkerWithDpRank::new(23, 0);
+        for query in [local_hashes(&[91]), Vec::new()] {
+            let continuation =
+                LowerTierContinuation::new(query.len(), ExternalSequenceBlockHash(1100));
+            let continuations = FxHashMap::from_iter([(worker, continuation)]);
+            let details = index.query_match_details(&query, &continuations);
+            assert_eq!(details.hits.get(&worker), Some(&0));
+            assert_eq!(details.next_continuations.get(&worker), Some(&continuation));
+        }
     }
 
     #[test]
@@ -2250,9 +2245,8 @@ mod tests {
             .apply_event(store_event(41, 0, 0, Some(3000), &[1], &[301]))
             .unwrap();
         index
-            .apply_event(store_event(41, 1, 1, Some(4000), &[2], &[401]))
+            .apply_event(store_event(41, 1, 1, Some(4000), &[1], &[401]))
             .unwrap();
-        index.remove_worker(41);
 
         let mut continuations = FxHashMap::default();
         continuations.insert(
@@ -2264,35 +2258,14 @@ mod tests {
             LowerTierContinuation::new(0, ExternalSequenceBlockHash(4000)),
         );
 
+        let before = index.query_contiguous_hits(&local_hashes(&[1]), &continuations);
+        assert_eq!(before.get(&WorkerWithDpRank::new(41, 0)), Some(&1));
+        assert_eq!(before.get(&WorkerWithDpRank::new(41, 1)), Some(&1));
+        index.remove_worker(41);
+
         let hits = index.query_contiguous_hits(&local_hashes(&[1]), &continuations);
         assert_eq!(hits.get(&WorkerWithDpRank::new(41, 0)), Some(&0));
         assert_eq!(hits.get(&WorkerWithDpRank::new(41, 1)), Some(&0));
-    }
-
-    #[test]
-    fn remove_worker_dp_rank_keeps_other_ranks() {
-        let mut index = TestLowerTierIndex::new();
-        index
-            .apply_event(store_event(43, 0, 0, Some(5000), &[1], &[501]))
-            .unwrap();
-        index
-            .apply_event(store_event(43, 1, 1, Some(6000), &[2], &[601]))
-            .unwrap();
-        index.remove_worker_dp_rank(43, 0);
-
-        let mut continuations = FxHashMap::default();
-        continuations.insert(
-            WorkerWithDpRank::new(43, 0),
-            LowerTierContinuation::new(0, ExternalSequenceBlockHash(5000)),
-        );
-        continuations.insert(
-            WorkerWithDpRank::new(43, 1),
-            LowerTierContinuation::new(0, ExternalSequenceBlockHash(6000)),
-        );
-
-        let hits = index.query_contiguous_hits(&local_hashes(&[2]), &continuations);
-        assert_eq!(hits.get(&WorkerWithDpRank::new(43, 0)), Some(&0));
-        assert_eq!(hits.get(&WorkerWithDpRank::new(43, 1)), Some(&1));
     }
 
     #[test]
@@ -2673,24 +2646,6 @@ mod tests {
         assert_eq!(details.hits.get(&WorkerWithDpRank::new(101, 0)), Some(&1),);
         assert_eq!(details.hits.get(&WorkerWithDpRank::new(102, 0)), Some(&0),);
         assert_eq!(details.hits.get(&WorkerWithDpRank::new(103, 0)), Some(&0),);
-    }
-
-    /// Empty sequence — every worker should get 0 hits.
-    #[test]
-    fn empty_sequence_returns_zero_hits() {
-        let mut index = TestLowerTierIndex::new();
-        index
-            .apply_event(store_event(111, 0, 0, None, &[1], &[101]))
-            .unwrap();
-
-        let mut continuations = FxHashMap::default();
-        continuations.insert(
-            WorkerWithDpRank::new(111, 0),
-            LowerTierContinuation::from_root(0),
-        );
-
-        let details = index.query_match_details(&local_hashes(&[]), &continuations);
-        assert_eq!(details.hits.get(&WorkerWithDpRank::new(111, 0)), Some(&0));
     }
 
     // --- dump_events tests ---

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -622,7 +622,7 @@ impl LowerTierIndexer {
         let indexed_owner = IndexedResidencyOwner::from_exact(owner);
         let remove_worker_entry = {
             let Some(owner_state) = worker_blocks.get_mut(&indexed_owner) else {
-                return Err(KvCacheEventError::BlockNotFound);
+                return Ok(());
             };
             if owner_state.owner != owner {
                 return Err(KvCacheEventError::UnsupportedResidencyDomain);
@@ -631,7 +631,7 @@ impl LowerTierIndexer {
 
             for block_hash in block_hashes {
                 let Some(key) = worker_map.remove(block_hash) else {
-                    return Err(KvCacheEventError::BlockNotFound);
+                    continue;
                 };
 
                 self.remove_owner_from_edge(key, indexed_owner);
@@ -2012,6 +2012,55 @@ mod tests {
             after_one_remove.get(&WorkerWithDpRank::new(13, 0)),
             Some(&0)
         );
+    }
+
+    #[test]
+    fn removal_batches_are_idempotent_and_preserve_other_owners() {
+        let mut index = TestLowerTierIndex::new();
+        let removed = WorkerWithDpRank::new(1, 0);
+        let other_rank = WorkerWithDpRank::new(1, 1);
+        let other_worker = WorkerWithDpRank::new(2, 0);
+        for worker in [removed, other_rank, other_worker] {
+            index
+                .apply_event(store_event(
+                    worker.worker_id,
+                    worker.dp_rank,
+                    0,
+                    None,
+                    &[11, 12],
+                    &[101, 102],
+                ))
+                .unwrap();
+        }
+
+        let batch = remove_event(
+            1,
+            1,
+            0,
+            vec![
+                ExternalSequenceBlockHash(999),
+                ExternalSequenceBlockHash(101),
+                ExternalSequenceBlockHash(101),
+                ExternalSequenceBlockHash(102),
+            ],
+        );
+        index.apply_event(batch.clone()).unwrap();
+        index.apply_event(batch).unwrap();
+        index
+            .apply_event(remove_event(99, 2, 0, vec![ExternalSequenceBlockHash(101)]))
+            .unwrap();
+
+        let continuations = [removed, other_rank, other_worker]
+            .into_iter()
+            .map(|worker| (worker, LowerTierContinuation::from_root(0)))
+            .collect::<FxHashMap<_, _>>();
+        let hits = index.query_contiguous_hits(&local_hashes(&[11, 12]), &continuations);
+        assert_eq!(hits.get(&removed), Some(&0));
+        assert_eq!(hits.get(&other_rank), Some(&2));
+        assert_eq!(hits.get(&other_worker), Some(&2));
+        assert!(index.dump_events().iter().all(|event| {
+            event.worker_id != removed.worker_id || event.event.dp_rank != removed.dp_rank
+        }));
     }
 
     #[test]

--- a/lib/kv-router/src/services/indexer/listener.rs
+++ b/lib/kv-router/src/services/indexer/listener.rs
@@ -229,25 +229,24 @@ impl ListenerLoop {
                     }
                 }
             };
-            if msg.len() != 4 {
-                tracing::warn!(
-                    worker_id,
-                    dp_rank,
-                    "Unexpected replay frame count: {}",
-                    msg.len()
-                );
-                break;
-            }
-
-            // vLLM replay responses include the DEALER identity delimiter plus the
-            // original PUB topic, so the payload shape is:
-            // [empty delimiter, topic, sequence number, encoded event batch].
-            let payload = msg.get(3).expect("frame count checked above");
+            // DEALER strips the ROUTER identity. vLLM includes the PUB topic;
+            // SGLang sends only the delimiter, sequence number, and payload.
+            let (seq_bytes, payload) = match msg.as_slice() {
+                [_, seq, payload] | [_, _, seq, payload] => (seq, payload),
+                _ => {
+                    tracing::warn!(
+                        worker_id,
+                        dp_rank,
+                        "Unexpected replay frame count: {}",
+                        msg.len()
+                    );
+                    break;
+                }
+            };
             if payload.is_empty() {
                 break;
             }
 
-            let seq_bytes = msg.get(2).expect("frame count checked above");
             if seq_bytes.len() != 8 {
                 tracing::warn!(
                     worker_id,
@@ -553,5 +552,89 @@ async fn connect_replay_socket(
             );
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::compute_block_hash_for_seq;
+    use crate::services::indexer::backend::create_indexer;
+    use std::time::Duration;
+
+    #[rstest::rstest]
+    #[case::sglang(false)]
+    #[case::vllm(true)]
+    #[tokio::test]
+    async fn replay_accepts_engine_framing(#[case] include_topic: bool) {
+        let context = zmq::Context::new();
+        let router = context.socket(zmq::ROUTER).unwrap();
+        router.set_linger(0).unwrap();
+        router.set_rcvtimeo(5000).unwrap();
+        router.set_sndtimeo(5000).unwrap();
+        router.bind("tcp://127.0.0.1:*").unwrap();
+        let endpoint = router.get_last_endpoint().unwrap().unwrap();
+        let replay_socket = connect_dealer_socket(&endpoint).unwrap();
+        let publisher = context.socket(zmq::PUB).unwrap();
+        publisher.bind("tcp://127.0.0.1:*").unwrap();
+        let live_socket =
+            connect_sub_socket(&publisher.get_last_endpoint().unwrap().unwrap()).unwrap();
+
+        let server = tokio::task::spawn_blocking(move || {
+            let request = router.recv_multipart(0).unwrap();
+            assert_eq!(&request[1..], &[vec![], 0_u64.to_be_bytes().to_vec()]);
+            for seq in 0_u64..=2 {
+                let mut frames = vec![request[0].clone(), vec![]];
+                if include_topic {
+                    frames.push(b"kv-events".to_vec());
+                }
+                if seq == 2 {
+                    frames.extend([u64::MAX.to_be_bytes().to_vec(), vec![]]);
+                } else {
+                    let event = (
+                        "BlockStored",
+                        vec![seq + 100],
+                        if seq == 0 { None } else { Some(100_u64) },
+                        vec![1_u32 + seq as u32; 4],
+                        4_usize,
+                        Option::<u64>::None,
+                        "GPU",
+                    );
+                    let payload = rmp_serde::to_vec(&(0.0_f64, vec![event], Some(0_i32))).unwrap();
+                    frames.extend([seq.to_be_bytes().to_vec(), payload]);
+                }
+                router.send_multipart(frames, 0).unwrap();
+            }
+            // Keep the socket open until the client consumes the queued replies.
+            assert_eq!(router.recv_multipart(0).unwrap()[1], b"done");
+        });
+        let indexer = create_indexer(4, 1);
+        let watermark = Arc::new(AtomicU64::new(WATERMARK_UNSET));
+        let cancel = CancellationToken::new();
+        let mut listener = ListenerLoop::new(
+            1,
+            0,
+            4,
+            indexer.clone(),
+            cancel.clone(),
+            live_socket,
+            Some(replay_socket.clone()),
+            watermark.clone(),
+        );
+        let replayed = tokio::time::timeout(Duration::from_secs(5), listener.replay_gap(0, 2))
+            .await
+            .expect("replay completion marker")
+            .unwrap();
+        send_multipart(&replay_socket, vec![b"done".to_vec()])
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(replayed, 2);
+        assert_eq!(watermark.load(Ordering::Acquire), 1);
+        indexer.dump_events().await.expect("flush indexer");
+        let hashes = compute_block_hash_for_seq(&[1, 1, 1, 1, 2, 2, 2, 2], 4, Default::default());
+        let matches = indexer.find_matches(hashes).await.unwrap();
+        assert_eq!(matches.scores.get(&WorkerWithDpRank::new(1, 0)), Some(&2));
+        cancel.cancel();
     }
 }

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -912,12 +912,9 @@ mod tests {
         registry.root_cancel_token.cancel();
     }
 
-    #[rstest::rstest]
-    #[case(1)]
-    #[case(2)]
     #[tokio::test]
-    async fn deregister_removes_watermark(#[case] num_threads: usize) {
-        let registry = WorkerRegistry::new(num_threads);
+    async fn deregister_removes_watermark() {
+        let registry = test_registry();
         registry.signal_ready();
 
         registry
@@ -946,12 +943,9 @@ mod tests {
         );
     }
 
-    #[rstest::rstest]
-    #[case(1)]
-    #[case(2)]
     #[tokio::test]
-    async fn deregister_dp_rank_removes_watermark(#[case] num_threads: usize) {
-        let registry = WorkerRegistry::new(num_threads);
+    async fn deregister_dp_rank_removes_watermark() {
+        let registry = test_registry();
         registry.signal_ready();
 
         registry
@@ -1043,12 +1037,9 @@ mod tests {
         assert_eq!(registry.listener_cancelled(1, 0), Some(true));
     }
 
-    #[rstest::rstest]
-    #[case(1)]
-    #[case(2)]
     #[tokio::test]
-    async fn re_register_gets_fresh_watermark(#[case] num_threads: usize) {
-        let registry = WorkerRegistry::new(num_threads);
+    async fn re_register_gets_fresh_watermark() {
+        let registry = test_registry();
         registry.signal_ready();
 
         registry
@@ -1098,12 +1089,9 @@ mod tests {
         );
     }
 
-    #[rstest::rstest]
-    #[case(1)]
-    #[case(2)]
     #[tokio::test]
-    async fn deregister_all_routing_groups_removes_watermarks(#[case] num_threads: usize) {
-        let registry = WorkerRegistry::new(num_threads);
+    async fn deregister_all_routing_groups_removes_watermarks() {
+        let registry = test_registry();
         registry.signal_ready();
 
         registry

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -318,6 +318,7 @@ pub struct WorkerRegistry {
     ready_tx: watch::Sender<bool>,
     ready_rx: watch::Receiver<bool>,
     root_cancel_token: CancellationToken,
+    retain_empty_indexers: bool,
 }
 
 impl WorkerRegistry {
@@ -364,7 +365,15 @@ impl WorkerRegistry {
             ready_tx,
             ready_rx,
             root_cancel_token,
+            retain_empty_indexers: false,
         }
+    }
+
+    #[cfg(feature = "standalone-selection")]
+    pub(crate) fn with_retained_indexers(mut self) -> Self {
+        // Selection entries and their schedulers retain these indexers across worker updates.
+        self.retain_empty_indexers = true;
+        self
     }
 
     pub fn signal_ready(&self) {
@@ -815,7 +824,8 @@ impl WorkerRegistry {
     }
 
     fn maybe_remove_indexer(&self, key: &RoutingPartitionId) {
-        if self.workers.iter().any(|entry| entry.value().key == *key) {
+        if self.retain_empty_indexers || self.workers.iter().any(|entry| entry.value().key == *key)
+        {
             return;
         }
 
@@ -940,6 +950,11 @@ mod tests {
         assert!(
             !registry.watermarks.contains_key(&(1, 0)),
             "watermark should be removed after deregister"
+        );
+        assert!(
+            registry
+                .get_indexer(&RoutingPartitionId::new("test-model", "default"))
+                .is_none()
         );
     }
 

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -311,6 +311,8 @@ pub struct WorkerEntry {
 pub struct WorkerRegistry {
     workers: DashMap<WorkerId, WorkerEntry>,
     indexers: DashMap<RoutingPartitionId, IndexerEntry>,
+    // Serialize indexer claims through worker publication with empty-indexer removal.
+    indexer_lifecycle: tokio::sync::Mutex<()>,
     peers: DashMap<String, ()>,
     watermarks: DashMap<(WorkerId, u32), Arc<AtomicU64>>,
     num_threads: usize,
@@ -358,6 +360,7 @@ impl WorkerRegistry {
         Self {
             workers: DashMap::new(),
             indexers: DashMap::new(),
+            indexer_lifecycle: tokio::sync::Mutex::new(()),
             peers: DashMap::new(),
             watermarks: DashMap::new(),
             num_threads,
@@ -423,6 +426,7 @@ impl WorkerRegistry {
         replay_endpoint: Option<String>,
     ) -> Result<()> {
         let key = RoutingPartitionId::new(model_name, routing_group);
+        let registration = self.indexer_lifecycle.lock().await;
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
@@ -495,6 +499,7 @@ impl WorkerRegistry {
             entry.listeners.insert(dp_rank, record.clone());
         }
 
+        drop(registration);
         self.spawn_listener(instance_id, dp_rank, attempt, record);
         Ok(())
     }
@@ -535,7 +540,7 @@ impl WorkerRegistry {
         if let Some(indexer) = indexer {
             indexer.remove_worker(instance_id).await;
         }
-        self.maybe_remove_indexer(&key);
+        self.maybe_remove_indexer(&key).await;
         Ok(())
     }
 
@@ -584,7 +589,7 @@ impl WorkerRegistry {
                 if let Some(indexer) = indexer {
                     indexer.remove_worker(instance_id).await;
                 }
-                self.maybe_remove_indexer(&key);
+                self.maybe_remove_indexer(&key).await;
             }
         } else {
             let indexer = self.indexers.get(&key).map(|entry| entry.indexer.clone());
@@ -629,7 +634,7 @@ impl WorkerRegistry {
         if let Some(indexer) = indexer {
             indexer.remove_worker(instance_id).await;
         }
-        self.maybe_remove_indexer(&key);
+        self.maybe_remove_indexer(&key).await;
         Ok(())
     }
 
@@ -823,9 +828,13 @@ impl WorkerRegistry {
         );
     }
 
-    fn maybe_remove_indexer(&self, key: &RoutingPartitionId) {
-        if self.retain_empty_indexers || self.workers.iter().any(|entry| entry.value().key == *key)
-        {
+    async fn maybe_remove_indexer(&self, key: &RoutingPartitionId) {
+        if self.retain_empty_indexers {
+            return;
+        }
+
+        let _lifecycle = self.indexer_lifecycle.lock().await;
+        if self.workers.iter().any(|entry| entry.value().key == *key) {
             return;
         }
 
@@ -836,6 +845,8 @@ impl WorkerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank};
+    use crate::services::indexer::backend::test_util::store_event;
     use std::future::Future;
     use std::sync::atomic::Ordering;
     use std::task::{Context, Poll, Waker};
@@ -919,6 +930,97 @@ mod tests {
             .unwrap();
         assert!(registry.workers.contains_key(&2));
         assert!(registry.indexers.contains_key(&key));
+        registry.root_cancel_token.cancel();
+    }
+
+    #[rstest::rstest]
+    #[case("worker")]
+    #[case("all_groups")]
+    #[case("last_rank")]
+    #[tokio::test]
+    async fn empty_indexer_removal_waits_for_registration(#[case] removal: &str) {
+        let registry = test_registry();
+        let key = RoutingPartitionId::new("test-model", "default");
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:15557".into(),
+                0,
+                "test-model".into(),
+                "default".into(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Queue registration ahead of pruning, without timing or thread scheduling assumptions.
+        let lifecycle = registry.indexer_lifecycle.lock().await;
+        let registration = registry.register(
+            2,
+            "tcp://127.0.0.1:15558".into(),
+            0,
+            "test-model".into(),
+            "default".into(),
+            1,
+            None,
+        );
+        tokio::pin!(registration);
+        assert!(matches!(
+            registration
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Pending
+        ));
+
+        let removal = async {
+            match removal {
+                "worker" => registry.deregister(1, "test-model", "default").await,
+                "all_groups" => {
+                    registry
+                        .deregister_all_routing_groups(1, "test-model")
+                        .await
+                }
+                "last_rank" => {
+                    registry
+                        .deregister_dp_rank(1, 0, "test-model", "default")
+                        .await
+                }
+                _ => unreachable!(),
+            }
+        };
+        tokio::pin!(removal);
+        assert!(matches!(
+            removal
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Pending
+        ));
+        assert!(registry.workers.is_empty());
+        assert!(registry.get_indexer(&key).is_some());
+        drop(lifecycle);
+        registration.await.unwrap();
+        removal.await.unwrap();
+
+        // Events written by the new listener must remain visible through the query registry.
+        let listener_indexer = registry.workers.get(&2).unwrap().listeners[&0]
+            .indexer
+            .clone();
+        listener_indexer
+            .apply_event_routed(store_event(2, 0, 0, &[], &[11], StorageTier::Device))
+            .await
+            .unwrap();
+        listener_indexer.dump_events().await.unwrap();
+        let query_indexer = registry
+            .get_indexer(&key)
+            .expect("registered indexer")
+            .indexer
+            .clone();
+        let scores = query_indexer
+            .find_matches(vec![LocalBlockHash(11)])
+            .await
+            .unwrap();
+        assert_eq!(scores.scores.get(&WorkerWithDpRank::new(2, 0)), Some(&1));
         registry.root_cancel_token.cancel();
     }
 

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -997,6 +997,7 @@ mod tests {
             Poll::Pending
         ));
         assert!(registry.workers.is_empty());
+        assert!(!registry.watermarks.contains_key(&(1, 0)));
         assert!(registry.get_indexer(&key).is_some());
         drop(lifecycle);
         registration.await.unwrap();
@@ -1022,42 +1023,6 @@ mod tests {
             .unwrap();
         assert_eq!(scores.scores.get(&WorkerWithDpRank::new(2, 0)), Some(&1));
         registry.root_cancel_token.cancel();
-    }
-
-    #[tokio::test]
-    async fn deregister_removes_watermark() {
-        let registry = test_registry();
-        registry.signal_ready();
-
-        registry
-            .register(
-                1,
-                "tcp://127.0.0.1:15557".to_string(),
-                0,
-                "test-model".to_string(),
-                "default".to_string(),
-                1,
-                None,
-            )
-            .await
-            .unwrap();
-
-        assert!(registry.watermarks.contains_key(&(1, 0)));
-
-        registry
-            .deregister(1, "test-model", "default")
-            .await
-            .unwrap();
-
-        assert!(
-            !registry.watermarks.contains_key(&(1, 0)),
-            "watermark should be removed after deregister"
-        );
-        assert!(
-            registry
-                .get_indexer(&RoutingPartitionId::new("test-model", "default"))
-                .is_none()
-        );
     }
 
     #[tokio::test]
@@ -1173,14 +1138,22 @@ mod tests {
             .unwrap();
 
         // Simulate that the listener advanced the watermark.
-        if let Some(wm) = registry.watermarks.get(&(1, 0)) {
-            wm.store(42, Ordering::Release);
-        }
+        registry
+            .watermarks
+            .get(&(1, 0))
+            .unwrap()
+            .store(42, Ordering::Release);
 
         registry
             .deregister(1, "test-model", "default")
             .await
             .unwrap();
+
+        assert!(
+            registry
+                .get_indexer(&RoutingPartitionId::new("test-model", "default"))
+                .is_none()
+        );
 
         registry
             .register(
@@ -1203,37 +1176,6 @@ mod tests {
             wm.load(Ordering::Acquire),
             u64::MAX,
             "re-registered watermark should be fresh (u64::MAX)"
-        );
-    }
-
-    #[tokio::test]
-    async fn deregister_all_routing_groups_removes_watermarks() {
-        let registry = test_registry();
-        registry.signal_ready();
-
-        registry
-            .register(
-                1,
-                "tcp://127.0.0.1:15562".to_string(),
-                0,
-                "test-model".to_string(),
-                "default".to_string(),
-                1,
-                None,
-            )
-            .await
-            .unwrap();
-
-        assert!(registry.watermarks.contains_key(&(1, 0)));
-
-        registry
-            .deregister_all_routing_groups(1, "test-model")
-            .await
-            .unwrap();
-
-        assert!(
-            !registry.watermarks.contains_key(&(1, 0)),
-            "watermark should be removed after deregister_all_routing_groups"
         );
     }
 

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -521,8 +521,10 @@ impl WorkerRegistry {
             }
         }
 
-        if let Some(ie) = self.indexers.get(&key) {
-            ie.indexer.remove_worker(instance_id).await;
+        // Registration needs this map's write lock while removal can wait on indexer queues.
+        let indexer = self.indexers.get(&key).map(|entry| entry.indexer.clone());
+        if let Some(indexer) = indexer {
+            indexer.remove_worker(instance_id).await;
         }
         self.maybe_remove_indexer(&key);
         Ok(())
@@ -569,13 +571,17 @@ impl WorkerRegistry {
                 .remove_if(&instance_id, |_, entry| entry.listeners.is_empty())
                 .is_some();
             if actually_removed {
-                if let Some(ie) = self.indexers.get(&key) {
-                    ie.indexer.remove_worker(instance_id).await;
+                let indexer = self.indexers.get(&key).map(|entry| entry.indexer.clone());
+                if let Some(indexer) = indexer {
+                    indexer.remove_worker(instance_id).await;
                 }
                 self.maybe_remove_indexer(&key);
             }
-        } else if let Some(ie) = self.indexers.get(&key) {
-            ie.indexer.remove_worker_dp_rank(instance_id, dp_rank).await;
+        } else {
+            let indexer = self.indexers.get(&key).map(|entry| entry.indexer.clone());
+            if let Some(indexer) = indexer {
+                indexer.remove_worker_dp_rank(instance_id, dp_rank).await;
+            }
         }
 
         Ok(())
@@ -610,8 +616,9 @@ impl WorkerRegistry {
             }
         }
 
-        if let Some(ie) = self.indexers.get(&key) {
-            ie.indexer.remove_worker(instance_id).await;
+        let indexer = self.indexers.get(&key).map(|entry| entry.indexer.clone());
+        if let Some(indexer) = indexer {
+            indexer.remove_worker(instance_id).await;
         }
         self.maybe_remove_indexer(&key);
         Ok(())
@@ -819,15 +826,98 @@ impl WorkerRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
     use std::sync::atomic::Ordering;
+    use std::task::{Context, Poll, Waker};
+    use std::time::Duration;
 
     fn test_registry() -> WorkerRegistry {
         WorkerRegistry::new(1)
     }
 
+    #[rstest::rstest]
+    #[case("worker")]
+    #[case("all_groups")]
+    #[case("last_rank")]
     #[tokio::test]
-    async fn deregister_removes_watermark() {
+    async fn registration_progresses_while_removal_is_backpressured(#[case] removal: &str) {
         let registry = test_registry();
+        let key = RoutingPartitionId::new("test-model", "default");
+        registry
+            .register(
+                1,
+                "tcp://127.0.0.1:15557".into(),
+                0,
+                "test-model".into(),
+                "default".into(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+        let indexer = registry.indexers.get(&key).unwrap().indexer.clone();
+        let Indexer::Single { primary, .. } = indexer else {
+            unreachable!();
+        };
+        let sender = primary.remove_worker_sender();
+        // Reserve the entire queue so removal must yield without blocking the executor.
+        let permits = sender.reserve_many(sender.max_capacity()).await.unwrap();
+        let removal = async {
+            match removal {
+                "worker" => registry.deregister(1, "test-model", "default").await,
+                "all_groups" => {
+                    registry
+                        .deregister_all_routing_groups(1, "test-model")
+                        .await
+                }
+                "last_rank" => {
+                    registry
+                        .deregister_dp_rank(1, 0, "test-model", "default")
+                        .await
+                }
+                _ => unreachable!(),
+            }
+        };
+        tokio::pin!(removal);
+        assert!(matches!(
+            removal
+                .as_mut()
+                .poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Pending
+        ));
+        // A nonblocking probe makes the regression fail instead of deadlocking the test.
+        assert!(matches!(
+            registry.indexers.try_get_mut(&key),
+            dashmap::try_result::TryResult::Present(_)
+        ));
+        registry
+            .register(
+                2,
+                "tcp://127.0.0.1:15558".into(),
+                0,
+                "test-model".into(),
+                "default".into(),
+                1,
+                None,
+            )
+            .await
+            .unwrap();
+        drop(permits);
+        tokio::time::timeout(Duration::from_secs(5), removal)
+            .await
+            .expect("removal should finish after queue capacity is released")
+            .unwrap();
+        assert!(registry.workers.contains_key(&2));
+        assert!(registry.indexers.contains_key(&key));
+        registry.root_cancel_token.cancel();
+    }
+
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(2)]
+    #[tokio::test]
+    async fn deregister_removes_watermark(#[case] num_threads: usize) {
+        let registry = WorkerRegistry::new(num_threads);
         registry.signal_ready();
 
         registry
@@ -856,9 +946,12 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(2)]
     #[tokio::test]
-    async fn deregister_dp_rank_removes_watermark() {
-        let registry = test_registry();
+    async fn deregister_dp_rank_removes_watermark(#[case] num_threads: usize) {
+        let registry = WorkerRegistry::new(num_threads);
         registry.signal_ready();
 
         registry
@@ -950,9 +1043,12 @@ mod tests {
         assert_eq!(registry.listener_cancelled(1, 0), Some(true));
     }
 
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(2)]
     #[tokio::test]
-    async fn re_register_gets_fresh_watermark() {
-        let registry = test_registry();
+    async fn re_register_gets_fresh_watermark(#[case] num_threads: usize) {
+        let registry = WorkerRegistry::new(num_threads);
         registry.signal_ready();
 
         registry
@@ -1002,9 +1098,12 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(2)]
     #[tokio::test]
-    async fn deregister_all_routing_groups_removes_watermarks() {
-        let registry = test_registry();
+    async fn deregister_all_routing_groups_removes_watermarks(#[case] num_threads: usize) {
+        let registry = WorkerRegistry::new(num_threads);
         registry.signal_ready();
 
         registry

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -1392,30 +1392,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn shutdown_keeps_parent_alive() {
-        let parent = CancellationToken::new();
-        let core = SelectionCore::try_new_local(
-            test_config(false),
-            1,
-            parent.clone(),
-            SelectionCacheConfig::default(),
-        )
-        .expect("valid test config");
-
-        core.shutdown();
-
-        assert!(core.cancel_token.is_cancelled());
-        assert!(!parent.is_cancelled());
-    }
-
     #[tokio::test]
-    async fn shutdown_cancels_listeners() {
+    async fn shutdown_cancels_listeners_but_keeps_parent_alive() {
         let parent = CancellationToken::new();
         let core = SelectionCore::try_new_local(
             test_config(true),
             1,
-            parent,
+            parent.clone(),
             SelectionCacheConfig::default(),
         )
         .expect("valid test config");
@@ -1428,6 +1411,8 @@ mod tests {
         assert_eq!(core.indexer_registry.listener_cancelled(1, 0), Some(false));
 
         core.shutdown();
+        assert!(core.cancel_token.is_cancelled());
+        assert!(!parent.is_cancelled());
         assert_eq!(core.indexer_registry.listener_cancelled(1, 0), Some(true));
     }
 

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -181,10 +181,10 @@ impl SelectionCore {
         tracking_hash: Arc<TrackingHashContext>,
     ) -> Self {
         let cancel_token = cancel_token.child_token();
-        let indexer_registry = Arc::new(WorkerRegistry::new_with_cancel_token(
-            indexer_threads,
-            cancel_token.clone(),
-        ));
+        let indexer_registry = Arc::new(
+            WorkerRegistry::new_with_cancel_token(indexer_threads, cancel_token.clone())
+                .with_retained_indexers(),
+        );
         if signal_indexer_ready {
             indexer_registry.signal_ready();
         }
@@ -1429,6 +1429,64 @@ mod tests {
 
         core.shutdown();
         assert_eq!(core.indexer_registry.listener_cancelled(1, 0), Some(true));
+    }
+
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(2)]
+    #[tokio::test]
+    async fn selection_sees_cache_after_last_worker_replacement(#[case] indexer_threads: usize) {
+        let core = SelectionCore::try_new_local(
+            test_config(true),
+            indexer_threads,
+            CancellationToken::new(),
+            SelectionCacheConfig::default(),
+        )
+        .expect("valid test config");
+        let key = RoutingPartitionId::new("model", "default");
+        let request = || {
+            let mut request = select_request();
+            request.prompt.token_ids = None;
+            request.prompt.block_hashes = Some(vec![11]);
+            request.prompt.sequence_hashes = Some(vec![101]);
+            request.prompt.isl_tokens = Some(4);
+            request
+        };
+
+        // Exercise an in-place update, then removing the last worker and adding a new one.
+        for worker_id in [1, 1, 2] {
+            if worker_id == 2 {
+                core.delete_worker(1).await.expect("delete last worker");
+            }
+            core.upsert_worker(worker_with_kv_events(worker_id))
+                .await
+                .expect("worker upsert");
+            assert_eq!(core.select(request()).await.unwrap().overlap.gpu, 0);
+
+            // Write through the registry used by listeners, not the selector's saved reference.
+            let indexer = core
+                .indexer_registry
+                .get_indexer(&key)
+                .unwrap()
+                .indexer
+                .clone();
+            indexer
+                .apply_event_routed(store_event(
+                    worker_id,
+                    0,
+                    1,
+                    &[],
+                    &[11],
+                    StorageTier::Device,
+                ))
+                .await
+                .unwrap();
+            indexer.dump_events().await.expect("flush indexer");
+            let selected = core.select(request()).await.expect("select cached worker");
+            assert_eq!(selected.worker_id, worker_id);
+            assert_eq!(selected.overlap.gpu, 4);
+        }
+        core.shutdown();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix two standalone KV indexer cleanup failures: an absent block no longer stops the rest of a host/disk deletion batch, and worker removal releases the indexer-map lock before waiting for asynchronous cleanup so registration can proceed under backpressure. Missing ownership is an idempotent no-op; other workers and DP ranks retain their ownership.

Clarify worker restarts for both HTTP APIs: the indexer requires unregister/register, while updating a schedulable selector worker reconciles its indexer registration. Document per-replica updates and replay limits. Publisher-generation fencing and authoritative cache resynchronization remain outside this change.

## Where should the reviewer start?

Start with the deregistration paths in `lib/kv-router/src/services/indexer/registry.rs`, then `remove_blocks_impl` in `lib/kv-router/src/indexer/lower_tier.rs`. The adjacent regression tests cover lock release under backpressure and idempotent deletion without removing other owners. The two standalone service docs clarify existing restart semantics.

## Related Issues

- [x] Confirmed — no related issue

## Validation

### Real-engine adversarial E2E (September 10, 2026)

Tested Dynamo `db201c357408165b7ae43def19337d2feecd658e` with [SGLang PR #38945](https://github.com/sgl-project/sglang/pull/38945) at `15337da9c8ad3602356e7bcbd8c8ccdd7f1cea54`, using Qwen/Qwen3-0.6B on one H100 PCIe. Two real SGLang processes were used for the one-worker/two-worker comparison.

The final-head campaign completed **1,057 successful inference requests**, including **960 through selection and reservation**. Across the intermediate-head and final-head campaigns, controls, and targeted probes, **2,231 test inferences succeeded** (excluding startup/health warmups). Campaign reservations and pending-load counts returned to zero.

| Adversarial case | Result |
| --- | --- |
| Drop a real engine cache-event batch, then forward the next batch to trigger replay | Final head recovered the missing 256-token prefix; the earlier Dynamo control stayed at zero overlap through 30 seconds. |
| Update the only worker, disable replay, then generate a fresh prefix | Final head retained 256-token overlap across all ten polls. Earlier control fell from 256 to zero across all ten polls. |
| Repeat the update with two real engines | 256-token overlap before and throughout all ten post-update polls. |
| Slow replay reader with replay SNDHWM 1 / SNDBUF 1024, while inference rotates the 128-batch history | All 128 batches arrived byte-for-byte, in order, followed by the completion marker; 180 new live batches were published during the stall. |
| Unknown-first, duplicate, and repeated CPU_PINNED/DISK removal batches | Target worker ownership fell from 16 blocks to zero; the other worker retained its 16 blocks. |
| Twelve worker upserts and twelve independent register/delete cycles during inference | All operations completed; cache visibility recovered after replay drained. |

The earlier Dynamo control restores the three updated production files to `8ae92dd8069ac50db87da21917032837bc73d99e` while retaining the same native service entry point.

**Replay convergence caveat:** the original one-second cache-visibility assertion still fails with the deliberately constrained replay queue. On the final head, the dropped-prefix probe first recovered at approximately 8 seconds and remained visible through the 30-second observation window; the intermediate-head probe took approximately 20.5 seconds. A separate intermediate-head churn probe briefly fluctuated before stabilizing. All six delayed churn observations on the final head reported full overlap. These are correctness observations under forced backpressure, not serving-latency benchmarks; service readiness does not certify completed cache replay.

Scope: the harness calls the production `SelectionServiceBuilder` / `run_server` and real SGLang inference. Lower-tier faults relabel real engine stores and inject deletion batches; they do not exercise natural CPU/disk offload. Python CLI packaging, full frontend forwarding, and Kubernetes were not tested. Replay remains limited to retained history; publisher-generation fencing and authoritative cache resynchronization remain out of scope.

Runtime: `lmsysorg/sglang:v0.5.19-cu130-runtime`, Torch `2.13.0+cu130`, with the tested SGLang source installed editable. Each engine used 4,096 cache tokens, page size 16, context length 1,024, concurrency 8, and two generated tokens per test request.

### Focused regression checks

- **105 service tests passed on the final Dynamo head**, including replay framing, last-worker replacement, registration progress under removal backpressure, and the new deterministic registration/removal race cases: `cargo test -p dynamo-kv-router --features standalone-selection --lib services::`.
- **39 lower-tier tests passed** on the unchanged lower-tier implementation: `cargo test -p dynamo-kv-router --features standalone-selection --lib indexer::lower_tier::tests`.
- **21 SGLang KV-event tests passed** in the installed runtime, using normal package imports and the actual `CustomTestCase`, without bootstrap or test-base substitutions.
- Formatting, diff checks, and commit hooks passed during implementation. Docs lint passed with five existing navigation warnings on unrelated pages; Fern CLI checks were unavailable locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repeated or unknown lower-tier block removals no longer produce errors, while valid ownership and rank handling remain unchanged.
  - Indexer registration and deregistration now progress more reliably during delayed removal operations.

- **Documentation**
  - Clarified standalone indexer restart procedures, including unregistering before re-registering workers.
  - Documented restart behavior across replicas, sequence watermarks, stale ownership, and replay limitations.
  - Clarified selector worker restart handling, cache readiness, and registration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

