### PR TITLE
fix(router): stop a decode-worker pin failing disaggregated requests

### DIFF
--- a/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
+++ b/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
@@ -33,7 +33,7 @@ Include `nvext` as a top-level field alongside standard OpenAI-compatible fields
 | `greed_sampling` | `bool` | `None` | Preprocessor | Forces greedy sampling regardless of other sampling parameters. |
 | `use_raw_prompt` | `bool` | `None` | Preprocessor | Bypasses the prompt template and passes the prompt directly to the tokenizer. |
 | `annotations` | `string[]` | `None` | Preprocessor | Triggers out-of-band information in the SSE stream via the `event:` field. |
-| `backend_instance_id` | `u64` | `None` | Router | Routes the request to a specific backend instance. |
+| `backend_instance_id` | `u64` | `None` | Router | Routes the request to a specific token-generating instance: the decode worker in disaggregated serving, or the single worker in an aggregated deployment. It never pins the prefill worker; use `prefill_worker_id` for that. |
 | `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When present, the frontend skips tokenization. |
 | `max_thinking_tokens` | `u32` | `None` | Backend | Maximum thinking tokens allowed (passed through to backends). |
 | `cache_salt` | `string` | `None` | Router / supported backends | Namespaces Dynamo KV routing. vLLM and TensorRT-LLM also isolate backend KV-cache reuse; see [Backend support](#backend-support). This is the recommended cache-isolation input. |
@@ -67,6 +67,8 @@ Routing fields can also be set via HTTP headers, which take priority over `nvext
 | `x-dynamo-dp-rank` | `dp_rank` |
 | `x-dynamo-prefill-dp-rank` | `prefill_dp_rank` |
 | `x-tenant-id` | `cache_salt` |
