### PR TITLE
build: [cherry-pick 1.5.0] refresh bundled runtime-image dependencies over the base copies (#14082)

### DIFF
--- a/components/src/dynamo/common/utils/install_media_decoders.py
+++ b/components/src/dynamo/common/utils/install_media_decoders.py
@@ -121,9 +121,9 @@ VALIDATED_SPECS: dict[str, str] = {d.package: d.spec for d in (_OPENCV, _PYAV, _
 # image cannot otherwise handle, without rebuilding the in-tree FFmpeg.
 #
 # Excluded on purpose, for two different reasons:
-#   * PyNvVideoCodec -- already shipped in every runtime image as the NVDEC
-#     path, so H.264/H.265 decode needs no install. Listing it here would
-#     reinstall what is already present.
+#   * PyNvVideoCodec -- already shipped in every CUDA runtime image as the
+#     NVDEC path, so H.264/H.265 decode needs no install there. Listing it
+#     here would reinstall what is already present.
 #   * torchcodec, PyAV-on-SGLang, opencv-on-SGLang -- no Dynamo decode path
 #     imports them, so installing them would add a carrier nothing calls.
 _BACKEND_DECODERS: dict[str, tuple[_Decoder, ...]] = {

--- a/container/deps/requirements.sglang.txt
+++ b/container/deps/requirements.sglang.txt
@@ -16,6 +16,15 @@
 
 blake3>=1.0.0,<2.0.0  # Dynamo SGLang multimodal request handlers import blake3 at startup
 imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive above
+# Refresh the upstream image's bundled mooncake wheel: older builds vendor a
+# stale Go dependency set inside libetcd_wrapper.so, and current wheels carry
+# the updated etcd client stack. The cu130 SGLang image installs the CUDA 13
+# distribution (mooncake-transfer-engine-cuda13, pinned to 0.3.12.post1 by its
+# Dockerfile). The generic project links libcudart.so.12 and ships the same
+# `mooncake` package, so flooring the generic name overlays the CUDA 13 build
+# with an unloadable one instead of upgrading it. CUDA only: stripped for the
+# XPU image in sglang_runtime.Dockerfile.
+mooncake-transfer-engine-cuda13>=0.3.13.post1,<0.4
 # The upstream SGLang image bundles pillow at an older patch release; floor it
 # so the install refreshes it to the current patch line.
 pillow>=12.3.0,<13  # bounded: this file installs with --force-reinstall

--- a/container/deps/requirements.vllm.txt
+++ b/container/deps/requirements.vllm.txt
@@ -11,7 +11,20 @@
 
 --no-binary imageio-ffmpeg
 
+# The upstream vllm-openai base bundles cryptography at the prior major; floor
+# it so the --no-deps install refreshes the bundled copy to the current release
+# line.
+cryptography>=50.0.0
 imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file
+# Refresh the upstream image's bundled mooncake wheel: older builds vendor a
+# stale Go dependency set inside libetcd_wrapper.so, and current wheels carry
+# the updated etcd client stack. vllm-openai is built with
+# INSTALL_KV_CONNECTORS=true on CUDA 13, and its Dockerfile uninstalls the
+# generic project and installs mooncake-transfer-engine-cuda13 in its place.
+# Both ship the same `mooncake` package and the generic one links
+# libcudart.so.12, so the floor has to name the CUDA 13 distribution. CUDA
+# only: stripped for the XPU and CPU images in vllm_runtime.Dockerfile.
+mooncake-transfer-engine-cuda13>=0.3.13.post1,<0.4
 # The upstream vllm-openai image bundles pillow at an older patch release;
 # floor it so the --no-deps install moves it to the current patch line.
 pillow>=12.3.0

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -14,6 +14,9 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 {% endif %}
 
 ARG MODELEXPRESS_VERSION
+{% if device == "cuda" %}
+ARG CUDA_MAJOR
+{% endif %}
 
 WORKDIR /workspace
 
@@ -174,11 +177,37 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
 # Install SGLang-specific runtime dependencies without changing the upstream
 # dependency solution. imageio-ffmpeg is installed from source (no bundled
 # binary) for the VP9 video-encode path; see requirements.sglang.txt.
+{% if device == "cuda" %}
 RUN --mount=type=bind,source=./container/deps/requirements.sglang.txt,target=/tmp/requirements.sglang.txt \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
+    [ "$CUDA_MAJOR" = "13" ] || { echo "ERROR: requirements.sglang.txt hardcodes the mooncake-transfer-engine-cuda13 distribution; got CUDA_MAJOR=$CUDA_MAJOR" >&2; exit 1; } && \
     pip install --break-system-packages --force-reinstall --no-deps \
         --requirement /tmp/requirements.sglang.txt
+{% else %}
+# mooncake and PyNvVideoCodec are CUDA-only. The mooncake floor names the CUDA 13
+# distribution, and PyNvVideoCodec decodes on NVDEC through libnvcuvid, so both
+# are inert on the XPU image and neither is present in its base. The patterns are
+# anchored to the line start so they cannot match inside another requirement, and
+# the checks fail the build if either package arrives by another route -- a filter
+# that silently stopped matching would otherwise look like success. Both checks
+# are positive tests with no `!` and no stderr redirect, so a broken interpreter
+# fails the build instead of passing it vacuously.
+#
+# Whole-RUN branches, rather than a conditional inside one RUN: a `{% raw %}{% if %}{% endraw %}` in the
+# middle of a `\`-continued command emits a blank line that ends the command
+# early. Matches the equivalent branch in vllm_runtime.Dockerfile.
+RUN --mount=type=bind,source=./container/deps/requirements.sglang.txt,target=/tmp/requirements.sglang.txt \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    export PIP_CACHE_DIR=/root/.cache/pip && \
+    grep -v -e '^PyNvVideoCodec' -e '^mooncake-transfer-engine-cuda13' \
+        /tmp/requirements.sglang.txt > /tmp/requirements.sglang.nonvidia.txt && \
+    pip install --break-system-packages --force-reinstall --no-deps \
+        --requirement /tmp/requirements.sglang.nonvidia.txt && \
+    rm -f /tmp/requirements.sglang.nonvidia.txt && \
+    python3 -c "import importlib.util,sys; sys.exit(1 if importlib.util.find_spec('PyNvVideoCodec') else 0)" && \
+    python3 -c "import importlib.metadata as m, re, sys; names={re.sub(r'[-_.]+', '-', n).lower() for d in m.distributions() if (n := (d.metadata or {}).get('Name'))}; sys.exit(1 if 'mooncake-transfer-engine-cuda13' in names else 0)"
+{% endif %}
 
 # Remove the codec-bearing video-DECODE components from the upstream SGLang image
 # (PyAV, decord, OpenCV, torchcodec + any base ffmpeg/libav*), then copy the

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -386,20 +386,43 @@ RUN set -eu; \
 # with a source install that leaves no binary on disk. On cuda, IMAGEIO_FFMPEG_EXE
 # (set above) points imageio at the LGPL CLI copied from wheel_builder. The
 # --no-binary directive lives in the requirements file itself.
+# The vllm-openai base sets UV_CACHE_DIR=/opt/uv/cache and used to bake a uv
+# cache there (v0.27.1 carried archived wheel copies, including mooncake, that
+# duplicated installed packages and kept stale versions on disk after floors
+# refreshed them). The pinned v0.28.0 base mounts a cache over that path in
+# every uv RUN and ships only the empty directory, so the rm below is a no-op
+# today. It stays as a guard against a base that bakes the cache again: the
+# cache would sit in an inherited layer, so removing it here does not shrink
+# the pulled image, it only drops it from the final filesystem view, which is
+# what the compliance scanners see.
 {% if device == "cuda" %}
 RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/requirements.vllm.txt \
     --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
+    [ "$CUDA_MAJOR" = "13" ] || { echo "ERROR: requirements.vllm.txt hardcodes the mooncake-transfer-engine-cuda13 distribution; got CUDA_MAJOR=$CUDA_MAJOR" >&2; exit 1; } && \
     uv pip install {{ pip_target }} \
         --reinstall-package imageio-ffmpeg --reinstall-package PyNvVideoCodec \
-        --no-deps --requirement /tmp/requirements.vllm.txt
+        --no-deps --requirement /tmp/requirements.vllm.txt && \
+    rm -rf /opt/uv/cache
 {% else %}
 # PyNvVideoCodec decodes on NVDEC through libnvcuvid, so it is inert on a
 # non-NVIDIA device. Drop it from the shared requirements rather than ship an
 # unusable NVIDIA codec wheel in, for example, the Intel XPU image. The pattern
 # is anchored to the line start so it cannot match inside another requirement,
-# and the import check fails the build if the package arrives by another route
+# and the presence check fails the build if the package arrives by another route
 # -- a filter that silently stopped matching would otherwise look like success.
+# It asks importlib for the distribution instead of importing it: `import
+# PyNvVideoCodec` dlopens libnvcuvid.so.1, which no driverless XPU or CPU
+# builder has, so an import-based check would raise whether or not the wheel is
+# installed and could never fail the build.
+#
+# mooncake goes the same way, for two reasons. The floor names the CUDA 13
+# distribution, and the XPU and CPU bases carry no mooncake at all, so under
+# --no-deps it would arrive here without msgpack, which vLLM does not pull in.
+# The check asserts the distribution is absent rather than the `mooncake` module,
+# so it tests the filter without assuming what a future base may ship. It is
+# written as a positive test with no `!` and no stderr redirect: a broken
+# interpreter then fails the build instead of passing it vacuously.
 #
 # Whole-RUN branches, rather than a conditional inside one RUN: a `{% raw %}{% if %}{% endraw %}` in the
 # middle of a `\`-continued command emits a blank line that ends the command
@@ -408,10 +431,14 @@ RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/
 RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/requirements.vllm.txt \
     --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
-    grep -v '^PyNvVideoCodec' /tmp/requirements.vllm.txt > /tmp/requirements.vllm.nonvidia.txt && \
+    grep -v -e '^PyNvVideoCodec' -e '^mooncake-transfer-engine-cuda13' \
+        /tmp/requirements.vllm.txt > /tmp/requirements.vllm.nonvidia.txt && \
     uv pip install {{ pip_target }} --reinstall-package imageio-ffmpeg --no-deps \
         --requirement /tmp/requirements.vllm.nonvidia.txt && \
-    ! /opt/venv/bin/python -c "import PyNvVideoCodec" 2>/dev/null
+    rm -f /tmp/requirements.vllm.nonvidia.txt && \
+    /opt/venv/bin/python -c "import importlib.util,sys; sys.exit(1 if importlib.util.find_spec('PyNvVideoCodec') else 0)" && \
+    /opt/venv/bin/python -c "import importlib.metadata as m, re, sys; names={re.sub(r'[-_.]+', '-', n).lower() for d in m.distributions() if (n := (d.metadata or {}).get('Name'))}; sys.exit(1 if 'mooncake-transfer-engine-cuda13' in names else 0)" && \
+    rm -rf /opt/uv/cache
 {% endif %}
 
 # Remove the vLLM source tree shipped in the base image to avoid pytest

--- a/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/additional-media-decoders.md
@@ -31,7 +31,7 @@ Each backend decodes such input through a specific Python package whose wheel bu
 | SGLang | video | `decord2>=3.4.0,<4` | `decord` |
 | TensorRT-LLM | video | `opencv-python-headless>=4.13.0.92,<5` | `cv2` |
 
-The lower bound of each spec is the version validated against Dynamo's multimodal test suite; the upper bound excludes the next major release so an install cannot silently pick up an unvalidated version. PyNvVideoCodec is not in this list because the images already ship it — it is the NVDEC path, not a fallback, so there is nothing to install. torchcodec is left out because no Dynamo decode path imports it.
+The lower bound of each spec is the version validated against Dynamo's multimodal test suite; the upper bound excludes the next major release so an install cannot silently pick up an unvalidated version. PyNvVideoCodec is not in this list because every CUDA runtime image already ships it — it is the NVDEC path, not a fallback, so there is nothing to install. torchcodec is left out because no Dynamo decode path imports it.
 
 ## Install with pip
 

--- a/lib/gpu_memory_service/tests/test_v1_mempool_client.py
+++ b/lib/gpu_memory_service/tests/test_v1_mempool_client.py
@@ -5,6 +5,13 @@ from contextlib import contextmanager
 from unittest.mock import Mock
 
 import pytest
+from _deps import HAS_GMS
+
+if not HAS_GMS:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
 
 torch = pytest.importorskip("torch", reason="torch is required")
 


### PR DESCRIPTION
Cherry-pick of #14082 to release/1.5.0.

Refresh the two third-party packages the vLLM and SGLang runtime images ship from their base images, through the requirement files each image already installs over its base: floor `cryptography` at 50.0.0 in the vLLM image and refresh the bundled mooncake wheel to `mooncake-transfer-engine-cuda13>=0.3.13.post1,<0.4` in both. The install steps assert CUDA 13, and the non-CUDA branches strip the CUDA-only packages.

Clean cherry-pick, no conflicts. All seven files match the main commit.

Source commit: 47f05b256995995c2d1dd1b2680be85a1cb836b5
