### PR TITLE
docs(examples): add validated diffusion deployment templates

### DIFF
--- a/examples/backends/sglang/deploy/agg_image_diffusion.yaml
+++ b/examples/backends/sglang/deploy/agg_image_diffusion.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# FLUX.1-schnell text-to-image serving with SGLang. This is the Kubernetes
+# equivalent of launch/image_diffusion.sh with --model-path overridden.
+# Request response_format=b64_json unless media storage is externally served.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: flux-1-schnell-sglang-agg
+spec:
+  backendFramework: sglang
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/sglang-runtime:my-tag
+  - name: ImageDiffusionWorker
+    type: worker
+    replicas: 1
+    sharedMemorySize: 16Gi
+    podTemplate:
+      spec:
+        # SGLang 0.5.16 in Dynamo 1.4.2 mistakes parent PID 1 for a dead parent.
+        # Share PIDs within this worker pod so the Dynamo process is not PID 1.
+        # Remove when the minimum runtime includes sgl-project/sglang#31361.
+        shareProcessNamespace: true
+        containers:
+        - name: main
+          image: my-registry/sglang-runtime:my-tag
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          args:
+          - --model-path
+          - black-forest-labs/FLUX.1-schnell
+          - --served-model-name
+          - black-forest-labs/FLUX.1-schnell
+          - --image-diffusion-worker
+          - --media-output-fs-url
+          - file:///tmp/dynamo_media
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          volumeMounts:
+          - name: media-output
+            mountPath: /tmp/dynamo_media
+        volumes:
+        - name: media-output
+          emptyDir:
+            sizeLimit: 20Gi

--- a/examples/backends/sglang/deploy/agg_llm_diffusion.yaml
+++ b/examples/backends/sglang/deploy/agg_llm_diffusion.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# LLaDA 2.0 diffusion-language-model serving with SGLang. This is the
+# Kubernetes equivalent of launch/diffusion_llada.sh.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-llada-agg
+spec:
+  backendFramework: sglang
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/sglang-runtime:my-tag
+  - name: DiffusionLanguageWorker
+    type: worker
+    replicas: 1
+    sharedMemorySize: 16Gi
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/sglang-runtime:my-tag
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          args:
+          - --model-path
+          - inclusionAI/LLaDA2.0-mini-preview
+          - --tp-size
+          - "1"
+          - --skip-tokenizer-init
+          - --trust-remote-code
+          - --enable-metrics
+          - --disable-cuda-graph
+          - --disable-overlap-schedule
+          - --attention-backend
+          - triton
+          - --dllm-algorithm
+          - LowConfidence
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"

--- a/examples/backends/trtllm/deploy/agg_image_diffusion.yaml
+++ b/examples/backends/trtllm/deploy/agg_image_diffusion.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# FLUX.2-klein-4B text-to-image serving with TensorRT-LLM. This is the
+# Kubernetes equivalent of launch/agg_image_diffusion.sh.
+# Request response_format=b64_json unless media storage is externally served.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-flux-image-agg
+spec:
+  backendFramework: trtllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/trtllm-runtime:my-tag
+  - name: ImageDiffusionWorker
+    type: worker
+    replicas: 1
+    sharedMemorySize: 16Gi
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/trtllm-runtime:my-tag
+          command:
+          - python3
+          - -m
+          - dynamo.trtllm
+          args:
+          - --model-path
+          - black-forest-labs/FLUX.2-klein-4B
+          - --served-model-name
+          - black-forest-labs/FLUX.2-klein-4B
+          - --modality
+          - image_diffusion
+          - --media-output-fs-url
+          - file:///tmp/dynamo_media
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          volumeMounts:
+          - name: media-output
+            mountPath: /tmp/dynamo_media
+        volumes:
+        - name: media-output
+          emptyDir:
+            sizeLimit: 20Gi

