### PR TITLE
fix(deps): [cherry-pick 1.5.0] align Triton client with patched protobuf 6 (#14491)

### DIFF
--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -31,7 +31,7 @@ opentelemetry-sdk<=1.38.0
 # Transitive via imageio/matplotlib; floor keeps images on the current patch line.
 pillow>=12.3.0
 prometheus_client==0.23.1
-protobuf>=5.29.5,<7.0.0
+protobuf==6.33.6
 pydantic>=2.11.4,<2.13
 pydantic-settings<2.13.0
 PyYAML==6.0.3

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -4,12 +4,12 @@
 # The experimental AIC router load model is provided by the separately staged
 # AISimulate wheel. Do not install the retired standalone AIC distributions.
 
-# tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
+# tritonclient 2.72.0 accepts modern grpcio and protobuf 6; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.
-grpcio<1.68,>=1.63.0
-protobuf>=5.29.5,<6.0dev
+grpcio>=1.81.1,<=1.83.1
+protobuf==6.33.6
 # Frontend-specific dependencies — used by the frontend runtime and any test
 # image that needs to run gRPC frontend tests (e.g. dynamo test image).
 
 # Triton client for gRPC frontend tests
-tritonclient[grpc]<=2.62.0  # May have platform-specific builds
+tritonclient[grpc]==2.72.0  # May have platform-specific builds

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -19,6 +19,6 @@ plotly>=6.0.1
 pmdarima==2.1.1
 prometheus-api-client==0.6.0
 prophet==1.2.1
-protobuf>=5.29.5,<7.0.0
+protobuf==6.33.6
 scikit-learn==1.7.2
 scipy>=1.14.0,<2.0

--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -26,7 +26,9 @@ COPY --chown=dynamo: launch/ /workspace/launch/
 WORKDIR /workspace
 USER dynamo
 
-RUN uv pip install --no-cache-dir tritonclient[grpc]
-RUN uv pip install /opt/tritonserver/python/triton*.whl
+RUN uv pip install --no-cache-dir \
+        'tritonclient[grpc]==2.72.0' 'protobuf==6.33.6' 'grpcio>=1.81.1,<=1.83.1' \
+        /opt/tritonserver/python/triton*.whl && \
+    uv pip check
 # Validate CUDA ABI compatibility at build time
-RUN python3 -c "import tritonserver"
+RUN python3 -c "import tritonserver; import tritonclient.grpc; from pathlib import Path; from google.protobuf import text_format; from tritonclient.grpc import model_config_pb2; text_format.Parse(Path('model_repo/identity/config.pbtxt').read_text(), model_config_pb2.ModelConfig())"

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -50,7 +50,8 @@ docker build \
 ```
 
 > [!NOTE]
-> The default `TRITON_SERVER_IMAGE` is `nvcr.io/nvidia/tritonserver:25.10-py3`
+> The default `TRITON_SERVER_IMAGE` is `nvcr.io/nvidia/tritonserver:25.10-py3`.
+> Rebuild `DYNAMO_BASE_IMAGE` from the same Dynamo checkout before building the Triton worker image. An older local `dynamo-base:latest` can retain `grpcio-tools` that requires protobuf 5, while this example installs protobuf 6. The build's `uv pip check` rejects that incompatible environment. If it reports this conflict, run both image-build commands above again.
 
 #### Step 2: Run the Container
 

--- a/tests/frontend/grpc/test_tensor_parameters.py
+++ b/tests/frontend/grpc/test_tensor_parameters.py
@@ -15,10 +15,10 @@ import logging
 import os
 import runpy
 import shlex
+import shutil
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
-import shutil
 
 import numpy as np
 import pytest

--- a/tests/frontend/grpc/test_tensor_parameters.py
+++ b/tests/frontend/grpc/test_tensor_parameters.py
@@ -10,21 +10,240 @@
 
 """Test gRPC parameter passing with tensor models."""
 
+import builtins
 import logging
 import os
+import runpy
+import shlex
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 import shutil
 
 import numpy as np
 import pytest
-
-try:
-    import tritonclient.grpc as grpcclient
-except ImportError:
-    grpcclient = None
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 from tests.utils.managed_process import ManagedProcess
 
+try:
+    from google.protobuf import any_pb2, empty_pb2, json_format
+except ImportError:
+    any_pb2 = empty_pb2 = json_format = None
+
+TRITON_SKIP_REASON = "tritonclient.grpc is not installed"
+try:
+    import tritonclient.grpc as grpcclient
+    from tritonclient.grpc import service_pb2
+except ImportError:
+    grpcclient = service_pb2 = None
+except RuntimeError as exc:
+    if not (
+        str(exc).startswith("The grpc package installed is at version ")
+        and "grpc_service_pb2_grpc.py depends on grpcio>=" in str(exc)
+    ):
+        raise
+    grpcclient = service_pb2 = None
+    TRITON_SKIP_REASON = str(exc)
+
 logger = logging.getLogger(__name__)
+
+
+def _requirement(text: str, package: str) -> Requirement:
+    pins = []
+    for line in text.splitlines():
+        value = line.partition("#")[0].strip()
+        if not value or value.startswith("-"):
+            continue
+        requirement = Requirement(value)
+        if requirement.name == package:
+            pins.append(requirement)
+    assert len(pins) == 1, f"Expected one {package} requirement, found {len(pins)}"
+    return pins[0]
+
+
+def _assert_triton_pins_match(frontend: str, dockerfile: str) -> None:
+    packages = ("tritonclient", "protobuf", "grpcio")
+    tokens = [
+        token
+        for line in dockerfile.replace("\\\n", " ").splitlines()
+        if line.startswith("RUN uv pip install ")
+        for token in shlex.split(line)[4:]
+        if token.startswith(packages)
+    ]
+    for package in packages:
+        actual = _requirement("\n".join(tokens), package)
+        expected = _requirement(frontend, package)
+        assert actual == expected, f"Triton example {actual} differs from {expected}"
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.gpu_0
+@pytest.mark.parallel
+@pytest.mark.parametrize("component", ["common", "frontend", "planner"])
+def test_protobuf_requirements_exclude_vulnerable_versions(component: str) -> None:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "container/deps"
+        / f"requirements.{component}.txt"
+    )
+    requirement = _requirement(path.read_text(encoding="utf-8"), "protobuf")
+    assert requirement.marker is None and requirement.url is None, str(path)
+    specifiers = list(requirement.specifier)
+    assert len(specifiers) == 1, f"{path} must use one exact protobuf pin"
+    specifier = specifiers[0]
+    assert specifier.operator == "==" and "*" not in specifier.version, str(path)
+    version = Version(specifier.version)
+    assert not version.is_prerelease and not version.is_devrelease, str(path)
+    assert Version("6.33.6") <= version < Version("7.0.0"), f"{path} pins {version}"
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.gpu_0
+@pytest.mark.parallel
+@pytest.mark.skipif(json_format is None, reason="protobuf is not installed")
+def test_protobuf_any_json_recursion_limit() -> None:
+    message = any_pb2.Any()
+    message.Pack(empty_pb2.Empty())
+    payload = json_format.MessageToDict(message)
+    assert (
+        json_format.ParseDict(payload, any_pb2.Any(), max_recursion_depth=5) == message
+    )
+    for _ in range(10):
+        payload = {"@type": "type.googleapis.com/google.protobuf.Any", "value": payload}
+    with pytest.raises(json_format.ParseError, match="[Rr]ecursion"):
+        json_format.ParseDict(payload, any_pb2.Any(), max_recursion_depth=5)
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.gpu_0
+@pytest.mark.parallel
+@pytest.mark.skipif(grpcclient is None, reason=TRITON_SKIP_REASON)
+def test_triton_protobuf_json_roundtrip() -> None:
+    response = service_pb2.ModelInferResponse(model_name="identity", id="roundtrip")
+    response.parameters["processed"].bool_param = True
+    response.outputs.add(name="OUTPUT", datatype="INT32", shape=[2])
+    response.raw_output_contents.append(np.array([3, 7], dtype=np.int32).tobytes())
+    wire_response = service_pb2.ModelInferResponse.FromString(
+        response.SerializeToString()
+    )
+    result = grpcclient.InferResult(wire_response)
+    assert result.get_response(as_json=True)["parameters"]["processed"]["bool_param"]
+    assert result.get_response().id == "roundtrip"
+    np.testing.assert_array_equal(result.as_numpy("OUTPUT"), [3, 7])
+
+
+def _load_with_triton_error(error: Exception) -> dict[str, Any]:
+    original_import = builtins.__import__
+
+    def import_with_error(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "tritonclient.grpc":
+            raise error
+        return original_import(name, *args, **kwargs)
+
+    with patch.object(builtins, "__import__", side_effect=import_with_error):
+        return runpy.run_path(__file__)
+
+
+@pytest.mark.unit
+@pytest.mark.pre_merge
+@pytest.mark.gpu_0
+@pytest.mark.parallel
+class TestDependencyGuards:
+    def test_triton_example_pins_match_frontend(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        frontend = (root / "container/deps/requirements.frontend.txt").read_text()
+        dockerfile = (root / "examples/backends/tritonserver/Dockerfile").read_text()
+        _assert_triton_pins_match(frontend, dockerfile)
+
+    @pytest.mark.parametrize("package", ["tritonclient", "protobuf", "grpcio"])
+    @pytest.mark.parametrize("mutation", ["changed", "missing", "duplicate"])
+    def test_triton_example_pin_drift(self, package: str, mutation: str) -> None:
+        frontend = (
+            "tritonclient[grpc]==2.72.0\nprotobuf==6.33.6\ngrpcio>=1.81.1,<=1.83.1"
+        )
+        requirements = frontend.splitlines()
+        pin = next(value for value in requirements if value.startswith(package))
+        replacement = {
+            "changed": f"{package}==1.0.0",
+            "missing": "",
+            "duplicate": f"'{pin}' '{pin}'",
+        }[mutation]
+        dockerfile = "RUN uv pip install " + " ".join(f"'{p}'" for p in requirements)
+        _assert_triton_pins_match(frontend, dockerfile)
+        with pytest.raises(AssertionError):
+            _assert_triton_pins_match(
+                frontend, dockerfile.replace(f"'{pin}'", replacement)
+            )
+
+    @pytest.mark.parametrize(
+        "pin",
+        [
+            "protobuf==6.33.6",
+            "protobuf==6.33.7",
+            "  protobuf==6.34.0  # patched runtime",
+        ],
+    )
+    def test_patched_protobuf_pins(self, pin: str) -> None:
+        with patch.object(Path, "read_text", return_value=pin):
+            test_protobuf_requirements_exclude_vulnerable_versions("frontend")
+
+    @pytest.mark.parametrize(
+        "pin",
+        [
+            "protobuf==3.20.3",
+            "protobuf==5.29.5",
+            "protobuf==6.33.4",
+            "protobuf==6.33.5",
+            "protobuf==7.0.0",
+            "protobuf==7.0.0rc1",
+            "protobuf==6.33.*",
+            "protobuf>=6.33.6",
+            "protobuf==6.33.6; python_version >= '3.12'",
+            "protobuf==6.33.6\nprotobuf==6.33.7",
+        ],
+    )
+    def test_unsafe_or_nonexact_protobuf_pins(self, pin: str) -> None:
+        with patch.object(Path, "read_text", return_value=pin):
+            with pytest.raises(AssertionError):
+                test_protobuf_requirements_exclude_vulnerable_versions("frontend")
+
+    def test_missing_protobuf_pin(self) -> None:
+        with patch.object(Path, "read_text", return_value="# no protobuf pin"):
+            with pytest.raises(AssertionError, match="Expected one protobuf"):
+                test_protobuf_requirements_exclude_vulnerable_versions("frontend")
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ModuleNotFoundError("No module named 'tritonclient'"),
+            RuntimeError(
+                "The grpc package installed is at version 1.76.0, but the generated "
+                "code in grpc_service_pb2_grpc.py depends on grpcio>=1.81.1. "
+                "Please upgrade your grpc module to grpcio>=1.81.1."
+            ),
+        ],
+    )
+    def test_unavailable_triton_preserves_requirement_tests(
+        self, error: Exception
+    ) -> None:
+        namespace = _load_with_triton_error(error)
+        assert namespace["grpcclient"] is None
+        assert namespace["service_pb2"] is None
+        guard = namespace["test_protobuf_requirements_exclude_vulnerable_versions"]
+        for component in ("common", "frontend", "planner"):
+            guard(component)
+        for name in ("test_triton_protobuf_json_roundtrip", "test_request_parameters"):
+            marks = namespace[name].pytestmark
+            assert any(mark.name == "skipif" and mark.args[0] for mark in marks)
+
+    def test_unrelated_triton_runtime_error_is_not_hidden(self) -> None:
+        with pytest.raises(RuntimeError, match="unexpected initialization failure"):
+            _load_with_triton_error(RuntimeError("unexpected initialization failure"))
 
 
 class EchoTensorWorkerProcess(ManagedProcess):
@@ -106,6 +325,7 @@ def extract_params(param_map) -> dict:
     ],
     ids=["no_params", "numeric_param", "mixed_params"],
 )
+@pytest.mark.skipif(grpcclient is None, reason=TRITON_SKIP_REASON)
 def test_request_parameters(
     file_storage_backend, start_services_with_echo_tensor_worker, request_params
 ):


### PR DESCRIPTION
Cherry-pick of #14491 to release/1.5.0.

Pin protobuf to 6.33.6 in the common, frontend and planner requirements, move the frontend to tritonclient 2.72.0 with grpcio 1.81.1 through 1.83.1, resolve the Triton example client and server wheels together, and add regression tests for the protobuf floor and the nested-Any JSON recursion limit.

Conflicts resolved:
- `container/deps/requirements.common.txt`: release/1.5.0 still carries `fastapi==0.120.1` and `pydantic>=2.11.4,<2.13` (#13490 and #14334 are not on the branch). Both lines stay; only the protobuf pin changes.
- `tests/frontend/grpc/test_tensor_parameters.py`: the import block. release/1.5.0 predates the test-infrastructure consolidation (#14391, #14499) and still uses `shutil` with an inline health-check lambda, so `import shutil` stays next to the new imports. Every other hunk matches the main commit.

Source commit: 384d7fdcd95d0beb5176752b6cc77c678fedc8f2
