### PR TITLE
perf(replay): generate synthetic prompts on concurrency admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,8 @@ dependencies = [
 
 [[package]]
 name = "aisimulate-core"
-version = "0.1.0-dev.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa0422f239fd9b9ca92d4a57fe7069771e158293d266e05a20fde477d15b9af"
+version = "0.12.0"
+source = "git+https://github.com/ai-dynamo/aisimulate.git?rev=0480320fdd20c2e063a28a90faa111180fce8e47#0480320fdd20c2e063a28a90faa111180fce8e47"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -45,16 +44,20 @@ dependencies = [
  "derive_builder",
  "flate2",
  "indicatif 0.18.4",
+ "log",
  "parquet",
  "pep440_rs",
  "quick_cache",
+ "rand 0.8.6",
  "rand 0.9.4",
+ "rand_chacha 0.3.1",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "slotmap",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Published separately by https://github.com/ai-dynamo/aisimulate.
-aisimulate-core = { version = "=0.1.0-dev.2" }
+aisimulate-core = { git = "https://github.com/ai-dynamo/aisimulate.git", rev = "0480320fdd20c2e063a28a90faa111180fce8e47" }
 
 # Local crates
 dynamo-runtime = { path = "lib/runtime", version = "1.5.0" }

--- a/components/src/dynamo/replay/simulation.py
+++ b/components/src/dynamo/replay/simulation.py
@@ -60,12 +60,13 @@ class DynamoReplayRunnerFactory:
 
     def estimate_host_resources(self, workload, *, concurrency=None):
         """Qualify lazy allocation only when the loaded native binding supports it."""
-        from dynamo import _core
         from aisimulate.resources import (
+            WORKER_BASELINE_BYTES,
             ResourceEstimate,
             estimate_workload,
-            WORKER_BASELINE_BYTES,
         )
+
+        from dynamo import _core
 
         fallback = estimate_workload(workload, stack="dynamo", concurrency=concurrency)
         active = concurrency or workload.get("concurrency")

--- a/components/src/dynamo/replay/simulation.py
+++ b/components/src/dynamo/replay/simulation.py
@@ -58,6 +58,37 @@ class DynamoReplayRunnerFactory:
     trace_block_size: int = 512
     benchmark_granularity: int = 8
 
+    def estimate_host_resources(self, workload, *, concurrency=None):
+        """Qualify lazy allocation only when the loaded native binding supports it."""
+        from dynamo import _core
+        from aisimulate.resources import (
+            ResourceEstimate,
+            estimate_workload,
+            WORKER_BASELINE_BYTES,
+        )
+
+        fallback = estimate_workload(workload, stack="dynamo", concurrency=concurrency)
+        active = concurrency or workload.get("concurrency")
+        if (
+            getattr(_core, "OFFLINE_SYNTHETIC_CONCURRENCY_ALLOCATION_MODEL", None)
+            != "generated-u32-v1"
+            or fallback.allocation_model != "dynamo-eager-u32-v1"
+            or not active
+            or workload.get("request_rate") is not None
+            or workload.get("arrival_interval_ms") is not None
+            or workload.get("shared_prefix_ratio", 0)
+            or workload.get("num_prefix_groups", 0)
+            or workload.get("inter_turn_delay_ms", 0)
+        ):
+            return fallback
+        count = fallback.request_count
+        isl, osl = int(workload.get("isl", 1024)), int(workload.get("osl", 128))
+        tokens = min(count, int(active)) * isl * 4
+        # Keep a conservative allowance for detailed capture and other report
+        # evidence. The generation capability alone does not qualify those paths.
+        peak = WORKER_BASELINE_BYTES + 2 * tokens + count * (4096 + 16 * osl)
+        return ResourceEstimate("dynamo-generated-u32-v1", count, tokens, tokens, peak)
+
     def capabilities(self) -> RunnerCapabilities:
         """Advertise the backend/topology and Dynamo hook support."""
 
@@ -124,11 +155,18 @@ class DynamoReplayRunner:
             **self._goodput_sla_kwargs(spec),
         }
 
-        if self._is_trace(spec):
-            report = self._run_trace(spec, common)
-        else:
-            common.update(self._synthetic_kwargs(spec))
-            report = self._run_synthetic(spec, common)
+        try:
+            if self._is_trace(spec):
+                report = self._run_trace(spec, common)
+            else:
+                common.update(self._synthetic_kwargs(spec))
+                report = self._run_synthetic(spec, common)
+        except MemoryError as error:
+            try:
+                from aisimulate.resources import ResourceLimitError
+            except ImportError:
+                raise error from None
+            raise ResourceLimitError(str(error)) from error
 
         metrics, metadata = self._normalize_report(report, output_requirements)
         self._require_goodput_metric(metrics, spec)

--- a/components/src/dynamo/replay/tests/test_simulation.py
+++ b/components/src/dynamo/replay/tests/test_simulation.py
@@ -450,9 +450,9 @@ def test_factory_owns_replay_spec_abi_version(monkeypatch) -> None:
             supports_disaggregated_attention_dp=False,
         ):
             seen["version"] = replay_spec_api_version
-            seen["supports_disaggregated_attention_dp"] = (
-                supports_disaggregated_attention_dp
-            )
+            seen[
+                "supports_disaggregated_attention_dp"
+            ] = supports_disaggregated_attention_dp
             self.replay_spec_api_version = replay_spec_api_version
             self.supported_backend_topologies = supported_backend_topologies
             self.supported_hooks = supported_hooks

--- a/components/src/dynamo/replay/tests/test_simulation.py
+++ b/components/src/dynamo/replay/tests/test_simulation.py
@@ -419,9 +419,9 @@ def test_factory_owns_replay_spec_abi_version(monkeypatch) -> None:
             supports_disaggregated_attention_dp=False,
         ):
             seen["version"] = replay_spec_api_version
-            seen[
-                "supports_disaggregated_attention_dp"
-            ] = supports_disaggregated_attention_dp
+            seen["supports_disaggregated_attention_dp"] = (
+                supports_disaggregated_attention_dp
+            )
             self.replay_spec_api_version = replay_spec_api_version
             self.supported_backend_topologies = supported_backend_topologies
             self.supported_hooks = supported_hooks
@@ -453,3 +453,62 @@ def test_goodput_goal_fails_closed_when_replay_omits_metric(monkeypatch) -> None
 
     with pytest.raises(RuntimeError, match="did not emit goodput"):
         simulation.DynamoReplayRunnerFactory().create(0).run(spec)
+
+
+def test_resource_estimate_requires_native_generated_capability(monkeypatch):
+    resources = pytest.importorskip("aisimulate.resources")
+    from dynamo import _core
+
+    factory = simulation.DynamoReplayRunnerFactory()
+    workload = {
+        "isl": 10240,
+        "osl": 1024,
+        "request_count": 6451200,
+        "concurrency": 64512,
+    }
+    monkeypatch.delattr(
+        _core, "OFFLINE_SYNTHETIC_CONCURRENCY_ALLOCATION_MODEL", raising=False
+    )
+    assert (
+        factory.estimate_host_resources(workload).allocation_model
+        == "dynamo-eager-u32-v1"
+    )
+    monkeypatch.setattr(
+        _core,
+        "OFFLINE_SYNTHETIC_CONCURRENCY_ALLOCATION_MODEL",
+        "generated-u32-v1",
+        raising=False,
+    )
+    estimate = factory.estimate_host_resources(workload)
+    assert isinstance(estimate, resources.ResourceEstimate)
+    assert estimate.allocation_model == "dynamo-generated-u32-v1"
+    assert estimate.input_token_bytes == 64512 * 10240 * 4
+    assert estimate.estimated_peak_bytes > 6451200 * 4096
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"request_rate": 1.0},
+        {"arrival_interval_ms": 1.0},
+        {"turns_per_session": 2},
+        {"shared_prefix_ratio": 0.5},
+        {"num_prefix_groups": 1},
+        {"inter_turn_delay_ms": 1},
+    ],
+)
+def test_resource_estimate_keeps_conservative_fallback_for_other_paths(
+    monkeypatch, extra
+):
+    pytest.importorskip("aisimulate.resources")
+    from dynamo import _core
+
+    monkeypatch.setattr(
+        _core,
+        "OFFLINE_SYNTHETIC_CONCURRENCY_ALLOCATION_MODEL",
+        "generated-u32-v1",
+        raising=False,
+    )
+    workload = {"isl": 16, "osl": 4, "request_count": 128, "concurrency": 8, **extra}
+    estimate = simulation.DynamoReplayRunnerFactory().estimate_host_resources(workload)
+    assert estimate.allocation_model != "dynamo-generated-u32-v1"

