### PR TITLE
docs(sizing): clarify AISimulate ownership of retained AIC workflows

### DIFF
--- a/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
+++ b/docs/fern/pages/cli/disaggregated-serving/sizing-with-aiconfigurator.mdx
@@ -5,6 +5,13 @@ title: Size a Local Deployment with AIConfigurator
 subtitle: Choose parallelism and worker counts before launching local Dynamo processes
 ---
 
+<Note>
+**AISimulate compatibility path.** This guide uses the retained `aiconfigurator` sizing command
+shipped by AISimulate. Install AISimulate as shown below and keep these command names and arguments.
+See [AISimulate ownership and compatibility](../../developer-guide/additional-resources/aiconfigurator-reference.md#aisimulate-ownership-and-compatibility)
+for the distinction between analytical sizing and the unified prediction and recommendation CLI.
+</Note>
+
 AIConfigurator estimates inference performance across candidate parallelism and deployment layouts.
 Use it before launching a local Dynamo deployment to choose tensor parallelism (TP), pipeline
 parallelism (PP), and the number of worker replicas to validate.

--- a/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
+++ b/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
@@ -39,7 +39,7 @@ layouts and can generate deployment artifacts for the selected target.
 > entry points provided by AISimulate. Follow the pinned AISimulate installation in [Quick
 > Start](#quick-start); do not install a separate `aiconfigurator` or `aiconfigurator-core` package.
 
-[AISimulate](https://github.com/ai-dynamo/aisimulate) maintains the performance models, analytical
+[AISimulate](https://pypi.org/project/aisimulate/) maintains the performance models, analytical
 sizing code, and deployment-artifact generator used here. The retained command and import names
 allow existing sizing workflows and Dynamo's Profiler integration to continue working.
 

--- a/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
+++ b/docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md
@@ -32,6 +32,27 @@ layouts and can generate deployment artifacts for the selected target.
 > [Supported Configurations](#supported-configurations) for the full matrix and
 > alternatives.
 
+## AISimulate Ownership and Compatibility
+
+> [!NOTE]
+> **Retained sizing interface.** The `aiconfigurator cli` commands on this page are compatibility
+> entry points provided by AISimulate. Follow the pinned AISimulate installation in [Quick
+> Start](#quick-start); do not install a separate `aiconfigurator` or `aiconfigurator-core` package.
+
+[AISimulate](https://github.com/ai-dynamo/aisimulate) maintains the performance models, analytical
+sizing code, and deployment-artifact generator used here. The retained command and import names
+allow existing sizing workflows and Dynamo's Profiler integration to continue working.
+
+For request-level offline prediction and configuration search, start with the [AISimulate
+workflows](../knowledge-base/modular-components/ai-simulate-experimental/overview.md) and their
+`aisimulate predict` and `aisimulate recommend` commands. These use public YAML configurations and
+have different inputs and outputs from the analytical sizing modes below. Keep the retained sizing
+commands when you need those modes or their deployment artifacts; changing only the executable
+name is not a migration.
+
+The support-matrix links below describe compatibility coverage for these retained sizing workflows.
+Check coverage for the model, system, backend, and version used by your installed release.
+
 ## When to Use AIConfigurator
 
 When deploying LLMs with Dynamo, you need to make several critical decisions:

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -11,6 +11,13 @@ The Dynamo Profiler analyzes model inference performance and generates optimized
 
 The profiler accepts a `DynamoGraphDeploymentRequestSpec` (DGDR) as input and uses [AIConfigurator (AIC)](../../../additional-resources/aiconfigurator-reference.md) compatibility APIs from the `aisimulate` wheel for performance simulation, candidate enumeration, and configuration picking. When the Planner is enabled, the profiler also emits the native AIC model identity and can generate optional engine interpolation curves used to bootstrap runtime autoscaling.
 
+> [!NOTE]
+> **AISimulate owns the sizing implementation.** The Profiler remains a supported Dynamo
+> component and consumes the retained AIC APIs shipped in AISimulate. The `aiconfigurator` and
+> `aiconfigurator_core` import names do not require separate legacy distributions. See
+> [AISimulate ownership and compatibility](../../../additional-resources/aiconfigurator-reference.md#aisimulate-ownership-and-compatibility)
+> for installation and the distinction from standalone prediction and recommendation workflows.
+
 ## Workflow
 
 - **What** model you want to deploy (`model`)

--- a/docs/fern/pages/kubernetes/disaggregated-serving/sizing-with-aiconfigurator.mdx
+++ b/docs/fern/pages/kubernetes/disaggregated-serving/sizing-with-aiconfigurator.mdx
@@ -5,6 +5,13 @@ title: Size a Kubernetes Deployment with AIConfigurator
 subtitle: Generate a tensor- and pipeline-parallel layout for your DGD worker from a latency target
 ---
 
+<Note>
+**AISimulate compatibility path.** This guide uses the retained `aiconfigurator` sizing command
+shipped by AISimulate. Install AISimulate as shown below and keep these command names and arguments.
+See [AISimulate ownership and compatibility](../../developer-guide/additional-resources/aiconfigurator-reference.md#aisimulate-ownership-and-compatibility)
+for the distinction between analytical sizing and the unified prediction and recommendation CLI.
+</Note>
+
 This page is a detour from the **Determine topology and parallelism** step of [Deploy with DGD](../model-deployment/deploy-with-dgd.md). Rather than hand-pick tensor- and pipeline-parallel sizes, run AIConfigurator to search layouts against a latency target, then copy the recommended parallelism into your worker. It covers parallelism sizing only. For the full workflow — aggregated versus disaggregated comparison, generating complete manifests, and validating with AIPerf — see the [AIConfigurator](../../developer-guide/additional-resources/aiconfigurator-reference.md) reference.
 
 <Note>


### PR DESCRIPTION
## Summary

Dynamo sizing guides still lead with AIConfigurator without a prominent explanation of the retained compatibility interface. Add notices to the local and Kubernetes guides and a shared ownership section in the reference.

## Details

Clarify that AISimulate supplies the command and import namespaces, distinguish analytical sizing from the unified prediction/recommendation CLI, and link the supported Profiler integration to that explanation. Existing commands, package pins, support-matrix links, and page URLs remain valid.

## Where should the reviewer start?

`docs/fern/pages/developer-guide/additional-resources/aiconfigurator-reference.md`

## Validation

- Full docs lint: passed with zero errors; existing navigation/style advisories remain.
- Changed-file pre-commit hooks and `git diff --check`: passed.
- Generated Python and Rust API reference pages, then ran Fern 5.80.2 configuration validation: zero errors.
- Fern broken-link scan: no findings in the changed pages. It reports one existing link in `docs/fern/pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx:254`, pointing to `/dynamo/recipes/model-recipes/deepseek-v4-pro`; that file is unchanged from base `b5bd1a1fbe`. The command exits zero despite reporting that diagnostic.
- Documentation-only change; runtime interfaces and behavior are unchanged.

## Related Issues

- Relates to #13583.
- Follow-up to #13665.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified AISimulate compatibility for retained AIConfigurator sizing commands.
  * Documented installation guidance, supported command and argument stability, and compatibility requirements.
  * Explained the distinction between analytical sizing and unified prediction and recommendation workflows.
  * Added guidance on legacy import names and support-matrix verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->