### PR TITLE
fix(sglang): use embedding requests for worker canary checks

### DIFF
--- a/components/src/dynamo/sglang/health_check.py
+++ b/components/src/dynamo/sglang/health_check.py
@@ -87,6 +87,24 @@ class SglangHealthCheckPayload(HealthCheckPayload):
         super().__init__()
 
 
+class SglangEmbeddingHealthCheckPayload(HealthCheckPayload):
+    """Send an embedding request through the worker's normal encode path."""
+
+    def __init__(
+        self,
+        model_name: str,
+        engine: Optional[sgl.Engine] = None,
+        use_text_input: bool = False,
+    ) -> None:
+        self.default_payload = {
+            "model": model_name,
+            "input": (
+                "Test" if use_text_input else [_get_bos_token_id_from_engine(engine)]
+            ),
+        }
+        super().__init__()
+
+
 class SglangDisaggHealthCheckPayload(HealthCheckPayload):
     """SGLang-specific health check payload for PD-disaggregated mode.
 

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -12,7 +12,7 @@ from dynamo.common.utils.prometheus import register_engine_metrics_callback
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
-from dynamo.sglang.health_check import SglangHealthCheckPayload
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload
 from dynamo.sglang.publisher import (
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
@@ -69,8 +69,10 @@ async def init_embedding(
     ready_event = asyncio.Event()
 
     handler = EmbeddingWorkerHandler(engine, config, publisher, shutdown_event)
-    health_check_payload = SglangHealthCheckPayload(
-        engine, use_text_input=dynamo_args.use_sglang_tokenizer
+    health_check_payload = SglangEmbeddingHealthCheckPayload(
+        server_args.served_model_name,
+        engine,
+        use_text_input=dynamo_args.use_sglang_tokenizer,
     ).to_dict()
 
     register_model_taint_route(runtime, generate_endpoint)

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
+    pytest.mark.timeout(30),
 ]
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -13,6 +13,7 @@ pytest.importorskip(
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput  # noqa: E402
 
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload  # noqa: E402
 from dynamo.sglang.request_handlers.embedding import (  # noqa: E402
     embedding_handler as eh,
 )
@@ -59,6 +60,29 @@ def _handler(*, enable_trace: bool = True) -> eh.EmbeddingWorkerHandler:
     handler.engine = _Engine()
     handler.enable_trace = enable_trace
     return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_text_input", [True, False])
+async def test_health_check_runs_embedding_inference(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    handler = _handler()
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", use_text_input=use_text_input
+    ).to_dict()
+
+    outputs = [output async for output in handler.generate(payload, _Context())]
+
+    assert len(outputs) == 1
+    assert outputs[0]["model"] == "embedding-model"
+    assert len(outputs[0]["data"]) == 1
+    if use_text_input:
+        assert handler.engine.async_encode_calls[0]["prompt"] == "Test"
+        assert handler.engine.tokenizer_manager.requests == []
+    else:
+        [(request, _)] = handler.engine.tokenizer_manager.requests
+        assert request.input_ids == [1]
+        assert handler.engine.async_encode_calls == []
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -9,18 +9,22 @@ no handler reads), and survives DYN_HEALTH_CHECK_PAYLOAD env overrides.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
+    SglangEmbeddingHealthCheckPayload,
     SglangHealthCheckPayload,
 )
+from dynamo.sglang.protocol import EmbeddingRequest
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
+    pytest.mark.fault_tolerance,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -33,6 +37,31 @@ def test_disagg_payload_has_marker():
 def test_decode_payload_has_no_marker():
     # Decode/agg handler doesn't read the marker; payload stays unmarked.
     assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
+
+
+@pytest.mark.parametrize("use_text_input", [True, False])
+def test_embedding_payload_matches_request_schema(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=42))
+    )
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", engine, use_text_input=use_text_input
+    ).to_dict()
+
+    request = EmbeddingRequest(**payload)
+    assert request.model == "embedding-model"
+    assert request.input == ("Test" if use_text_input else [42])
+
+
+def test_embedding_env_override(monkeypatch):
+    override = {"model": "embedding-model", "input": "custom probe"}
+    monkeypatch.setenv("DYN_HEALTH_CHECK_PAYLOAD", json.dumps(override))
+
+    payload = SglangEmbeddingHealthCheckPayload("embedding-model").to_dict()
+
+    assert payload == override
+    assert EmbeddingRequest(**payload).input == "custom probe"
 
 
 def test_disagg_env_override_preserves_marker(monkeypatch):

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -39,19 +39,18 @@ def test_decode_payload_has_no_marker():
     assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
 
 
-@pytest.mark.parametrize("use_text_input", [True, False])
-def test_embedding_payload_matches_request_schema(monkeypatch, use_text_input):
+def test_embedding_payload_uses_engine_bos_token(monkeypatch):
     monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
     engine = SimpleNamespace(
         tokenizer_manager=SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=42))
     )
     payload = SglangEmbeddingHealthCheckPayload(
-        "embedding-model", engine, use_text_input=use_text_input
+        "embedding-model", engine, use_text_input=False
     ).to_dict()
 
     request = EmbeddingRequest(**payload)
     assert request.model == "embedding-model"
-    assert request.input == ("Test" if use_text_input else [42])
+    assert request.input == [42]
 
 
 def test_embedding_env_override(monkeypatch):


### PR DESCRIPTION
## Summary

Related design and implementation plan: [DEP #14685](https://github.com/ai-dynamo/dynamo/issues/14685). This PR implements the independent embedding canary fix (phase 1). Merge order: #14680 → #14681 → #14460.

SGLang embedding workers register a generation-style canary payload containing `prompt` or `token_ids`. Their handler parses `EmbeddingRequest`, which requires `model` and `input`, so active canary checks fail validation before reaching the embedding engine and can keep an otherwise serving worker unready.

Use an embedding-specific payload with the served model name and text or BOS-token input. Preserve `DYN_HEALTH_CHECK_PAYLOAD` overrides. Add schema and handler regressions for both input modes.

Extracted from #14460 so the backend correctness fix can be reviewed and merged independently of deployment-test infrastructure. This is the first part of the split; #14681 adds shared deploy coverage, and #14460 consumes it for the N-2 matrix.

## Validation

- Embedding handler unit tests have a 30-second module timeout.

- Local isolated schema check: the original payload fails for missing `model` and `input` in both modes; the new text/token payloads and environment override pass. This executes the actual payload classes with the SGLang import stubbed; it does not run an engine.
- Black and diff whitespace checks passed.
- Attempted the embedding handler unit test locally; collection skips because SGLang is not installed on this macOS host. The committed tests require the SGLang CPU CI environment. No new GPU pass is claimed.
- Added tests use mocked engines and no model downloads; expected CPU-only runtime is seconds.