--- a/components/src/dynamo/replay/tests/test_simulation.py
+++ b/components/src/dynamo/replay/tests/test_simulation.py
@@ -178,7 +178,6 @@ def test_trace_paths_only_workload_routes_to_trace_replay(monkeypatch) -> None:
             "trace_paths": ["first.jsonl", "second.jsonl"],
             "trace_format": "dynamo",
             "arrival_speedup_ratio": 2.0,
-            "agentic_lanes": 4,
         },
         goal={"target": "throughput"},
     )
@@ -187,8 +186,40 @@ def test_trace_paths_only_workload_routes_to_trace_replay(monkeypatch) -> None:
 
     assert seen["trace_files"] == ["first.jsonl", "second.jsonl"]
     assert seen["arrival_speedup_ratio"] == 2.0
-    assert seen["agentic_lanes"] == 4
+    assert seen["agentic_lanes"] is None
     assert report.metrics["completed_requests"] == 2.0
+
+
+def test_trace_adapter_forwards_agentic_lanes_without_qualifying_runner(monkeypatch):
+    seen = {}
+
+    def fake_run_trace_replay(**kwargs):
+        seen.update(kwargs)
+        return _report({"completed_requests": 2})
+
+    monkeypatch.setattr(simulation, "MockEngineArgs", _FakeEngineArgs)
+    monkeypatch.setattr(simulation, "run_trace_replay", fake_run_trace_replay)
+    spec = ReplaySpec(
+        backend_deployment=_agg_deployment(),
+        workload={
+            "trace_paths": ["first.jsonl", "second.jsonl"],
+            "trace_format": "dynamo",
+            "agentic_lanes": 4,
+        },
+        goal={"target": "throughput"},
+    )
+    runner = simulation.DynamoReplayRunnerFactory().create(0)
+
+    # Verify adapter plumbing separately from the public capability contract.
+    # Older optional AISimulate packages predate the explicit lane capability.
+    if hasattr(runner.capabilities, "supports_agentic_lanes"):
+        with pytest.raises(ValueError, match="runner does not support agentic_lanes"):
+            runner.run(spec)
+        assert not seen
+
+    runner._run_trace(spec, {})
+    assert seen["trace_files"] == ["first.jsonl", "second.jsonl"]
+    assert seen["agentic_lanes"] == 4
 
 
 def test_trace_replay_rejects_boolean_agentic_lanes() -> None:

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -34,9 +34,8 @@ dependencies = [
 
 [[package]]
 name = "aisimulate-core"
-version = "0.1.0-dev.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa0422f239fd9b9ca92d4a57fe7069771e158293d266e05a20fde477d15b9af"
+version = "0.12.0"
+source = "git+https://github.com/ai-dynamo/aisimulate.git?rev=0480320fdd20c2e063a28a90faa111180fce8e47#0480320fdd20c2e063a28a90faa111180fce8e47"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -45,17 +44,21 @@ dependencies = [
  "derive_builder",
  "flate2",
  "indicatif 0.18.4",
+ "log",
  "parquet",
  "pep440_rs",
  "pyo3",
  "quick_cache",
+ "rand 0.8.6",
  "rand 0.9.4",
+ "rand_chacha 0.3.1",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "slotmap",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uuid",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -60,7 +60,7 @@ request-trace-s3 = ["dynamo-llm/request-trace-s3"]
 # former AIC crate surface. The `python` feature is required for
 # AicEngineBuilder; this extension supplies the interpreter, so the dependency
 # must not enable `extension-module`.
-aisimulate-core = { version = "=0.1.0-dev.2", optional = true, features = ["python"] }
+aisimulate-core = { git = "https://github.com/ai-dynamo/aisimulate.git", rev = "0480320fdd20c2e063a28a90faa111180fce8e47", optional = true, features = ["python"] }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { version = "8.1.0" }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -212,6 +212,10 @@ fn register_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_select_service, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::make_engine, m)?)?;
     m.add_function(wrap_pyfunction!(llm::replay::run_mocker_trace_replay, m)?)?;
+    m.add(
+        "OFFLINE_SYNTHETIC_CONCURRENCY_ALLOCATION_MODEL",
+        "generated-u32-v1",
+    )?;
     m.add_function(wrap_pyfunction!(
         llm::replay::run_mocker_synthetic_trace_replay,
         m

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -18,7 +18,7 @@ use dynamo_mocker::replay::{
 };
 use parking_lot::Mutex;
 use pyo3::{
-    exceptions::{PyException, PyValueError},
+    exceptions::{PyException, PyMemoryError, PyValueError},
     prelude::*,
 };
 use pythonize::pythonize;
@@ -1154,7 +1154,8 @@ pub fn run_mocker_trace_replay(
         })))
         .map_err(|error| scaling_run_err_to_pyerr(error, &callback_error))?
     } else {
-        py.allow_threads(move || run(None)).map_err(to_pyerr)?
+        py.allow_threads(move || run(None))
+            .map_err(replay_run_err_to_pyerr)?
     };
     let runtime_evidence = report.runtime_evidence.clone();
     // Write per-request JSONL from Rust directly if requested, avoiding a
@@ -1583,6 +1584,29 @@ pub fn run_mocker_synthetic_trace_replay(
             };
         }
 
+        // Only this single-turn closed-loop path can defer token allocation.
+        // Open-loop timestamps and multi-turn/session traces keep their existing
+        // behavior and must not advertise the generated allocation model.
+        if replay_mode == "offline"
+            && let Some(max_in_flight) = replay_concurrency
+        {
+            let requests =
+                build_generated_synthetic_requests(input_tokens, output_tokens, request_count)?;
+            return match args_selection {
+                ReplayArgsSelection::Aggregated(args) =>
+                    dynamo_mocker::replay::simulate_concurrency_requests_with_router_mode_and_scaling_policy(
+                        *args, router_config.clone(), prefill_load_estimator.clone(), requests,
+                        max_in_flight, num_workers, router_mode, record_per_request, sla,
+                        scaling_policy.take(),
+                    ),
+                ReplayArgsSelection::Disagg(config) =>
+                    dynamo_mocker::replay::simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
+                        *config, router_config.clone(), prefill_load_estimator.clone(), requests,
+                        max_in_flight, router_mode, record_per_request, sla, scaling_policy.take(),
+                    ),
+            };
+        }
+
         let arrival_timestamps_ms = load_controller
             .arrival_spec()
             .map(|spec| spec.timestamps(request_count, arrival_seed))
