### PR TITLE
docs(sweeper): distinguish retained SDK from unified CLI

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/configuration.md
@@ -8,6 +8,11 @@ subtitle: Core fields and optional adapter-owned search spaces
 > [!WARNING]
 > **Experimental.** Sweeper's configuration schema may change without a standard deprecation period.
 
+> [!NOTE]
+> **Retained Python SDK schema.** These fields belong to `SmartSearchConfig`, not the public
+> `aisimulate recommend` YAML. See [SDK and CLI configuration](overview.md#sdk-and-cli-configuration)
+> for migration guidance and the public recommendation reference.
+
 `SmartSearchConfig.search_space` contains backend and deployment fields. Optional feature-specific
 search spaces are mappings under `SmartSearchConfig.adapters`.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/overview.md
@@ -10,6 +10,13 @@ subtitle: Experimental backend-neutral configuration search
 > planning. Its API, configuration schema, search behavior, and output may change without a
 > standard deprecation period.
 
+> [!NOTE]
+> **Retained Python SDK.** This section documents `SmartSearchConfig` and `Sweeper.run` for
+> applications that inject a replay runtime. For new command-line workflows, start with
+> [Sweep DynoSim Configurations](../../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx)
+> and `aisimulate recommend --stack dynamo`. See [SDK and CLI
+> configuration](#sdk-and-cli-configuration) before reusing an SDK YAML file with the unified CLI.
+
 Sweeper searches deployment configurations with a black-box optimizer. It turns every suggestion
 into a versioned `ReplaySpec`, sends that specification to an injected `RunnerFactory`, and returns
 ranked candidates or a Pareto front.
@@ -31,7 +38,7 @@ of a replay. Sweeper imports a provider only when its adapter name appears in th
 
 ## Python Entry Point
 
-`Sweeper` is the only public execution interface. Supply a replay runtime explicitly:
+`Sweeper.run` executes the retained Python SDK configuration. Supply a replay runtime explicitly:
 
 ```python
 from aisimulate.sweeper import SmartSearchConfig, Sweeper
@@ -43,6 +50,19 @@ candidates = Sweeper(runner_factory=my_runner_factory).run(config)
 For the public YAML contract and stack discovery, use `aisimulate recommend --config
 recommendation.yaml`. The `Sweeper` class remains available for callers that need the legacy Python
 SDK configuration and an explicitly injected runtime.
+
+## SDK and CLI Configuration
+
+| Interface | Configuration and execution |
+|---|---|
+| Retained Python SDK | `SmartSearchConfig` with `search_space`, `workload`, `goal`, `sweep`, and optional `adapters`; the application supplies a `RunnerFactory` |
+| Unified CLI | Public recommendation YAML with `engine`, `optimization`, and optional `traffic`, `evaluation`, and `optimizer`; `--stack dynamo` loads Dynamo's runner and top-level `router` and `planner` adapters |
+
+The SDK YAML examples in this section are not input files for `aisimulate recommend --config`.
+Re-express the workload, search domains, and objectives using the [recommendation
+reference](../../../../../reference/components/dynosim-sweep-reference.mdx), then validate the
+result with the unified CLI. The SDK remains available for existing integrations and explicit
+runner injection; this guidance does not deprecate Dynamo's Router or Planner providers.
 
 ## Compatibility
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/quickstart.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/quickstart.md
@@ -9,6 +9,13 @@ subtitle: Run a backend-neutral sweep with an injected replay runtime
 > **Experimental.** Sweeper is intended for evaluation and feedback, not production capacity
 > planning.
 
+> [!NOTE]
+> **Retained Python SDK.** This quickstart uses `SmartSearchConfig` and an application-supplied
+> runner. For a command-line sweep, follow [Sweep DynoSim
+> Configurations](../../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx).
+> The SDK YAML file below cannot be passed directly to `aisimulate recommend`; see [SDK and CLI
+> configuration](overview.md#sdk-and-cli-configuration).
+
 Install AISimulate:
 
 ```bash

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/tutorial.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/tutorial.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Sweeper Tutorial
 subtitle: Configure, execute, and inspect a replay-backed search
@@ -8,6 +8,12 @@ subtitle: Configure, execute, and inspect a replay-backed search
 > [!WARNING]
 > **Experimental.** Sweeper's API and search behavior may change without a standard deprecation
 > period.
+
+> [!NOTE]
+> **Retained Python SDK.** The YAML fragments in this tutorial build a `SmartSearchConfig` for
+> `Sweeper.run`. For `aisimulate recommend --stack dynamo`, use the [public recommendation
+> walkthrough](../../../../../cli/operations/simulation-with-dynosim/dynosim-sweeps.mdx) instead.
+> See [SDK and CLI configuration](overview.md#sdk-and-cli-configuration) for the schema boundary.
 
 ## 1. Define the Backend Search
 


### PR DESCRIPTION
## Summary

The Sweeper quickstart, tutorial, and configuration page teach `SmartSearchConfig` without identifying its boundary with the unified CLI. Label these as retained SDK guidance and route command-line users to the current recommendation workflow.

## Details

Add a schema comparison, explain that SDK YAML cannot be passed directly to `aisimulate recommend`, and correct the claim that `Sweeper` is the only public execution interface. Preserve the supported Router and Planner providers.

## Where should the reviewer start?

`docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/sweeper-experimental/overview.md`

## Validation

- Full docs lint: passed with zero errors; existing navigation/style advisories remain.
- Changed-file pre-commit hooks and `git diff --check`: passed.
- Generated Python and Rust API reference pages, then ran Fern 5.80.2 configuration validation: zero errors.
- Fern broken-link scan: no findings in the changed pages. It reports one existing link in `docs/fern/pages/recipes/model-recipes/deepseek-v4-pro-0813.mdx:254`, pointing to `/dynamo/recipes/model-recipes/deepseek-v4-pro`; that file is unchanged from base `b5bd1a1fbe`. The command exits zero despite reporting that diagnostic.
- Documentation-only change; runtime interfaces and behavior are unchanged.

## Related Issues

- Relates to #13583.
- Follow-up to #13665.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Sweeper guides use the retained Python SDK and its `SmartSearchConfig` format.
  * Directed command-line users to the appropriate DynoSim sweep and recommendation documentation.
  * Documented differences between SDK and CLI configuration formats, including migration and validation guidance.
  * Updated tutorial copyright coverage through 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->