+
+In disaggregated serving, `x-dynamo-worker-instance-id` pins only the token-generating worker; the prefill hop still routes freely unless you also send `x-dynamo-prefill-instance-id`.
 
 > [!WARNING]
 > The unprefixed forms (`x-worker-instance-id`, `x-prefill-instance-id`, `x-dp-rank`,

--- a/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
+++ b/docs/fern/pages/developer-guide/additional-resources/nvidia-request-extensions-nvext.md
@@ -68,7 +68,7 @@ Routing fields can also be set via HTTP headers, which take priority over `nvext
 | `x-dynamo-prefill-dp-rank` | `prefill_dp_rank` |
 | `x-tenant-id` | `cache_salt` |
 
-In disaggregated serving, `x-dynamo-worker-instance-id` pins only the token-generating worker; the prefill hop still routes freely unless you also send `x-dynamo-prefill-instance-id`.
+In disaggregated serving, `x-dynamo-worker-instance-id` pins only the token-generating worker; the prefill hop still routes freely unless you also send `x-dynamo-prefill-instance-id`. The same split applies to the ranks: `x-dynamo-dp-rank` is the token-generating worker's rank and is never applied to the prefill hop, so pin a prefill rank with `x-dynamo-prefill-dp-rank`.
 
 > [!WARNING]
 > The unprefixed forms (`x-worker-instance-id`, `x-prefill-instance-id`, `x-dp-rank`,

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -422,7 +422,7 @@ fn pinned_worker_hint(
     let routing = routing?;
     match phase {
         RequestPhase::Prefill => {
-            let worker_id = routing.prefill_worker_id.or(routing.backend_instance_id)?;
+            let worker_id = routing.prefill_worker_id?;
             let dp_rank = routing.prefill_dp_rank.or(routing.dp_rank);
             Some((worker_id, dp_rank))
         }
@@ -529,6 +529,28 @@ mod tests {
         assert_eq!(
             pinned_worker_hint(RequestPhase::Aggregated, Some(&routing)),
             Some((5, Some(7)))
+        );
+    }
+
+    #[test]
+    fn pinned_worker_hint_prefill_ignores_backend_instance_id() {
+        let routing = RoutingHints {
+            backend_instance_id: Some(1),
+            dp_rank: Some(0),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Prefill, Some(&routing)),
+            None
+        );
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Decode, Some(&routing)),
+            Some((1, Some(0)))
+        );
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Aggregated, Some(&routing)),
+            Some((1, Some(0)))
         );
     }
 

--- a/lib/llm/src/kv_router/routing_host/kv_selection.rs
+++ b/lib/llm/src/kv_router/routing_host/kv_selection.rs
@@ -423,8 +423,7 @@ fn pinned_worker_hint(
     match phase {
         RequestPhase::Prefill => {
             let worker_id = routing.prefill_worker_id?;
-            let dp_rank = routing.prefill_dp_rank.or(routing.dp_rank);
-            Some((worker_id, dp_rank))
+            Some((worker_id, routing.prefill_dp_rank))
         }
         RequestPhase::Decode => {
             let worker_id = routing.decode_worker_id.or(routing.backend_instance_id)?;
@@ -551,6 +550,24 @@ mod tests {
         assert_eq!(
             pinned_worker_hint(RequestPhase::Aggregated, Some(&routing)),
             Some((1, Some(0)))
+        );
+    }
+
+    #[test]
+    fn pinned_worker_hint_prefill_ignores_decode_dp_rank() {
+        let routing = RoutingHints {
+            prefill_worker_id: Some(2),
+            dp_rank: Some(3),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Prefill, Some(&routing)),
+            Some((2, None))
+        );
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Decode, Some(&routing)),
+            None
         );
     }
 

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -767,11 +767,7 @@ mod tests {
             ..Default::default()
         });
 
-        for phase in [
-            RequestPhase::Aggregated,
-            RequestPhase::Prefill,
-            RequestPhase::Decode,
-        ] {
+        for phase in [RequestPhase::Aggregated, RequestPhase::Decode] {
             let permit = tracker.set_phase(phase).await;
             for error_type in [ErrorType::Disconnected, ErrorType::WorkerOverloaded] {
                 let error = migratable_error(error_type);
@@ -782,6 +778,18 @@ mod tests {
             }
             drop(permit);
         }
+
+        // A backend pin names the worker that generates tokens, so it leaves the
+        // prefill hop unpinned and that hop stays migratable.
+        let permit = tracker.set_phase(RequestPhase::Prefill).await;
+        for error_type in [ErrorType::Disconnected, ErrorType::WorkerOverloaded] {
+            let error = migratable_error(error_type);
+            assert!(
+                is_migratable_for_request(&request, &error),
+                "backend pin must not block {error_type:?} migration during prefill"
+            );
+        }
+        drop(permit);
     }
 
     #[tokio::test]

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -910,10 +910,7 @@ pub fn explicit_target(
         return Ok(None);
     };
     let (worker_id, dp_rank) = match phase {
-        RequestPhase::Prefill => (
-            routing.prefill_worker_id.or(routing.backend_instance_id),
-            routing.prefill_dp_rank.or(routing.dp_rank),
-        ),
+        RequestPhase::Prefill => (routing.prefill_worker_id, routing.prefill_dp_rank),
         RequestPhase::Decode | RequestPhase::Aggregated => (
             routing.decode_worker_id.or(routing.backend_instance_id),
             routing.dp_rank,

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -131,6 +131,28 @@ fn session_affinity_explicit_targets_are_phase_local_and_preserve_rank_zero() {
 }
 
 #[test]
+fn session_affinity_prefill_target_ignores_backend_instance_id() {
+    let request = request_with_routing(RoutingHints {
+        backend_instance_id: Some(1),
+        dp_rank: Some(0),
+        ..Default::default()
+    });
+
+    assert_eq!(
+        explicit_target(&request, RequestPhase::Prefill).unwrap(),
+        None
+    );
+    assert_eq!(
+        explicit_target(&request, RequestPhase::Decode).unwrap(),
+        Some(target(1, Some(0)))
+    );
+    assert_eq!(
+        explicit_target(&request, RequestPhase::Aggregated).unwrap(),
+        Some(target(1, Some(0)))
+    );
+}
+
+#[test]
 fn session_affinity_context_type_errors_are_preserved() {
     let mut request = Context::new(request_with_routing(RoutingHints::default()));
     request.insert(SESSION_AFFINITY_CONTEXT_KEY, "wrong type".to_string());

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -153,6 +153,20 @@ fn session_affinity_prefill_target_ignores_backend_instance_id() {
 }
 
 #[test]
+fn session_affinity_prefill_target_ignores_decode_dp_rank() {
+    let request = request_with_routing(RoutingHints {
+        prefill_worker_id: Some(2),
+        dp_rank: Some(3),
+        ..Default::default()
+    });
+
+    assert_eq!(
+        explicit_target(&request, RequestPhase::Prefill).unwrap(),
+        Some(target(2, None))
+    );
+}
+
+#[test]
 fn session_affinity_context_type_errors_are_preserved() {
     let mut request = Context::new(request_with_routing(RoutingHints::default()));
     request.insert(SESSION_AFFINITY_CONTEXT_KEY, "wrong type".to_string());


### PR DESCRIPTION
Source issue: [DYN-4339](https://linear.app/nvidia/issue/DYN-4339).

## Summary

In a prefill/decode-disaggregated deployment, a request that pinned only the token-generating worker with `x-dynamo-worker-instance-id` failed with `HTTP 500` and the body `Pinned worker <id> dp_rank 0 is not eligible: worker <id> is unavailable`. The prefill hop resolved its own pin from the generic `backend_instance_id` field and then looked that decode worker up in a map that holds only prefill-pool workers, so the lookup always missed. Such a request now routes prefill freely and honours the pin at the decode hop.

## Details:

The fix is a removal at the two functions that feed the single merged prefill pin. The `RequestPhase::Prefill` arm of `pinned_worker_hint` (`lib/llm/src/kv_router/routing_host/kv_selection.rs`) and of `explicit_target` (`lib/llm/src/session_affinity/coordinator.rs`) no longer fall back to `backend_instance_id` or the generic `dp_rank` in either function. The `Decode` and `Aggregated` arms are untouched, so an aggregated deployment pinned by the same header behaves exactly as before, and pinning a prefill worker still uses `prefill_worker_id` / `x-dynamo-prefill-instance-id`.

Four regression tests cover the prefill arms: backend-only hints leave prefill unpinned while decode and aggregated still resolve the pin, and generic `dp_rank` does not leak into an explicit prefill pin. One existing test, `explicit_worker_pin_blocks_migration_for_worker_failures` in `lib/llm/src/migration.rs`, asserted that a `backend_instance_id` pin blocks migration in all three phases; it now asserts that the pin blocks migration during `Aggregated` and `Decode` but not during `Prefill`, the same shape the sibling test already asserts for `decode_worker_id`. The `nvext` field reference is corrected to match.

## Where should the reviewer start?

`lib/llm/src/kv_router/routing_host/kv_selection.rs` and `lib/llm/src/session_affinity/coordinator.rs` hold the four deleted fallbacks. Then read the rewritten migration test in `lib/llm/src/migration.rs` — the one pre-existing assertion this change inverts.

## Validation

The prior implementation run reported `cargo test -p dynamo-llm --lib` passing (`2693 passed; 0 failed; 5 ignored`) on `ac93777f8725f5eddd3ff196e21c9838d848a453`, including all four new tests and the rewritten migration test. `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets --no-deps -- -D warnings`, and `cargo fmt --all --check` are clean. A disaggregated vLLM prefill/decode pair was started on one GPU, and a completion request carrying only `x-dynamo-worker-instance-id` returned `HTTP 200` where it previously returned `HTTP 500`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

No related GitHub issue; the internal source ticket is linked above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how worker-routing hints apply to decode and prefill workers in disaggregated deployments.
  * Documented that decode-worker pinning does not automatically pin prefill workers.

* **Bug Fixes**
  * Prefill requests now honor only explicit prefill-worker routing hints.
  * Backend instance pins no longer incorrectly prevent prefill migration or create prefill session-affinity targets.
  * Decode and aggregated routing behavior remains unchanged.

* **Tests**
  * Added regression coverage for routing, migration, and session-affinity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->