@@ -1700,7 +1724,8 @@ pub fn run_mocker_synthetic_trace_replay(
         })))
         .map_err(|error| scaling_run_err_to_pyerr(error, &callback_error))?
     } else {
-        py.allow_threads(move || run(None)).map_err(to_pyerr)?
+        py.allow_threads(move || run(None))
+            .map_err(replay_run_err_to_pyerr)?
     };
     let runtime_evidence = report.runtime_evidence.clone();
     if is_offline {
@@ -1781,6 +1806,22 @@ mod tests {
     };
     use dynamo_mocker::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
     use dynamo_mocker::loadgen::ArrivalSpec;
+
+    #[test]
+    fn generated_synthetic_source_validates_without_allocating_the_population() {
+        assert!(super::build_generated_synthetic_requests(10240, 1024, 6_451_200).is_ok());
+        for (input, output, count) in [(0, 1, 1), (1, 0, 1), (1, 1, 0)] {
+            assert!(super::build_generated_synthetic_requests(input, output, count).is_err());
+        }
+        let eager = super::build_synthetic_requests(16, 4, 8, None).unwrap();
+        for (index, request) in eager.iter().enumerate() {
+            let generated = super::build_synthetic_request(16, 4, index, None);
+            assert_eq!(request.tokens, generated.tokens);
+            assert_eq!(request.uuid, generated.uuid);
+            assert_eq!(request.max_output_tokens, generated.max_output_tokens);
+            assert_eq!(request.arrival_timestamp_ms, generated.arrival_timestamp_ms);
+        }
+    }
 
     #[test]
     fn online_disaggregation_is_rejected_with_stable_message() {
@@ -2343,22 +2384,61 @@ fn build_synthetic_requests(
         );
     }
 
-    let mut requests = Vec::with_capacity(request_count);
-    for request_idx in 0..request_count {
-        let tokens = (0..input_tokens)
-            .map(|token_idx| synthetic_token_id(request_idx, token_idx))
-            .collect();
-        requests.push(DirectRequest {
-            tokens,
-            max_output_tokens: output_tokens,
-            uuid: Some(Uuid::from_u128((request_idx as u128) + 1)),
-            dp_rank: 0,
-            arrival_timestamp_ms: arrival_timestamps_ms.map(|values| values[request_idx]),
-            ..Default::default()
-        });
-    }
+    Ok((0..request_count)
+        .map(|index| {
+            build_synthetic_request(
+                input_tokens,
+                output_tokens,
+                index,
+                arrival_timestamps_ms.map(|values| values[index]),
+            )
+        })
+        .collect())
+}
 
-    Ok(requests)
+fn build_generated_synthetic_requests(
+    input_tokens: usize,
+    output_tokens: usize,
+    request_count: usize,
+) -> anyhow::Result<dynamo_mocker::replay::GeneratedRequests> {
+    if input_tokens == 0 {
+        anyhow::bail!("input_tokens must be at least 1");
+    }
+    if output_tokens == 0 {
+        anyhow::bail!("output_tokens must be at least 1");
+    }
+    if request_count == 0 {
+        anyhow::bail!("request_count must be at least 1");
+    }
+    Ok(dynamo_mocker::replay::GeneratedRequests::new(
+        request_count,
+        move |index| {
+            Ok(build_synthetic_request(
+                input_tokens,
+                output_tokens,
+                index,
+                None,
+            ))
+        },
+    ))
+}
+
+fn build_synthetic_request(
+    input_tokens: usize,
+    output_tokens: usize,
+    request_idx: usize,
+    arrival_timestamp_ms: Option<f64>,
+) -> DirectRequest {
+    DirectRequest {
+        tokens: (0..input_tokens)
+            .map(|token_idx| synthetic_token_id(request_idx, token_idx))
+            .collect(),
+        max_output_tokens: output_tokens,
+        uuid: Some(Uuid::from_u128((request_idx as u128) + 1)),
+        dp_rank: 0,
+        arrival_timestamp_ms,
+        ..Default::default()
+    }
 }
 
 fn synthetic_token_id(request_idx: usize, token_idx: usize) -> u32 {
@@ -2425,6 +2505,19 @@ fn validate_sla_threshold(name: &str, value: Option<f64>) -> PyResult<()> {
 /// separately instead of relying on it to remain the root anyhow error.
 /// Non-Python errors (e.g. a simulation dead-end) fall back to the generic
 /// conversion.
+fn replay_run_err_to_pyerr(error: anyhow::Error) -> PyErr {
+    if error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<dynamo_mocker::replay::ReplayError>(),
+            Some(dynamo_mocker::replay::ReplayError::ResourceLimited(_))
+        )
+    }) {
+        PyMemoryError::new_err(format!("{error:#}"))
+    } else {
+        to_pyerr(error)
+    }
+}
+
 fn scaling_run_err_to_pyerr(
     err: anyhow::Error,
     callback_error: &PyReplayScalingErrorSlot,
@@ -2434,7 +2527,7 @@ fn scaling_run_err_to_pyerr(
     }
     match err.downcast::<PyErr>() {
         Ok(py_err) => py_err,
-        Err(other) => to_pyerr(other),
+        Err(other) => replay_run_err_to_pyerr(other),
     }
 }
 