--- a/examples/backends/vllm/deploy/agg_omni_image.yaml
+++ b/examples/backends/vllm/deploy/agg_omni_image.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Qwen-Image text-to-image serving with vLLM-Omni. This is the Kubernetes
+# equivalent of launch/agg_omni_image.sh.
+# Request response_format=b64_json unless media storage is externally served.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-omni-image-agg
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/vllm-runtime:my-tag
+  - name: OmniImageWorker
+    type: worker
+    replicas: 1
+    sharedMemorySize: 16Gi
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: my-registry/vllm-runtime:my-tag
+          command:
+          - python3
+          - -m
+          - dynamo.vllm.omni
+          args:
+          - --model
+          - Qwen/Qwen-Image
+          - --output-modalities
+          - image
+          - --media-output-fs-url
+          - file:///tmp/dynamo_media
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          volumeMounts:
+          - name: media-output
+            mountPath: /tmp/dynamo_media
+        volumes:
+        - name: media-output
+          emptyDir:
+            sizeLimit: 20Gi


### PR DESCRIPTION
## Summary

Add five portable `DynamoGraphDeployment` templates for diffusion workflows. The four original image/text templates were validated on Dynamo 1.4.2. The Qwen3-TTS audio template was validated with matched **Dynamo 1.5.0.dev20260826 nightly serving images on the existing 1.4.2 chart/operator**; stock 1.4.2 serving images remain affected by #14669:

| Backend | Model / workflow | Template |
|---|---|---|
| SGLang | FLUX.1-schnell text-to-image | `examples/backends/sglang/deploy/agg_image_diffusion.yaml` |
| SGLang | LLaDA 2.0 diffusion language model | `examples/backends/sglang/deploy/agg_llm_diffusion.yaml` |
| TensorRT-LLM | FLUX.2-klein-4B text-to-image | `examples/backends/trtllm/deploy/agg_image_diffusion.yaml` |
| vLLM-Omni | Qwen-Image text-to-image | `examples/backends/vllm/deploy/agg_omni_image.yaml` |
| vLLM-Omni | Qwen3-TTS text-to-audio | `examples/backends/vllm/deploy/agg_omni_audio.yaml` |

The SGLang FLUX worker uses `shareProcessNamespace: true` to work around the SGLang 0.5.16 PID-1 parent check in the public Dynamo 1.4.2 image. That check kills a diffusion scheduler whose legitimate parent is PID 1. SGLang's upstream fix is sgl-project/sglang#31361, but the inspected 1.4.2 image still contains the old implementation. The setting applies only to the worker pod and shares process visibility among containers in that pod; the template has one application container. It should be removed when the minimum supported runtime includes the upstream correction.

Templates retain image placeholders and the conventional Hugging Face secret reference. Cluster-specific node selection, cache/PVC mounts, and private deployment names are not included. The audio template documents the exact public nightly image pair tested and sets `runtimeVersionOverride: "1.5.0"` on both components; replace both image placeholders together. The version override describes the serving image, not the Helm/operator version.

This PR is intentionally templates-only. Fern pages, README changes, handoff/status notes, runtime changes, and launch-script edits are deferred. Cases with malformed sample output, video color corruption, blocked LoRA lifecycle validation, or diagnostic-only disaggregated results are not included.

## Validation

The original four cases were functionally validated on September 10, 2026 UTC with H100 GPUs and matched Dynamo 1.4.2 chart/operator, frontend, and backend runtime versions. Audio was validated separately on September 18, 2026 UTC as described below. Each included template uses one GPU for its worker.

| Case | Live result |
|---|---|
| SGLang FLUX | Controlled A/B: original PID layout reproduced scheduler `-9` / `EOFError`; changing only the worker's `shareProcessNamespace` setting reached Ready and returned a strict-valid, visually coherent 1024x1024 PNG. |
| SGLang LLaDA | Ready, expected model listed, HTTP 200 and a coherent non-empty chat completion. |
| TensorRT-LLM FLUX.2 | Ready, expected model listed, HTTP 200 and a strict-valid, visually coherent 256x256 PNG from the 10-step request. |
| vLLM Qwen Image | Ready, expected model listed, HTTP 200 and strict-valid 512x512 PNGs for 4-step and 20-step requests; the 20-step output passed visual review. |

