### PR TITLE
build(deps): [cherry-pick 1.5.0] upgrade AIPerf to 0.12.0 (#14492)

### DIFF
--- a/benchmarks/frontend/scripts/README.md
+++ b/benchmarks/frontend/scripts/README.md
@@ -116,7 +116,7 @@ When `--num-models` is 1, the served model name matches the HF model path (e.g.,
 |------|----------|---------|
 | etcd | Yes | `apt install etcd` or [releases](https://github.com/etcd-io/etcd/releases) |
 | nats-server | Yes | `apt install nats-server` or [nats.io](https://nats.io/download/) |
-| aiperf | Yes | `uv pip install "aiperf==0.10.0"` (in dynamo venv) |
+| aiperf | Yes | `uv pip install "aiperf==0.12.0"` (in dynamo venv) |
 | jq | Yes | `apt install jq` |
 | perf | Optional | `apt install linux-tools-$(uname -r)` |
 | bpftrace | Optional | `apt install bpftrace` (needs root or CAP_BPF + CAP_PERFMON) |

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -71,7 +71,7 @@ apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
 if [ "$(uname -m)" = "aarch64" ]; then
     apt-get install -y -qq gcc libc6-dev 2>/dev/null
 fi
-pip install --quiet aiperf==0.10.0
+pip install --quiet aiperf==0.12.0
 echo "aiperf installed"
 
 # Wait for model

--- a/benchmarks/multimodal/sweep/experiments/epd/run_experiment.py
+++ b/benchmarks/multimodal/sweep/experiments/epd/run_experiment.py
@@ -31,7 +31,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-EXPECTED_AIPERF_VERSION = "0.10.0"
+EXPECTED_AIPERF_VERSION = "0.12.0"
 TOPOLOGY_ALIASES = {
     "aggregate": "aggregate",
     "agg": "aggregate",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
     {name = "NVIDIA CORPORATION & AFFILIATES"}
 ]
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,7 +31,6 @@ classifiers = [
     "Intended Audience :: Information Technology",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
@@ -41,7 +40,7 @@ classifiers = [
 
 dependencies = [
     "aisimulate==0.1.0.dev2; python_version >= '3.11' and python_version < '3.14'",
-    "aiperf==0.10.0",
+    "aiperf==0.12.0",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -3,4 +3,4 @@
 
 # Benchmark and profiling tool dependencies.
 
-aiperf==0.10.0
+aiperf==0.12.0

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -43,4 +43,4 @@ tensorboardX==2.6.2.2
 # SGLang 0.5.16 pins 5.12.1.
 transformers>=4.56.0
 uvicorn==0.38.0
-zstandard==0.23.0
+zstandard==0.25.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -66,4 +66,4 @@ types-aiofiles>=24.1.0
 types-PyYAML==6.0.12.20250915
 types-requests==2.32.4.20250913
 types-tabulate>=0.9.0
-zstandard==0.23.0
+zstandard==0.25.0

--- a/docs/fern/pages/recipes/feature-benchmarks/kv-router-a-b-testing.md
+++ b/docs/fern/pages/recipes/feature-benchmarks/kv-router-a-b-testing.md
@@ -452,7 +452,7 @@ spec:
           - -lc
           - |
             apt-get update -qq && apt-get install -y -qq tmux > /dev/null 2>&1
-            pip install -q aiperf==0.10.0
+            pip install -q aiperf==0.12.0
             echo "Benchmark pod ready (tmux + aiperf installed)."
             sleep infinity
         imagePullPolicy: IfNotPresent

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
@@ -32,7 +32,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install aiperf==0.10.0;
+          pip install aiperf==0.12.0;
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/perf.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/perf.yaml
@@ -65,7 +65,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
-          pip install -q aiperf==0.10.0 transformers==4.57.3 tokenizers==0.22.2
+          pip install -q aiperf==0.12.0 transformers==4.57.3 tokenizers==0.22.2
 
           echo "Waiting for model at http://$ENDPOINT/v1/models..."
           python3 - <<'PY'

--- a/recipes/deepseek-v4/perf/README.md
+++ b/recipes/deepseek-v4/perf/README.md
@@ -103,7 +103,7 @@ validated for the deployed frontend/backend path.
 | `TRACE_FILE` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | Mooncake JSONL on PVC |
 | `CONCURRENCY` | `16` | Single value per Job |
 | `REQUEST_TIMEOUT_SECONDS` | `1200` | Long enough for long-context requests |
-| `AIPERF_VERSION` | `0.10.0` | Match local benchmark runs unless updated intentionally |
+| `AIPERF_VERSION` | `0.12.0` | Match local benchmark runs unless updated intentionally |
 
 ## Required Evidence for a Result Row
 

--- a/recipes/deepseek-v4/perf/perf.yaml
+++ b/recipes/deepseek-v4/perf/perf.yaml
@@ -118,7 +118,7 @@ spec:
         - name: REQUEST_TIMEOUT_SECONDS
           value: "1200"
         - name: AIPERF_VERSION
-          value: "0.10.0"
+          value: "0.12.0"
         - name: AIPERF_API_PORT
           value: "18090"
         - name: JOB_NAME

--- a/recipes/glm-5-nvfp4/sglang/disagg/efa/perf.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/efa/perf.yaml
@@ -71,7 +71,7 @@ spec:
           # GLM-5 NVFP4 tokenizer uses the `TokenizersBackend` auto-tokenizer
           # class introduced in transformers 5.x — pin to match the runtime
           # image (see `pip show transformers` inside the sglang decode pod).
-          pip install aiperf==0.10.0 transformers==5.3.0 tokenizers==0.22.2
+          pip install aiperf==0.12.0 transformers==5.3.0 tokenizers==0.22.2
 
           # Pre-save tokenizer to a flat directory once, then point aiperf at
           # that path. Avoids each of aiperf's N record-processor subprocesses

--- a/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
@@ -57,7 +57,7 @@ spec:
           apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
           # GLM-5's tokenizer_config.json uses tokenizer_class=TokenizersBackend,
           # which is supported by Transformers v5.
-          pip install -q aiperf==0.10.0 transformers==5.8.0 tokenizers==0.22.2
+          pip install -q aiperf==0.12.0 transformers==5.8.0 tokenizers==0.22.2
 
           echo "Waiting for model at http://$ENDPOINT/v1/models..."
           python3 - <<'PY'

--- a/recipes/gpt-oss-120b/perf/perf.yaml
+++ b/recipes/gpt-oss-120b/perf/perf.yaml
@@ -47,7 +47,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
-          pip install "aiperf==0.10.0" "transformers==4.57.3" "tiktoken==0.13.0" "blobfile"
+          pip install "aiperf==0.12.0" "transformers==4.57.3" "tiktoken==0.13.0" "blobfile"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
@@ -31,7 +31,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/gpt-oss-120b/trtllm/disagg/perf.yaml
+++ b/recipes/gpt-oss-120b/trtllm/disagg/perf.yaml
@@ -31,7 +31,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-round-robin/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.6/perf/perf.yaml
+++ b/recipes/kimi-k2.6/perf/perf.yaml
@@ -63,7 +63,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          pip install "aiperf==0.12.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/nemotron-3-super/perf/perf.yaml
+++ b/recipes/nemotron-3-super/perf/perf.yaml
@@ -65,7 +65,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          pip install "aiperf==0.12.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/vllm/disagg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/vllm/disagg/perf.yaml
@@ -19,7 +19,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.10.0";
+          pip install "aiperf==0.12.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
+++ b/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq build-essential -y
 
         # Install benchmarking tool
-        pip install aiperf==0.10.0
+        pip install aiperf==0.12.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq build-essential -y
 
         # Install benchmarking tool
-        pip install aiperf==0.10.0
+        pip install aiperf==0.12.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
+++ b/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
@@ -21,7 +21,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt update && apt install -y tmux curl jq build-essential
-          pip install aiperf==0.10.0
+          pip install aiperf==0.12.0
 
           echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
           until curl -s "http://${FRONTEND}:8000/v1/models" | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do

--- a/recipes/qwen3-vl-32b-fp8/benchmark/perf.yaml
+++ b/recipes/qwen3-vl-32b-fp8/benchmark/perf.yaml
@@ -28,7 +28,7 @@ spec:
           set -e
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
 
-          pip install aiperf==0.10.0
+          pip install aiperf==0.12.0
           echo "aiperf installation completed"
 
           export COLUMNS=200

--- a/recipes/qwen3.6-35b/README.md
+++ b/recipes/qwen3.6-35b/README.md
@@ -159,7 +159,7 @@ nodes live in a different AZ.
 
 ## aiperf install
 
-We install `aiperf==0.10.0` from PyPI. This release includes
+We install `aiperf==0.12.0` from PyPI. This release includes
 [PR 824](https://github.com/ai-dynamo/aiperf/pull/824)
 (`feat(dataset): add session_id to single-turn for causal ordering`),
 which makes `single_turn` mode honor `session_id` ordering so

--- a/recipes/qwen3.6-35b/perf.yaml
+++ b/recipes/qwen3.6-35b/perf.yaml
@@ -41,7 +41,7 @@ spec:
           # GB200 benchmark pods need build tools to compile it from source.
           apt update && apt install -y --no-install-recommends curl jq git build-essential
 
-          pip install --no-cache-dir "aiperf==0.10.0"
+          pip install --no-cache-dir "aiperf==0.12.0"
           python -c "import aiperf; print('aiperf', aiperf.__version__, 'OK')"
 
           echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models ..."

--- a/tests/dependencies/test_aiperf_consistency.py
+++ b/tests/dependencies/test_aiperf_consistency.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep AIPerf install requirements compatible across the source tree."""
+
+import ast
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.parallel,
+]
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_epd_aiperf_version_gate_matches_release() -> None:
+    path = ROOT / "benchmarks/multimodal/sweep/experiments/epd/run_experiment.py"
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    versions = [
+        ast.literal_eval(node.value)
+        for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "EXPECTED_AIPERF_VERSION"
+            for target in node.targets
+        )
+    ]
+    assert versions == ["0.12.0"]
+
+
+def test_aiperf_install_pins_match() -> None:
+    with (ROOT / "benchmarks/pyproject.toml").open("rb") as handle:
+        dependencies = tomllib.load(handle)["project"]["dependencies"]
+    benchmark_pin = next(
+        Requirement(item) for item in dependencies if Requirement(item).name == "aiperf"
+    )
+    container_pin = next(
+        Requirement(line)
+        for line in (ROOT / "container/deps/requirements.benchmark.txt")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.startswith("aiperf==")
+    )
+    assert (
+        benchmark_pin.specifier == container_pin.specifier == SpecifierSet("==0.12.0")
+    )
+
+
+@pytest.mark.parametrize("version", ["3.10", "3.11", "3.12", "3.13", "3.14"])
+def test_benchmark_python_range_matches_aiperf(version: str) -> None:
+    with (ROOT / "benchmarks/pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    expected = version in SpecifierSet(">=3.11,<3.14")
+    assert (version in SpecifierSet(project["requires-python"])) == expected
+    assert "Programming Language :: Python :: 3.10" not in project["classifiers"]
+
+
+@pytest.mark.parametrize("component", ["common", "test"])
+def test_zstandard_pin_accepts_aiperf_requirement(component: str) -> None:
+    requirements = ROOT / f"container/deps/requirements.{component}.txt"
+    pin = next(
+        Requirement(line)
+        for line in requirements.read_text(encoding="utf-8").splitlines()
+        if line.startswith("zstandard==")
+    )
+    assert pin.specifier == SpecifierSet("==0.25.0")


### PR DESCRIPTION
Cherry-pick of #14492 to release/1.5.0.

Upgrade every AIPerf pin to 0.12.0 and add `tests/dependencies/test_aiperf_consistency.py`, which keeps the pins on one version.

Release adaptation: release/1.5.0 does not ship `recipes/deepseek-v4/deepseek-v4-pro-0813`, so the two perf files under it are dropped from the pick. The remaining 37 files match the main commit.

Source commit: 712d21cedf7ff49b7ef719bd8bef5ebc9383a9ac