--- a/lib/mocker/src/engine_adapter.rs
+++ b/lib/mocker/src/engine_adapter.rs
@@ -125,7 +125,7 @@ pub(crate) fn engine_components(
         preemption_mode,
         emit_kv_events,
         emit_kv_token_ids,
-        kv_bytes_per_token: args.kv_bytes_per_token,
+        kv_cache_bytes_per_token: args.kv_bytes_per_token,
         kv_transfer_bandwidth: args.kv_transfer_bandwidth,
         kv_transfer_timing_mode,
         timing_model,
@@ -157,6 +157,7 @@ pub(crate) fn aggregated_replay_setup(
 ) -> Result<(ReplayEngineConfig, ReplayEngineFactory)> {
     let components = engine_components(args.clone(), false, false)?;
     let config = ReplayEngineConfig {
+        num_gpu_blocks_is_explicit: None,
         dp_size: components.args.dp_size,
         tensor_parallel_size: replay_tensor_parallel_size(&components.args)?,
         rank: components.rank,
@@ -179,16 +180,19 @@ pub(crate) fn disaggregated_replay_setup(
     let prefill = engine_components(prefill_args.clone(), false, false)?;
     let decode = engine_components(decode_args.clone(), false, false)?;
     let prefill_role = ReplayRoleConfig {
+        num_gpu_blocks_is_explicit: None,
         dp_size: prefill.args.dp_size,
         tensor_parallel_size: replay_tensor_parallel_size(&prefill.args)?,
         rank: prefill.rank,
     };
     let decode_role = ReplayRoleConfig {
+        num_gpu_blocks_is_explicit: None,
         dp_size: decode.args.dp_size,
         tensor_parallel_size: replay_tensor_parallel_size(&decode.args)?,
         rank: decode.rank,
     };
     let config = ReplayEngineConfig {
+        num_gpu_blocks_is_explicit: None,
         dp_size: prefill_role.dp_size,
         tensor_parallel_size: prefill_role.tensor_parallel_size,
         rank: prefill_role.rank.clone(),

--- a/lib/mocker/src/loadgen/weka.rs
+++ b/lib/mocker/src/loadgen/weka.rs
@@ -32,6 +32,8 @@ pub fn load_weka_trace(path: &std::path::Path) -> Result<AgenticTrace> {
 
 fn agentic_mooncake_row(row: dynamo_data_gen::AgenticMooncakeRow) -> AgenticMooncakeRow {
     AgenticMooncakeRow {
+        source_play_ordinal: None,
+        recorded_api_time_ms: None,
         request_id: row.request_id,
         play_id: row.play_id,
         session_id: row.session_id,

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -1666,7 +1666,7 @@ pub fn simulate_concurrency_requests_with_router_mode_and_scaling_policy(
     args: MockEngineArgs,
     router_config: Option<KvRouterConfig>,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
-    requests: Vec<DirectRequest>,
+    requests: impl Into<super::ReplayConcurrencyRequests>,
     max_in_flight: usize,
     num_workers: usize,
     router_mode: ReplayRouterMode,
@@ -1682,6 +1682,7 @@ pub fn simulate_concurrency_requests_with_router_mode_and_scaling_policy(
         router_mode,
         scaling_policy.is_some(),
     )?;
+    let requests = requests.into();
     if requests.is_empty() {
         bail!("concurrency replay requires at least one request");
     }
@@ -1690,7 +1691,7 @@ pub fn simulate_concurrency_requests_with_router_mode_and_scaling_policy(
         args,
         router_config,
         prefill_load_estimator,
-        requests,
+        requests.into_runtime_input(),
         max_in_flight,
         num_workers,
         router_mode,
@@ -1729,7 +1730,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
     config: OfflineDisaggReplayConfig,
     router_config: Option<KvRouterConfig>,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
-    requests: Vec<DirectRequest>,
+    requests: impl Into<super::ReplayConcurrencyRequests>,
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
     record_per_request: bool,
@@ -1738,6 +1739,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_concurrency_args(&config, max_in_flight, router_mode)?;
+    let requests = requests.into();
     if requests.is_empty() {
         bail!("concurrency replay requires at least one request");
     }
@@ -1746,7 +1748,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
         config,
         router_config,
         prefill_load_estimator,
-        requests,
+        requests.into_runtime_input(),
         max_in_flight,
         router_mode,
         record_per_request,
@@ -2335,6 +2337,112 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
+
+    #[test]
+    fn generated_requests_match_eager_replay_across_backends_and_topologies() {
+        fn request(index: usize) -> DirectRequest {
+            DirectRequest {
+                tokens: vec![index as u32 + 1; 16],
+                max_output_tokens: 3,
+                uuid: Some(Uuid::from_u128(index as u128 + 1)),
+                ..Default::default()
+            }
+        }
+        for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+            for disagg in [false, true] {
+                for capture in [false, true] {
+                    let run = |requests: super::super::ReplayConcurrencyRequests| {
+                        let mut args = replay_test_args();
+                        args.engine_type = engine_type;
+                        args.sglang = Some(SglangArgs {
+                            page_size: Some(4),
+                            ..Default::default()
+                        });
+                        if disagg {
+                            let config = OfflineDisaggReplayConfig {
+                                prefill_args: MockEngineArgs {
+                                    worker_type: WorkerType::Prefill,
+                                    ..args.clone()
+                                },
+                                decode_args: MockEngineArgs {
+                                    worker_type: WorkerType::Decode,
+                                    ..args
+                                },
+                                num_prefill_workers: 1,
+                                num_decode_workers: 1,
+                            };
+                            simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
+                                config, None, None, requests, 4, ReplayRouterMode::RoundRobin,
+                                capture, SlaThresholds::default(), None,
+                            ).unwrap()
+                        } else {
+                            simulate_concurrency_requests_with_router_mode_and_scaling_policy(
+                                args,
+                                None,
+                                None,
+                                requests,
+                                4,
+                                1,
+                                ReplayRouterMode::RoundRobin,
+                                capture,
+                                SlaThresholds::default(),
+                                None,
+                            )
+                            .unwrap()
+                        }
+                    };
+                    let eager = run((0..32).map(request).collect::<Vec<_>>().into());
+                    let generated =
+                        run(super::super::GeneratedRequests::new(32, |i| Ok(request(i))).into());
+                    assert_eq!(
+                        serde_json::to_value(eager.clone().with_wall_time_ms(0.0)).unwrap(),
+                        serde_json::to_value(generated.clone().with_wall_time_ms(0.0)).unwrap()
+                    );
+                    assert_eq!(
+                        serde_json::to_value(eager.per_request).unwrap(),
+                        serde_json::to_value(generated.per_request).unwrap()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn huge_generated_population_reaches_only_the_admission_window() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        let requests = super::super::GeneratedRequests::new(6_451_200, move |index| {
+            observed.fetch_add(1, Ordering::SeqCst);
+            if index == 4 {
+                anyhow::bail!("bounded sentinel");
+            }
+            Ok(DirectRequest {
+                tokens: vec![1; 16],
+                max_output_tokens: 3,
+                uuid: Some(Uuid::from_u128(index as u128 + 1)),
+                ..Default::default()
+            })
+        });
+        let error = simulate_concurrency_requests_with_router_mode_and_scaling_policy(
+            replay_test_args(),
+            None,
+            None,
+            requests,
+            4,
+            1,
+            ReplayRouterMode::RoundRobin,
+            false,
+            SlaThresholds::default(),
+            None,
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("bounded sentinel"));
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+    }
 
     fn replay_test_args() -> MockEngineArgs {
         MockEngineArgs::builder()

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -16,7 +16,46 @@ use dynamo_kv_router::PrefillLoadEstimator;
 
 /// Backward-compatible Dynamo Mocker name for [`aisimulate_core::ReplayReport`].
 pub use aisimulate_core::ReplayReport as TraceSimulationReport;
+pub use aisimulate_core::replay::ReplayError;
 pub(crate) use aisimulate_core::replay::TraceCollector;
+pub use aisimulate_core::replay::loadgen::GeneratedRequests;
+
+/// Input for closed-loop offline replay. Generated requests are materialized
+/// only when the runtime admits them into the concurrency window.
+pub enum ReplayConcurrencyRequests {
+    Materialized(Vec<DirectRequest>),
+    Generated(GeneratedRequests),
+}
+
+impl From<Vec<DirectRequest>> for ReplayConcurrencyRequests {
+    fn from(requests: Vec<DirectRequest>) -> Self {
+        Self::Materialized(requests)
+    }
+}
+
+impl From<GeneratedRequests> for ReplayConcurrencyRequests {
+    fn from(requests: GeneratedRequests) -> Self {
+        Self::Generated(requests)
+    }
+}
+
+impl ReplayConcurrencyRequests {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Materialized(requests) => requests.is_empty(),
+            Self::Generated(requests) => requests.is_empty(),
+        }
+    }
+
+    fn into_runtime_input(self) -> aisimulate_core::replay::ReplayRuntimeInput {
+        use aisimulate_core::replay::ReplayRuntimeInput;
+        match self {
+            Self::Materialized(requests) => ReplayRuntimeInput::Requests(requests.into()),
+            Self::Generated(requests) => ReplayRuntimeInput::GeneratedRequests(requests),
+        }
+    }
+}
+
 pub use aisimulate_core::replay::{
     CanonicalReplayCoverage, CanonicalReplayRecord, LifecycleOperation, OfflineRuntimeEvidence,
     PerRequestRecord, ReplayCaptureOptions, ReplayDeterminism, ReplayTerminalStatus, SlaThresholds,

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -6,8 +6,6 @@
 //! This module lowers Dynamo configuration into Replay-owned contracts. It
 //! must never include or compile implementation sources from another crate.
 
-use std::collections::VecDeque;
-
 use aisimulate_core::replay::{
     CURRENT_REPLAY_SPEC_VERSION, ProviderSpec, ReplayAdapters, ReplayCaptureOptions,
     ReplayEngineConfig, ReplayRuntimeInput, ReplayScalingPolicy, ReplaySpec, ReplayTopology,
@@ -402,7 +400,7 @@ pub(crate) fn simulate_concurrency_with_scaling_policy(
     args: MockEngineArgs,
     router_config: Option<ReplayKvRouterConfig>,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
-    requests: Vec<DirectRequest>,
+    requests: ReplayRuntimeInput,
     max_in_flight: usize,
     num_workers: usize,
     router_mode: ReplayRouterMode,
@@ -415,7 +413,7 @@ pub(crate) fn simulate_concurrency_with_scaling_policy(
         args,
         router_config,
         prefill_load_estimator,
-        ReplayRuntimeInput::Requests(VecDeque::from(requests)),
+        requests,
         num_workers,
         Some(max_in_flight),
         router_mode,
@@ -686,7 +684,7 @@ pub(crate) fn simulate_concurrency_disagg_with_scaling_policy(
     config: OfflineDisaggReplayConfig,
     router_config: Option<ReplayKvRouterConfig>,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
-    requests: Vec<DirectRequest>,
+    requests: ReplayRuntimeInput,
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
     record_per_request: bool,
@@ -698,7 +696,7 @@ pub(crate) fn simulate_concurrency_disagg_with_scaling_policy(
         config,
         router_config,
         prefill_load_estimator,
-        ReplayRuntimeInput::Requests(VecDeque::from(requests)),
+        requests,
         Some(max_in_flight),
         router_mode,
         record_per_request,

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -154,6 +154,7 @@ pub(crate) struct WorkerAdmission {
     uuid: Uuid,
     worker_idx: usize,
     overlap_blocks: u32,
+    best_available_overlap_blocks: u32,
     isl_blocks: u32,
 }
 
@@ -169,6 +170,7 @@ pub(crate) struct RouterEffects {
 struct AdmitOutcome {
     worker_idx: usize,
     overlap_blocks: u32,
+    best_available_overlap_blocks: u32,
     isl_blocks: u32,
 }
 
@@ -367,11 +369,13 @@ impl KvRouterPlacement {
     fn placement(&self, admission: WorkerAdmission) -> Placement {
         Placement {
             request_id: admission.uuid,
+            placement_replica_id: None,
             scheduler_id: admission.worker_idx,
             reported_overlap_tokens: admission.overlap_blocks as usize
                 * self.router.block_size as usize,
             cache_sample: Some(PlacementCacheSample {
                 overlap_blocks: admission.overlap_blocks,
+                best_available_overlap_blocks: admission.best_available_overlap_blocks,
                 isl_blocks: admission.isl_blocks,
             }),
         }
@@ -662,6 +666,7 @@ impl OfflineReplayRouter {
                 uuid,
                 worker_idx: outcome.worker_idx,
                 overlap_blocks: outcome.overlap_blocks,
+                best_available_overlap_blocks: outcome.best_available_overlap_blocks,
                 isl_blocks: outcome.isl_blocks,
             }],
         })
@@ -927,6 +932,18 @@ impl OfflineReplayRouter {
             .project_worker_loads(request.token_seq.as_deref(), decay_now);
         let scheduling_request = request.scheduling_request(self.block_size as usize, worker_loads);
         let eligibility = scheduling_request.eligibility();
+        let best_available_overlap_blocks = request
+            .overlaps
+            .scores
+            .iter()
+            .filter(|(worker, _)| {
+                eligibility
+                    .validate_worker_rank(&self.workers_with_configs, **worker)
+                    .is_ok()
+            })
+            .map(|(_, blocks)| *blocks)
+            .max()
+            .unwrap_or(0);
         let selection = self
             .selector
             .select_worker(WorkerSelectionInput::configured(
@@ -972,6 +989,7 @@ impl OfflineReplayRouter {
         Ok(AdmitOutcome {
             worker_idx,
             overlap_blocks,
+            best_available_overlap_blocks,
             isl_blocks,
         })
     }
@@ -993,6 +1011,7 @@ impl OfflineReplayRouter {
                 uuid,
                 worker_idx: outcome.worker_idx,
                 overlap_blocks: outcome.overlap_blocks,
+                best_available_overlap_blocks: outcome.best_available_overlap_blocks,
                 isl_blocks: outcome.isl_blocks,
             });
         }
@@ -1171,6 +1190,7 @@ mod tests {
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             preferred_dp_rank: None,
+            preferred_prefill_dp_rank: None,
             arrival_timestamp_ms: Some(0.0),
             priority,
             strict_priority,
@@ -1419,6 +1439,7 @@ mod tests {
                 uuid: Uuid::from_u128(1),
                 worker_idx: 1,
                 overlap_blocks: 1,
+                best_available_overlap_blocks: 1,
                 isl_blocks: 1,
             }]
         );
@@ -1804,6 +1825,7 @@ policy_classes:
                 uuid: Uuid::from_u128(1),
                 worker_idx: 3,
                 overlap_blocks: 0,
+                best_available_overlap_blocks: 0,
                 isl_blocks: 1,
             }]
         );
@@ -1901,6 +1923,7 @@ policy_classes:
                 uuid: Uuid::from_u128(2),
                 worker_idx: 1,
                 overlap_blocks: 0,
+                best_available_overlap_blocks: 0,
                 isl_blocks: 1,
             }]
         );

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -583,6 +583,7 @@ mod tests {
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             preferred_dp_rank: None,
+            preferred_prefill_dp_rank: None,
             arrival_timestamp_ms: Some(0.0),
             priority,
             strict_priority,


### PR DESCRIPTION
## Summary

Generate synthetic prompts when requests enter the offline concurrency window, instead of materializing all prompts before replay starts. **Measured peak process RAM falls from 275.70 to 12.66 MiB (95.41%) for aggregated replay, and from 275.64 to 12.77 MiB (95.37%) for disaggregated replay**, at 16,384 requests × 4,096 input tokens, concurrency 32. All corresponding replay reports are identical after excluding wall-clock timing.

The gain is host RAM and removal of the full-population input-construction pause. Prompt storage changes from `N × ISL × 4` bytes to approximately `min(N, concurrency) × ISL × 4`, plus active-runtime copies and other state. Existing vector callers remain supported. Both modes use the same request builder, preserving prompt IDs, UUIDs, output lengths, order, and concurrency admission behavior.

This applies to **offline, single-turn synthetic concurrency replay**, for aggregated and disaggregated topologies. Open-loop/rate-driven replay, trace inputs, shared-prefix/session workloads, multi-turn replay, and online replay keep their existing paths. The Python factory advertises the lower estimate only when the loaded native binary exposes `generated-u32-v1`; older binaries retain the conservative eager estimate. Native report-limit errors propagate as resource failures.

## Validation

### Measured memory and execution cost

Fresh measurements on **2026-09-17, Apple M3 Pro, 36 GiB RAM, macOS 26.7 arm64, Rust 1.96.0**, at Dynamo `81c3909f0704d41e12b3157da06032c9985fc136`, with AISimulate core `830b3d33a39f0837d7a911034bfc0208f3b3510a`. The reproducer below is the only local addition to the exact Dynamo head.

Controlled comparison: the same native binary runs either `Vec<DirectRequest>` or `GeneratedRequests` through the PR's public concurrency replay API, using the Python binding's identical synthetic token formula. This isolates input allocation from the separate AISimulate dependency update; it is **not a whole-branch before/after benchmark**.

Each row is the median of **three fresh processes per mode**, run sequentially with alternating mode order. Peak RSS is the OS high-water mark from macOS `/usr/bin/time -l`, including engine/request/report memory, with no baseline subtraction; 1 MiB = 1,048,576 bytes. Build profile: **unoptimized dev + debuginfo**. Wall time includes input construction and replay, excluding process startup and final JSON serialization. vLLM simulation, round-robin routing, prefix caching off, summary capture, block size 64, 65,536 simulated GPU blocks, batch-token cap 16,384, sequence cap = concurrency, speedup ratio 1,000; one aggregated worker or one prefill plus one decode worker. No real GPU/model is used.

| Topology | Requests | Input/output tokens | Concurrency | Eager peak MiB | Lazy peak MiB | RAM reduction | Eager / lazy seconds |
|---|---:|---:|---:|---:|---:|---:|---:|
| agg | 1,024 | 4,096/8 | 32 | 28.44 | 12.44 | 56.26% | 0.174 / 0.171 |
| agg | 4,096 | 4,096/8 | 32 | 78.02 | 12.62 | 83.82% | 0.685 / 0.686 |
| agg | 16,384 | 4,096/8 | 32 | 275.70 | 12.66 | 95.41% | 2.641 / 2.626 |
| disagg | 1,024 | 4,096/8 | 32 | 28.31 | 12.48 | 55.91% | 0.296 / 0.287 |
| disagg | 4,096 | 4,096/8 | 32 | 77.91 | 12.62 | 83.79% | 1.141 / 1.130 |
| disagg | 16,384 | 4,096/8 | 32 | 275.64 | 12.77 | 95.37% | 4.587 / 4.566 |
| agg | 16,384 | 4,096/8 | 256 | 278.20 | 18.59 | 93.32% | 3.961 / 3.993 |
| disagg | 16,384 | 4,096/8 | 256 | 278.89 | 19.42 | 93.04% | 6.382 / 6.280 |
| agg | 8,192 | 10,240/128 | 32 | 401.06 | 13.72 | 96.58% | 6.293 / 6.274 |
| disagg | 8,192 | 10,240/128 | 32 | 401.27 | 14.27 | 96.44% | 10.814 / 9.734 |

- **Scaling with request count:** increasing requests 16× (1,024 → 16,384) at concurrency 32 raises eager RSS from ~28 to ~276 MiB, while lazy RSS stays near 12.4–12.8 MiB in this experiment.
- **Scaling with concurrency:** at 16,384 requests, increasing concurrency 32 → 256 raises lazy RSS from 12.66 → 18.59 MiB aggregated, and 12.77 → 19.42 MiB disaggregated, consistent with more active request state.
- **Startup work:** for the 16,384-request aggregated case, eager input construction takes 1.071 s; constructing the lazy source takes ~1.2 µs. Token generation still happens during admission, so this does not remove total token-generation work or measure time to first completed request.
- **Runtime tradeoff:** no general speedup claim. At concurrency 32 and 16,384 requests, aggregated wall time is 2.641 → 2.626 s; disaggregated is 4.587 → 4.566 s. At concurrency 256, aggregated is 3.961 → 3.993 s (~0.8% slower). These debug-build timings expose cost, not production performance qualification.
- **Small detailed-capture cases:** at 256 requests × 1,024 input / 8 output tokens and concurrency 16, aggregate peak RSS is 17.27 → 16.56 MiB (4.07% reduction) and disaggregate is 19.33 → 18.72 MiB (3.15%). Savings depend on workload size and retained report state; the large summary-only percentages are not universal.
- **Parity:** all 72 measured processes complete their requested workload, with exact input/output-token totals. All six normalized reports per configuration match, including a separate 256-request detailed-capture case in each topology that checks all per-request records. Only wall-clock-derived fields are normalized. The existing native parity test additionally covers vLLM/SGLang × aggregated/disaggregated × capture off/on; the large-population sentinel test checks bounded admission without materializing 6,451,200 prompts.

### What this means for the reported large candidate

For `N = 6,451,200`, `ISL = 10,240`, and `concurrency = 64,512`:

| Prompt-ID payload calculation | Before | After | Gain |
|---|---:|---:|---:|
| 32-bit prompt tokens per candidate | 246.09375 GiB | 2.4609375 GiB | **100× smaller; 99% less; 243.6328125 GiB avoided** |

**This row is arithmetic, not measured full-scale RSS or a completed incident reproduction.** It excludes request metadata, token copies, scheduler/router state, Python overhead, and detailed reporting. Even the active prompt payload alone exceeds 2 GiB. With OSL 1,024, the factory's conservative total estimate remains **128.46875 GiB** (`512 MiB + 2 × active_prompt_bytes + N × (4096 + 16 × OSL)`), so this PR does not make the full candidate admissible under a 2 GiB budget. Detailed capture and other retained evidence still need independent budgeting. No disk-space, GPU-memory, serving-throughput, original-panic-root-cause, or incident-closure claim is made.

### Tests and integration status

Current review update: `246b9649e94731dd451d03352bb2b6683ac1f388` (September 19).

- **New P3 addressed:** the Python adapter explicitly keeps `turns_per_session != 1` on the conservative resource estimate, and the deleted multi-turn parameterized case is restored. Restoring that case before adding the guard produces **1 failed, 5 passed**; the guard makes the full adapter suite pass **24/24, zero skipped** against the published `aisimulate==0.12.0` macOS wheel. Repository pre-commit checks pass. This two-line update uses the existing native build; it changes no Rust code.
- **P2 verified fixed by the reviewer:** only absence of `aisimulate.resources` is handled at import time. Missing transitive dependencies still raise. Older published packages receive `None` (no qualified resource estimate) and preserve native `MemoryError`; packages with host-resource accounting receive the conservative/generated `ResourceEstimate` contract.
- **Original P3 verified fixed by the reviewer:** the sentinel test is named for factory-error propagation. A separate regression observes generation at simulated time zero, before completion, for windows 1/2/4/8 and aggregated/disaggregated replay. Widening the runtime window by one makes it fail. The reviewer independently confirmed this on Linux and checked eager/generated parity when the window exceeds the population.
- Native validation recorded at previous head `2d80c1dedbe3912a38197c9af9f24ff8988e3223`: 215 mocker library tests on macOS, a fresh native wheel build, and 8 Python/native replay smoke combinations. Those native runs were not repeated for this Python-only update.
- On the current head, `tests/dependencies/test_aisimulate_consistency.py` reports **1 failed, 4 passed** with the published `0.12.0` wheel. The failing test rejects the Rust Git source; the installed-version control passes. No dependency guard was relaxed.
- The memory measurements and raw data remain historical measurements at `81c3909f0704d41e12b3157da06032c9985fc136`, not measurements of the latest review update.

**P1 remains a release/integration blocker; this PR is not ready for merge.**

Rust still pins AISimulate core `830b3d33a39f0837d7a911034bfc0208f3b3510a`, while Python/container use published `aisimulate==0.12.0`. The dependency guard fails, and that older Python compiler does not accept the newer Rust caller's `database_mode` argument. The newest published nightly pair (`0.12.0.dev202609170000000044` / `0.12.0-dev.202609170000000044`) contains `GeneratedRequests` but lacks `ReplayError::ResourceLimited` and the required cancellation-retirement fix; it also lacks a macOS wheel.

[AISimulate #173](https://github.com/ai-dynamo/aisimulate/pull/173) and the development-nightly migration-gate change [#281](https://github.com/ai-dynamo/aisimulate/pull/281) have merged. Publication remains incomplete:

- The [September 19 scheduled nightly](https://github.com/ai-dynamo/aisimulate/actions/runs/35431525121) built artifacts from `108cb5d6ca8b4048915783b6155445f1c731825a` but failed FPE qualification before publication. The A100/SGLang artifact records a DeepSeek-V4.1-Flash native `NotImplementedError` at `attention_dp_size=2`; the supported text baseline requires `attention_dp_size=1`, `pp_size=1`, and `cp_size=1`.
- [Manual nightly run #46](https://github.com/ai-dynamo/aisimulate/actions/runs/35381603930), targeting `8536063428188e6a6d22a1453d46abd7b80d8c1e`, is still waiting for Devops approval of `manual-release-approver`. The requesting account cannot approve that environment. Approval alone would not establish successful build, qualification, security, or publication.

Once a compatible pair is published, update both Cargo manifests, all three Cargo lockfiles, `pyproject.toml`, and `container/deps/requirements.aisimulate.txt` together; validate supported platform artifacts and downstream API compatibility; then rerun dependency, replay, profiler, and required CI checks on that exact head. [Dynamo #14065](https://github.com/ai-dynamo/dynamo/pull/14065) remains a stable-release migration prerequisite.

The new P3 thread has a corrective-commit reply and is awaiting reviewer verification. P1 remains open. Full-CI qualification is incomplete; the CI mirror still points to older `81c3909f07`, and the known dependency failure must be corrected before a successful full-CI run can qualify this PR.

Linux RSS measurements and full incident-sized completion are not established by the historical macOS experiments. The [AISimulate #174 evidence](https://github.com/ai-dynamo/aisimulate/pull/174) demonstrated small replay and safe refusal, not full-workload completion.

## Related issues and review entry points

Related: #14637. Internal tracking: DGH-1571.

Start with `lib/bindings/python/rust/llm/replay.rs` (path selection and request construction), `lib/mocker/src/replay/entrypoints.rs` (generated/vector integration and parity tests), and `components/src/dynamo/replay/simulation.py` (version-qualified resource estimate).

<details>
<summary>Reproduce the experiment (complete source and runner)</summary>

Check out the exact head and save the Rust source below as `lib/mocker/examples/replay_memory.rs`; save the Python runner in a separate output directory as `run_experiment.py`. The AISimulate Git dependency must be readable. These commands use macOS peak-RSS units; on Linux adapt the timing collector rather than interpreting KiB as bytes.

```bash
git checkout --detach 81c3909f0704d41e12b3157da06032c9985fc136
cargo build --locked -p dynamo-mocker --example replay_memory
python3 /path/to/output/run_experiment.py "$PWD/target/debug/examples/replay_memory"
cargo test --locked -p dynamo-mocker --lib generated_
```

Rust source:

```rust
// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
// SPDX-License-Identifier: Apache-2.0
// Experiment for PR #14679 at 81c3909f0704d41e12b3157da06032c9985fc136.
// synthetic_token_id matches lib/bindings/python/rust/llm/replay.rs at that SHA.
use dynamo_mocker::common::protocols::{DirectRequest, MockEngineArgs, WorkerType};
use dynamo_mocker::replay::{
    GeneratedRequests, OfflineDisaggReplayConfig, ReplayConcurrencyRequests, ReplayRouterMode,
    SlaThresholds, simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy,
    simulate_concurrency_requests_with_router_mode_and_scaling_policy,
};
use serde_json::json;
use std::time::Instant;
use uuid::Uuid;

fn request(index: usize, isl: usize, osl: usize) -> DirectRequest {
    DirectRequest {
        tokens: (0..isl)
            .map(|token_idx| {
                let mut value = (((index as u64) << 32) ^ token_idx as u64)
                    .wrapping_add(0x9E37_79B9_7F4A_7C15);
                value ^= value >> 30;
                value = value.wrapping_mul(0xBF58_476D_1CE4_E5B9);
                value ^= value >> 27;
                value = value.wrapping_mul(0x94D0_49BB_1331_11EB);
                value ^= value >> 31;
                let token = value as u32;
                if token == 0 { 1 } else { token }
            })
            .collect(),
        max_output_tokens: osl,
        uuid: Some(Uuid::from_u128(index as u128 + 1)),
        ..Default::default()
    }
}

fn main() -> anyhow::Result<()> {
    let cli: Vec<String> = std::env::args().collect();
    anyhow::ensure!(cli.len() == 8, "MODE TOPOLOGY N ISL OSL CONCURRENCY CAPTURE");
    let mode = &cli[1];
    let topology = &cli[2];
    let n: usize = cli[3].parse()?;
    let isl: usize = cli[4].parse()?;
    let osl: usize = cli[5].parse()?;
    let concurrency: usize = cli[6].parse()?;
    let capture: bool = cli[7].parse()?;
    anyhow::ensure!(n > 0 && isl > 0 && osl > 0 && concurrency > 0);
    // Avoid accidentally reproducing the incident-sized eager allocation.
    anyhow::ensure!(n as u128 * isl as u128 * 4 <= 512 * 1024 * 1024);
    let start = Instant::now();
    let input: ReplayConcurrencyRequests = match mode.as_str() {
        "eager" => (0..n).map(|i| request(i, isl, osl)).collect::<Vec<_>>().into(),
        "generated" => GeneratedRequests::new(n, move |i| Ok(request(i, isl, osl))).into(),
        _ => anyhow::bail!("unknown mode"),
    };
    let construction_s = start.elapsed().as_secs_f64();
    let args = MockEngineArgs::builder()
        .block_size(64)
        .num_gpu_blocks(65536)
        .max_num_batched_tokens(Some(16384))
        .max_num_seqs(Some(concurrency))
        .enable_prefix_caching(false)
        .speedup_ratio(1000.0)
        .build()?;
    let report = match topology.as_str() {
        "agg" => simulate_concurrency_requests_with_router_mode_and_scaling_policy(
            args, None, None, input, concurrency, 1, ReplayRouterMode::RoundRobin,
            capture, SlaThresholds::default(), None,
        )?,
        "disagg" => simulate_concurrency_requests_disagg_with_router_mode_and_scaling_policy(
            OfflineDisaggReplayConfig {
                prefill_args: MockEngineArgs { worker_type: WorkerType::Prefill, ..args.clone() },
                decode_args: MockEngineArgs { worker_type: WorkerType::Decode, ..args },
                num_prefill_workers: 1,
                num_decode_workers: 1,
            },
            None, None, input, concurrency, ReplayRouterMode::RoundRobin,
            capture, SlaThresholds::default(), None,
        )?,
        _ => anyhow::bail!("unknown topology"),
    };
    let elapsed_s = start.elapsed().as_secs_f64();
    let report = report.with_wall_time_ms(0.0);
    // Include the per-request evidence separately; it is omitted by report serialization.
    let value = json!({"report": &report, "per_request": &report.per_request});
    let fingerprint = blake3::hash(&serde_json::to_vec(&value)?).to_hex().to_string();
    println!("{}", json!({
        "mode": mode, "topology": topology, "n": n, "isl": isl, "osl": osl,
        "concurrency": concurrency, "capture": capture, "construction_s": construction_s,
        "elapsed_s": elapsed_s, "report_blake3": fingerprint, "report": value,
    }));
    Ok(())
}
```

Python runner (writes each raw report and timing log, checks completion and exact report parity, and writes `results.json`):

```python
#!/usr/bin/env python3
"""Measure PR #14679 eager/generated replay in separate sequential processes."""
import hashlib
import json
import platform
import re
import statistics
import subprocess
import sys
from pathlib import Path

binary = Path(sys.argv[1]).resolve()
root = Path(__file__).resolve().parent
cases = [(t, n, 4096, 8, 32, False) for t in ("agg", "disagg") for n in (1024, 4096, 16384)]
cases += [(t, 16384, 4096, 8, 256, False) for t in ("agg", "disagg")]
cases += [(t, 8192, 10240, 128, 32, False) for t in ("agg", "disagg")]
cases += [(t, 256, 1024, 8, 16, True) for t in ("agg", "disagg")]
rows = []
result = {
    "head": "81c3909f0704d41e12b3157da06032c9985fc136",
    "core": "830b3d33a39f0837d7a911034bfc0208f3b3510a",
    "platform": platform.platform(),
    "machine": platform.machine(),
    "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
    "build_profile": "dev (unoptimized + debuginfo)",
    "rss_measurement": "/usr/bin/time -l maximum resident set size; Darwin bytes",
    "cases": rows,
}
assert sys.platform == "darwin", "This runner parses macOS time output (bytes)."
for topology, n, isl, osl, concurrency, capture in cases:
    key = f"{topology}-n{n}-i{isl}-o{osl}-c{concurrency}-capture{capture}"
    runs = []
    reports = []
    for repeat in range(3):
        # Alternate order to reduce systematic warm-cache/order bias.
        for mode in (("eager", "generated") if repeat % 2 == 0 else ("generated", "eager")):
            stem = root / f"{key}-{mode}-{repeat}"
            command = ["/usr/bin/time", "-l", str(binary), mode, topology, str(n),
                       str(isl), str(osl), str(concurrency), str(capture).lower()]
            with stem.with_suffix(".json").open("w") as out, stem.with_suffix(".time").open("w") as err:
                subprocess.run(command, stdout=out, stderr=err, check=True, timeout=180)
            sample = json.loads(stem.with_suffix(".json").read_text())
            timing = stem.with_suffix(".time").read_text()
            sample["peak_rss_bytes"] = int(re.search(r"(\d+)\s+maximum resident set size", timing)[1])
            sample["repeat"] = repeat
            report = sample.pop("report")
            assert report["report"]["completed_requests"] == n
            assert report["report"]["total_input_tokens"] == n * isl
            assert report["report"]["total_output_tokens"] == n * osl
            if capture:
                assert len(report["per_request"]) == n
            reports.append(report)
            runs.append(sample)
    assert all(report == reports[0] for report in reports), key
    summary = {}
    for mode in ("eager", "generated"):
        samples = [r for r in runs if r["mode"] == mode]
        summary[mode] = {
            field: statistics.median(r[field] for r in samples)
            for field in ("peak_rss_bytes", "elapsed_s", "construction_s")
        }
        summary[mode]["rss_min_bytes"] = min(r["peak_rss_bytes"] for r in samples)
        summary[mode]["rss_max_bytes"] = max(r["peak_rss_bytes"] for r in samples)
    summary["rss_reduction_pct"] = 100 * (1 - summary["generated"]["peak_rss_bytes"] / summary["eager"]["peak_rss_bytes"])
    rows.append({"key": key, "report_parity": True, "summary": summary, "runs": runs})
    (root / "results.json").write_text(json.dumps(result, indent=2) + "\n")
    print(json.dumps({"key": key, **summary}), flush=True)
```

</details>

<details>
<summary>All measured RSS/time samples and normalized report digests</summary>

Each line is one case. Each mode lists all three samples in repetition order; RSS is bytes, seconds are construction + replay. The report digest is identical for every eager/generated repetition in that case.

```jsonl
{"case":"agg-n1024-i4096-o8-c32-captureFalse","report_blake3":"3e179ff5f6977ddc62bb26d576d1b61032c658289a4f1c19043f612dc4a3d03d","eager":[{"rss_bytes":29851648,"seconds":0.176481666},{"rss_bytes":29818880,"seconds":0.169660042},{"rss_bytes":29818880,"seconds":0.173995833}],"generated":[{"rss_bytes":13025280,"seconds":0.166700584},{"rss_bytes":13041664,"seconds":0.170952583},{"rss_bytes":13041664,"seconds":0.178130541}]}
{"case":"agg-n4096-i4096-o8-c32-captureFalse","report_blake3":"ab9831d9b7b3026097471578fa2a81302a0c6c0d9730ab25ea59724e773683f4","eager":[{"rss_bytes":81821696,"seconds":0.6850695},{"rss_bytes":81788928,"seconds":0.647649209},{"rss_bytes":81805312,"seconds":0.693291667}],"generated":[{"rss_bytes":13254656,"seconds":0.687353125},{"rss_bytes":13238272,"seconds":0.67132925},{"rss_bytes":13238272,"seconds":0.685959166}]}
{"case":"agg-n16384-i4096-o8-c32-captureFalse","report_blake3":"3398c3d21775254b0d5383a725fb156ad34a24264d8e1a081dfdab52403073cf","eager":[{"rss_bytes":289128448,"seconds":2.661270459},{"rss_bytes":289095680,"seconds":2.640685625},{"rss_bytes":289095680,"seconds":2.638017958}],"generated":[{"rss_bytes":13303808,"seconds":2.613265208},{"rss_bytes":13271040,"seconds":2.6304325},{"rss_bytes":13271040,"seconds":2.626192875}]}
{"case":"disagg-n1024-i4096-o8-c32-captureFalse","report_blake3":"dbbcc84066c07c1d4b89a21526bdd8aa07a4812383c327b49e308a1b898e968f","eager":[{"rss_bytes":29638656,"seconds":0.291897625},{"rss_bytes":29687808,"seconds":0.30793775},{"rss_bytes":29769728,"seconds":0.296336333}],"generated":[{"rss_bytes":13074432,"seconds":0.296003333},{"rss_bytes":13123584,"seconds":0.287101833},{"rss_bytes":13090816,"seconds":0.281085375}]}
{"case":"disagg-n4096-i4096-o8-c32-captureFalse","report_blake3":"22cae93eeb5f302513935b5280fadd86dc9c7e14c4e7cef5af3ebd4a5a25b02d","eager":[{"rss_bytes":81674240,"seconds":1.141053417},{"rss_bytes":81690624,"seconds":1.146882084},{"rss_bytes":81756160,"seconds":1.141375917}],"generated":[{"rss_bytes":13254656,"seconds":1.129553375},{"rss_bytes":13238272,"seconds":1.125961041},{"rss_bytes":13156352,"seconds":1.131343917}]}
{"case":"disagg-n16384-i4096-o8-c32-captureFalse","report_blake3":"d1bdab0fdbc0d9d8e4834e9dd7b74d7408abac87cc434d625fa55db0a6cc6b41","eager":[{"rss_bytes":289030144,"seconds":4.586701083},{"rss_bytes":289030144,"seconds":4.571400208},{"rss_bytes":289013760,"seconds":4.701202708}],"generated":[{"rss_bytes":13385728,"seconds":4.509359959},{"rss_bytes":13385728,"seconds":4.566244167},{"rss_bytes":13385728,"seconds":4.575635375}]}
{"case":"agg-n16384-i4096-o8-c256-captureFalse","report_blake3":"2c6b7a400f54722e14d47dfa11c196bd74e65f1ab02f494d85f8530d2a0e411c","eager":[{"rss_bytes":291717120,"seconds":3.961481292},{"rss_bytes":291618816,"seconds":3.957340167},{"rss_bytes":291717120,"seconds":3.962940292}],"generated":[{"rss_bytes":19562496,"seconds":4.173129834},{"rss_bytes":19496960,"seconds":3.993227625},{"rss_bytes":19480576,"seconds":3.950223791}]}
{"case":"disagg-n16384-i4096-o8-c256-captureFalse","report_blake3":"5d717f5b735018c869f7a5314cfaf58334d2e18d90b488aa28cd21ae1d9cf08c","eager":[{"rss_bytes":292454400,"seconds":6.234915416},{"rss_bytes":292438016,"seconds":6.382073417},{"rss_bytes":292225024,"seconds":6.490644417}],"generated":[{"rss_bytes":20217856,"seconds":6.277251042},{"rss_bytes":20430848,"seconds":6.279907042},{"rss_bytes":20365312,"seconds":6.32643375}]}
{"case":"agg-n8192-i10240-o128-c32-captureFalse","report_blake3":"707a4ebf71ddff910663ae5ff9dafeb2cbc3a451256843d398581b34a666dccc","eager":[{"rss_bytes":420544512,"seconds":6.458172709},{"rss_bytes":420544512,"seconds":6.287448667},{"rss_bytes":420544512,"seconds":6.292935666}],"generated":[{"rss_bytes":14385152,"seconds":6.274407},{"rss_bytes":14319616,"seconds":6.286749333},{"rss_bytes":14385152,"seconds":6.189548792}]}
{"case":"disagg-n8192-i10240-o128-c32-captureFalse","report_blake3":"4653f256f2456329b4868d63db27d643916b032d87571a231324232784b1957c","eager":[{"rss_bytes":420757504,"seconds":9.753265416},{"rss_bytes":420888576,"seconds":10.814416375},{"rss_bytes":420659200,"seconds":10.8170825}],"generated":[{"rss_bytes":15564800,"seconds":10.117981542},{"rss_bytes":14958592,"seconds":9.7344785},{"rss_bytes":14696448,"seconds":9.717473791}]}
{"case":"agg-n256-i1024-o8-c16-captureTrue","report_blake3":"467dce15da0c10f083218dfce29a6801d822a8bfcaf073e8145e1089aa43bd2a","eager":[{"rss_bytes":18087936,"seconds":0.019889583},{"rss_bytes":18120704,"seconds":0.019945583},{"rss_bytes":18104320,"seconds":0.019917417}],"generated":[{"rss_bytes":17367040,"seconds":0.020285625},{"rss_bytes":17367040,"seconds":0.019894541},{"rss_bytes":17383424,"seconds":0.019898542}]}
{"case":"disagg-n256-i1024-o8-c16-captureTrue","report_blake3":"e1e4f7282a8e014f983732a4d07fe685080e0efc1d040db44146f6f55c0bea47","eager":[{"rss_bytes":20250624,"seconds":0.036190292},{"rss_bytes":20299776,"seconds":0.036081167},{"rss_bytes":20267008,"seconds":0.036440875}],"generated":[{"rss_bytes":19660800,"seconds":0.035898834},{"rss_bytes":19611648,"seconds":0.035979625},{"rss_bytes":19628032,"seconds":0.036372958}]}
```

Experiment binary SHA-256: `900824f68b66e501da401c1f9d04c88dea12913932bafed8e475f6f90a5eae84`.

</details>

