### PR TITLE
docs(replay): map removed Replay CLI to AISimulate

### DIFF
--- a/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
+++ b/docs/fern/pages/cli/operations/simulation-with-dynosim/dynosim-replay.mdx
@@ -5,6 +5,13 @@ title: Run a DynoSim Simulation
 subtitle: Predict a synthetic workload or saved trace against one simulated configuration
 ---
 
+<Note>
+The legacy `python -m dynamo.replay` CLI has been removed. Follow the
+[Replay migration map](../../../reference/components/dynosim-replay-cli-reference.mdx#migration-from-dynamo-replay)
+to select the AISimulate command for your workload and check which SDK and live worker paths remain
+available.
+</Note>
+
 A DynoSim prediction evaluates one workload against one simulated Dynamo configuration. AISimulate
 drives the simulated engine cores directly without starting a frontend, registering workers, or
 sending HTTP requests. It runs on CPUs and writes an AIPerf-style summary and JSON report.

--- a/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
+++ b/docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx
@@ -14,11 +14,33 @@ For an end-to-end workflow, see
 search configuration domains, see
 [Sweep DynoSim Configurations](../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx).
 
+## Migration from Dynamo Replay
+
 <Warning>
-The former Replay `online` mode has no replacement in the unified AISimulate CLI yet. `aisimulate
-predict` and `aisimulate recommend` are offline-only. The separate `python3 -m dynamo.mocker`
-command remains available for launching live workers but does not provide replay orchestration.
+**Removed CLI.** `python -m dynamo.replay` was removed when Dynamo adopted the unified AISimulate
+CLI. There is no compatibility command or warning period for this entry point. Choose a replacement
+by workload below.
 </Warning>
+
+| Workflow | Current entry point |
+|---|---|
+| Engine-only offline prediction | `aisimulate predict --stack engine` |
+| Offline prediction through Dynamo, including Router or Planner adapters | `aisimulate predict --stack dynamo` |
+| Search simulated configurations | `aisimulate recommend --stack engine` or `aisimulate recommend --stack dynamo` |
+| Public Replay `online` CLI | No unified CLI replacement yet; the Python replay SDK retains online mode |
+
+Build a public prediction or recommendation YAML file and pass it with `--config`. The removed
+Replay flags are not aliases for the new YAML fields. Use the [prediction
+walkthrough](../../cli/operations/simulation-with-dynosim/dynosim-replay.mdx) or [recommendation
+walkthrough](../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx) for complete Dynamo
+examples, and the [AISimulate overview](../../developer-guide/knowledge-base/modular-components/ai-simulate-experimental/overview.md)
+for stack ownership and installation.
+
+The removal applies to the CLI. The `dynamo.replay` Python API remains available for single-run
+replay, Router and Planner integration, and online replay. Some [SDK trace
+capabilities](#typed-agentic-replay-through-the-dynamo-api) are not exposed by the unified CLI.
+`python3 -m dynamo.mocker` remains the supported live worker launcher; it does not orchestrate replay
+traffic. `aisimulate predict` and `aisimulate recommend` are offline-only.
 
 ## Command
 


### PR DESCRIPTION
## Summary

The removed `python -m dynamo.replay` command had no explicit old-to-new mapping in the current replay guide. Add a migration table for engine prediction, Dynamo prediction, configuration search, and online replay availability, linked from the simulation walkthrough.

## Details

The notice preserves the supported replay SDK and live Mocker worker launcher. It documents the direct cutover implemented by #13665.

## Where should the reviewer start?

`docs/fern/pages/reference/components/dynosim-replay-cli-reference.mdx`

## Validation

- Full docs lint: passed with zero errors; existing navigation/style advisories remain.
- Changed-file pre-commit hooks and `git diff --check`: passed.
- Generated Python and Rust API reference pages, then ran Fern 5.80.2 configuration validation: zero errors.
- Fern broken-link scan: no findings in the changed pages. It reports one existing link in `docs/fern/pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx:254`, pointing to `/dynamo/recipes/model-recipes/deepseek-v4-pro`; that file is unchanged from base `b5bd1a1fbe`. The command exits zero despite reporting that diagnostic.
- Documentation-only change; runtime interfaces and behavior are unchanged.

## Related Issues

- Relates to #13583.
- Follow-up to #13665.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the removal of the legacy `python -m dynamo.replay` command.
  - Added migration guidance for selecting the appropriate AISimulate command and YAML configuration by workflow.
  - Clarified that Python replay APIs remain supported.
  - Documented the unified CLI’s offline-only behavior and identified remaining SDK and live worker paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->