### Audio validation: September 18, 2026 UTC

The exact request from #14669 passed **3/3** times with these matched images:

| Component | Tested image |
|---|---|
| Frontend | `nvcr.io/nvidia/ai-dynamo/dynamo-frontend-nightly:20260826-27f09d5` |
| Worker | `nvcr.io/nvidia/ai-dynamo/vllm-runtime-nightly:20260826-27f09d5` |

- Both containers report `ai-dynamo` / `ai-dynamo-runtime` **1.5.0.dev20260826**; worker packages are **vLLM 0.27.1** and **vLLM-Omni 0.27.0rc1**.
- The source commit is `27f09d5bcdcf333aa1a74b73245b2ccaff23f91c`, which contains the #12100 fix commit `a97afd2d51819f88d1033522312137b35feabc9d`. This was the earliest matching dated frontend/worker pair found after the fix; `20260825-f7de8eb` does not contain it.
- The existing **1.4.2 chart/operator was not upgraded**. Live pod image IDs matched the registry digests, the model was listed, the DGD reached Ready, and both pods had zero restarts.

| Trial | HTTP | WAV bytes | Audio duration | Nonzero PCM samples |
|---|---:|---:|---:|---:|
| 1 | 200 | 176,684 | 3.68 s | 85,347 |
| 2 | 200 | 153,644 | 3.20 s | 73,339 |
| 3 | 200 | 157,484 | 3.28 s | 76,519 |

All outputs were 24 kHz mono PCM16 with one RIFF header. Each retained the initial 80 ms of silence **and continued with non-silent audio**, rather than returning only the 3,884-byte silent chunk. WAV responses are raw audio bytes, not a JSON/base64 envelope. The template calls this out explicitly.

This validates waveform delivery and framing, not listening/transcription quality or general mixed-version compatibility. It does not claim that stock 1.4.2 serving images are fixed or that the fix has been backported. Temporary test resources were removed after capture; the shared platform and existing workloads were left unchanged.

### Manifest and documentation checks

- Parse all five YAMLs. The four original templates retain their September 10 release-aligned rendering checks.
- Confirm rendered functional specs match the successful live-test manifests; only the FLUX diagnostic run's temporary hostname pin is omitted. The new audio template was rendered with the tested image pair and infrastructure adaptations and compared equal to the exact successful September 18 DGD.
- Kubernetes server-side dry-run: the original four passed during branch preparation; the new audio template passed a fresh server-side dry-run on September 18. The publication-time checks did not create cluster workloads.
- Targeted documentation lint (`--no-nav`): **5 files, zero findings/errors**.
- Existing CODEOWNERS rules cover all five paths.
- Staged whitespace check passed.
- Full documentation lint: zero errors (eight existing warnings in unchanged docs).
- `fern check`: zero errors, two warnings, with the generated, ignored Python/Rust API references present.
- `fern docs broken-links` reports one pre-existing link error in `docs/fern/pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx`, targeting `/dynamo/recipes/model-recipes/deepseek-v4-pro`. The page/link is unchanged from the upstream base (`82a57feb01b`); this PR changes no docs pages or navigation. No unrelated docs fix is included.

These are functional validations, not performance benchmarks. Runtime-image digests, installed Dynamo package versions, and generated outputs were checked during the live validations. Full repository CI has not been run locally; GitHub CI status will be tracked on the draft PR.

Related: #13383 and #14669. The audio runtime fix itself is #12100; this PR adds only its validated Kubernetes example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kubernetes deployment examples for aggregated multimodal inference workloads.
  - Added image-generation deployments using SGLang, TensorRT-LLM, and vLLM-Omni.
  - Added audio-generation deployment support using vLLM-Omni.
  - Added diffusion-language-model deployment support using SGLang.
  - Examples include GPU allocation, Hugging Face authentication, media output storage, and configurable runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->