### PR TITLE
fix(container): [cherry-pick 1.5.0] stop the vLLM sidecar failing to start on a missing vllm-rs (#14362)

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -176,6 +176,12 @@ COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /o
 
 {% set pip_target = "--system" if device == "cuda" else "--python /opt/venv/bin/python" %}
 {% set python_executable = "python3" if device == "cuda" else "/opt/venv/bin/python" %}
+{# cuda installs into the system interpreter (/usr/local/bin); xpu and cpu run out
+   of ${VIRTUAL_ENV} and prepend ${VIRTUAL_ENV}/bin to PATH. #}
+{% set vllm_rs_link = "/usr/local/bin/vllm-rs" if device == "cuda" else "${VIRTUAL_ENV}/bin/vllm-rs" %}
+{# Inline expression, not a block tag: render.py leaves trim_blocks off, so a tag
+   on its own line inside the RUN breaks the backslash continuation. #}
+{% set vllm_rs_required = "1" if device == "cuda" else "0" %}
 
 # The vLLM 0.28.0 release images resolve the unbounded `transformers>=5.5.3`
 # requirement to 5.15.1, but vLLM-Omni 0.28.0rc1 caps Transformers below 5.15.
@@ -492,6 +498,20 @@ expected = sys.argv[1]
 if actual != expected:
     raise RuntimeError(f"expected transformers {expected}, found {actual}")
 PY
+
+# `vllm-rs` ships inside the installed `vllm` package, not as a console script;
+# linking it keeps the binary at that package's vLLM revision. Fatal on cuda only.
+RUN set -eu; \
+    pkg="$({{ python_executable }} -c 'import os, vllm; print(os.path.dirname(vllm.__file__))')"; \
+    if [ -f "${pkg}/vllm-rs" ] && [ -x "${pkg}/vllm-rs" ]; then \
+        ln -sf "${pkg}/vllm-rs" {{ vllm_rs_link }}; \
+        vllm-rs --help >/dev/null; \
+    elif [ "{{ vllm_rs_required }}" = "1" ]; then \
+        echo "ERROR: installed vllm package (${pkg}) ships no executable vllm-rs" >&2; \
+        exit 1; \
+    else \
+        echo "WARNING: installed vllm package (${pkg}) ships no executable vllm-rs; not linking it onto PATH" >&2; \
+    fi
 
 USER dynamo
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -153,6 +153,8 @@ command.
 
 The sidecar waits for both the Control and Inference services through the standard gRPC health API before registering the worker. The deployment manifests retain lightweight socket probes for container lifecycle monitoring. The engine image must include a `vllm-rs` build compatible with the vendored protocol.
 
+The Dynamo vLLM CUDA runtime image exposes `vllm-rs` on `PATH`, linked from the `vllm` package that image installs, so `vllm-rs serve` runs there by name; that image fails to build if its `vllm` package ever stops shipping the binary. The XPU and CPU variants build from separate upstream vLLM distributions and link it the same way when it is present, but only warn when it is not, so check `command -v vllm-rs` before relying on it there. A stock upstream engine image ships the same binary inside the package but leaves it off `PATH`; `deploy/agg.yaml` and `deploy/disagg.yaml` run that image and resolve the path out of the package themselves.
+
 ### Prerequisites
 
 - A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature


### PR DESCRIPTION
Cherry-pick of #14362 to `release/1.5.0`.

This backport exposes the `vllm-rs` binary shipped in the installed vLLM package on `PATH`, allowing the vLLM sidecar launch scripts to start the engine. CUDA images fail their build if the binary is absent; XPU and CPU images warn instead.

Source issue: [DYN-4278](https://linear.app/nvidia/issue/DYN-4278)

Signed-off cherry-pick with `-x --signoff`.

Validation:
- Applied cleanly with no conflicts.
- Remote Git tree matches the locally verified cherry-pick tree (`43f324cdd52fd43562c48fa72ee2fe710d461d47`).
- `git diff --check release/1.5.0...HEAD` passed.
- Focused `pre-commit` checks were not run because `pre-commit` is unavailable in this environment.
- The CUDA runtime image build was not run locally; the repository's `vllm-build` CI job exercises it on Linux AMD64 and ARM64.