### PR TITLE
fix(ci): name test artifacts from the test_type input, not GITHUB_ENV

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -104,10 +104,9 @@ runs:
         HF_XET_HIGH_PERFORMANCE: 1
         PYTEST_DD_FLAKY_RETRY_ENABLED: ${{ inputs.dd_flaky_retry_enabled }}
       run: |
-        # Sanitize test_type for filenames: remove commas and spaces. Exported
-        # for the per-stage upload steps' artifact names.
+        # Sanitize test_type for the JUnit and coverage filenames this step
+        # writes: remove commas and spaces.
         STR_TEST_TYPE=$(echo "${TEST_TYPE}" | tr ', ' '_')
-        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
 
         if [[ "${GPU_TESTS}" == "true" ]]; then
           # Only GPU tests require MinIO (LoRA tests). Wait for the job service.
@@ -298,11 +297,15 @@ runs:
     # pipeline consumes them by name. `always()` because the step above exits
     # with the pytest status. The JUnit upload happens once per job in
     # shared-test.yml.
+    # `test_type` is the only part of these names that distinguishes the stages
+    # a single job runs, and upload-artifact rejects a duplicate name with a
+    # non-retryable 409. Callers must pass a filename-safe value that is unique
+    # per stage; GitHub expressions have no `replace()` to sanitize it here.
     - name: Upload Coverage Data
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always() && inputs.enable_coverage == 'true'
       with:
-        name: coverage-python-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        name: coverage-python-${{ inputs.framework }}-${{ inputs.test_type }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: test-results/
         include-hidden-files: true
         retention-days: 7
@@ -311,7 +314,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
-        name: allure-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        name: allure-results-${{ inputs.framework }}-${{ inputs.test_type }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: test-results/allure-results/
         retention-days: 7
         if-no-files-found: ignore


### PR DESCRIPTION
## Overview:

### Summary

Framework test jobs have been failing intermittently with all tests passing:

```
##[error]Failed to CreateArtifact: Received non-retryable error: Failed request:
(409) Conflict: an artifact with this name already exists on the workflow run
```

`shared-test.yml` invokes `.github/actions/pytest-local` four times per job (CPU,
CPU e2e, GPU parallel, GPU sequential). The per-stage Allure and coverage artifact
names were built from `env.STR_TEST_TYPE`, exported to `$GITHUB_ENV` by the long
`Run pytest` step. Every other component of those names is identical across the
four stages — `framework` is always the literal `unknown`, and `platform_arch`,
`run_id` and `check_run_id` are fixed per job — so that export was the only thing
making them unique.

`$GITHUB_ENV` writes are job-scoped, so `env.STR_TEST_TYPE` is not a per-stage
value: it is whatever the last stage that successfully wrote it left behind. When
the `Run pytest` step's script does not run to completion the export is lost and
the stage silently inherits the **previous stage's** value — which is precisely
the value guaranteed to collide. `upload-artifact` rejects the duplicate with a
non-retryable 409, failing the step, the job, and the `backend-status-check` gate.

`test_type` is already an action input, so this reads it directly. `inputs` is
resolved at the call site before the step runs, so nothing the step does or fails
to do can affect it, and it removes the `$GITHUB_ENV` round trip without adding a
hook round trip back.

Observed on three GPU test jobs in one evening, always in a GPU stage:

| job | affected stage(s) |
|---|---|
| [103046830380](https://github.com/ai-dynamo/dynamo/actions/runs/34528514299/job/103046830380) (vLLM) | `pre_merge_gpu_parallel`, `pre_merge_gpu` |
| [103064712215](https://github.com/ai-dynamo/dynamo/actions/runs/34531961840/job/103064712215) (vLLM) | `pre_merge_gpu_parallel` |
| [103061212268](https://github.com/ai-dynamo/dynamo/actions/runs/34529497593/job/103061212268) (SGLang) | `pre_merge_gpu` |

In every case the affected stage is exactly the one whose epilogue is missing from
the log (`🧪 Tests completed with exit code`, `📊 N tests completed`, `📝 Renamed
XML file to:`), and every stage that prints its epilogue gets the correct name.

### Scope — what this does not fix

This addresses the name collision only. The underlying cause is that the
`Run pytest` step's script is sometimes truncated while still being reported
`outcome=success`, which has two further consequences that remain open:

- `exit ${TEST_EXIT_CODE}` never runs, so a GPU stage with real test failures can
  be reported green. This predates the step collapse — the pre-#14352 action read
  `TEST_EXIT_CODE` from `$GITHUB_ENV` written by the same long step, so a
  truncated step gave `exit` with no argument there too.
- The stage's JUnit XML never gets its per-stage name and is overwritten by the
  next stage. Job 103046830380 uploaded 2 JUnit XMLs instead of 4 and 2 Allure
  artifacts instead of 4.

Worth being explicit that after this lands, the 409 stops being the canary for
that truncation. Filed separately rather than bundled here so the CI unblock can
merge on its own.

## Details:

Both upload steps now interpolate `inputs.test_type` instead of
`env.STR_TEST_TYPE`. The shell-local `STR_TEST_TYPE` is unchanged and still names
the JUnit XML and the `.coverage.<stage>` data file; only its `$GITHUB_ENV` export
is removed, which had no readers outside this action.

The tradeoff: GitHub expressions have no `replace()`, so the `tr ', ' '_'`
sanitization cannot be reproduced in the name expression and the "must be
filename-safe and unique per stage" requirement moves to the caller. A comment
records that constraint. All four current call sites already pass safe literals.

A step output (`steps.<id>.outputs.*`) would not be an improvement — it travels
the same file-command channel, and an unset output interpolates to empty, which
would collapse all four stages to one name and collide anyway.

`.github/actions/pytest/action.yml` uses the same `env.STR_TEST_TYPE` pattern but
is not affected: it still sets it in a separate short `Process Test Results` step
immediately before its uploads. Left alone to keep this diff minimal.

## Where should the reviewer start?

The two `name:` expressions at the bottom of
`.github/actions/pytest-local/action.yml`, then the removed `$GITHUB_ENV` export
at the top of the `Run pytest` script.

### Validation

- `pre-commit run --files .github/actions/pytest-local/action.yml` passes,
  including `check yaml` and the action-pin hook.
- `bash -n` accepts the `run:` script extracted from the step.
- The action still parses to the same three steps; both upload steps interpolate
  `inputs.test_type`.
- `shared-test.yml` is the only caller of `pytest-local` and passes four
  filename-safe, mutually unique literals (`pre_merge_cpu`, `pre_merge_cpu_e2e`,
  `pre_merge_gpu_parallel`, `pre_merge_gpu`) → 4/4 distinct artifact names, where
  job 103046830380 produced 3.
- No reference to `STR_TEST_TYPE` remains outside the two pytest actions.
- [ ] Full CI: four distinct `allure-results-unknown-<test_type>-<arch>-<run>-<job>`
  artifacts on each framework `Test ... amd64` job (three on SGLang and
  TensorRT-LLM, whose CPU e2e stage is skipped), with no `CreateArtifact` 409.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Relates to #14352, which introduced the dependency on the long step's
`$GITHUB_ENV` export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test artifact naming to use the provided test type value directly.
  * Test type values must now be filename-safe and unique for each stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->