### PR TITLE
test(deploy): share chat and embedding API coverage

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -526,6 +526,18 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
+  frontend-copy-to-acr:
+    name: frontend-nightly
+    needs: [compute-release-mode, frontend-build]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: $/.github/workflows/shared-copy.yml
+    with:
+      target_tag_plain: ${{ format('{0}-nightly', needs.frontend-build.outputs.target_tag_plain) }}
+      cuda_version: '[""]'
+      override_arch: amd64
+      copy_timeout_minutes: 10
+    secrets: inherit
+
   sglang-copy-to-acr:
     name: sglang-runtime-nightly
     needs: [compute-release-mode, sglang-build]
@@ -582,13 +594,14 @@ jobs:
 
   deploy-test-vllm:
     name: vLLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: vllm
       profiles: '["agg", "agg_router_kv_approx"]'
       image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -596,13 +609,14 @@ jobs:
 
   deploy-test-sglang:
     name: sglang Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
-      profiles: '["agg", "agg_logging"]'
+      profiles: '["agg", "agg_logging", "agg_embed"]'
       image_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -610,13 +624,14 @@ jobs:
 
   deploy-test-trtllm:
     name: TensorRT-LLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, trtllm-build, trtllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, trtllm-build, trtllm-copy-to-acr, frontend-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: trtllm
       profiles: '["agg"]'
       image_tag: ${{ needs.trtllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -216,6 +216,7 @@ jobs:
   operator:
     needs: changed-files
     if: |
+      needs.changed-files.outputs.core == 'true' ||
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.vllm == 'true' ||
       needs.changed-files.outputs.sglang == 'true' ||
@@ -739,6 +740,10 @@ jobs:
     name: frontend
     needs: [changed-files]
     if: |
+      needs.changed-files.outputs.core == 'true' ||
+      needs.changed-files.outputs.vllm == 'true' ||
+      needs.changed-files.outputs.sglang == 'true' ||
+      needs.changed-files.outputs.trtllm == 'true' ||
       needs.changed-files.outputs.frontend == 'true' ||
       needs.changed-files.outputs.operator == 'true' ||
       needs.changed-files.outputs.snapshot == 'true' ||
@@ -1120,7 +1125,14 @@ jobs:
     needs: [changed-files, frontend-build]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.snapshot == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.frontend == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
+       needs.changed-files.outputs.deploy == 'true' ||
+       needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
       needs.changed-files.outputs.snapshot_vllm == 'true' ||
       needs.changed-files.outputs.snapshot_sglang == 'true' ||
       needs.changed-files.outputs.snapshot_trtllm == 'true') &&
@@ -1301,7 +1313,8 @@ jobs:
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.operator == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
@@ -1339,11 +1352,12 @@ jobs:
 
   deploy-test-vllm:
     name: vllm Deploy Test
-    needs: [changed-files, deploy-operator, vllm-copy-to-acr]
+    needs: [changed-files, deploy-operator, vllm-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.vllm == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
@@ -1351,6 +1365,7 @@ jobs:
       framework: vllm
       profiles: '["agg", "agg_router", "disagg", "disagg_router"]'
       image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -1358,18 +1373,20 @@ jobs:
 
   deploy-test-sglang:
     name: sglang Deploy Test
-    needs: [changed-files, deploy-operator, sglang-copy-to-acr]
+    needs: [changed-files, deploy-operator, sglang-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.sglang == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
-      profiles: '["agg", "agg_router"]'
+      profiles: '["agg", "agg_router", "agg_embed"]'
       image_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -1377,11 +1394,12 @@ jobs:
 
   deploy-test-trtllm:
     name: trtllm Deploy Test
-    needs: [changed-files, deploy-operator, trtllm-copy-to-acr]
+    needs: [changed-files, deploy-operator, trtllm-copy-to-acr, frontend-copy-to-acr]
     if: |
       needs.changed-files.outputs.run_deploy_tests == 'true' &&
       !cancelled() && !failure() &&
-      (needs.changed-files.outputs.trtllm == 'true' ||
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
        needs.changed-files.outputs.operator == 'true')
     uses: $/.github/workflows/shared-deploy-test.yml
@@ -1389,6 +1407,7 @@ jobs:
       framework: trtllm
       profiles: '["agg", "agg_router"]'
       image_tag: ${{ needs.trtllm-copy-to-acr.outputs.image_tag }}
+      frontend_tag: ${{ needs.frontend-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -18,6 +18,10 @@ on:
         description: 'Runtime image tag'
         type: string
         required: true
+      frontend_tag:
+        description: 'Standalone frontend image tag'
+        type: string
+        default: ''
       namespace:
         description: 'Host namespace where the vCluster lives'
         type: string
@@ -85,7 +89,9 @@ jobs:
           profile: ${{ matrix.profile }}
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ vars.ACR_REPOSITORY }}:${{ inputs.image_tag }}
           platform_arch: amd64
-          extra_pytest_args: -m framework_only
+          extra_pytest_args: >-
+            -m framework_only
+            ${{ inputs.frontend_tag != '' && format('--frontend-image={0}/{1}:{2}', secrets.AZURE_ACR_HOSTNAME, vars.ACR_REPOSITORY, inputs.frontend_tag) || '' }}
           # Mount the shared model cache only when both endpoint vars are set
           # (matches the PV/PVC creation gate); otherwise workers download from HF.
           model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}

--- a/components/src/dynamo/sglang/health_check.py
+++ b/components/src/dynamo/sglang/health_check.py
@@ -87,6 +87,24 @@ class SglangHealthCheckPayload(HealthCheckPayload):
         super().__init__()
 
 
+class SglangEmbeddingHealthCheckPayload(HealthCheckPayload):
+    """Send an embedding request through the worker's normal encode path."""
+
+    def __init__(
+        self,
+        model_name: str,
+        engine: Optional[sgl.Engine] = None,
+        use_text_input: bool = False,
+    ) -> None:
+        self.default_payload = {
+            "model": model_name,
+            "input": (
+                "Test" if use_text_input else [_get_bos_token_id_from_engine(engine)]
+            ),
+        }
+        super().__init__()
+
+
 class SglangDisaggHealthCheckPayload(HealthCheckPayload):
     """SGLang-specific health check payload for PD-disaggregated mode.
 

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -12,7 +12,7 @@ from dynamo.common.utils.prometheus import register_engine_metrics_callback
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
-from dynamo.sglang.health_check import SglangHealthCheckPayload
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload
 from dynamo.sglang.publisher import (
     set_forward_pass_metrics_worker_id,
     setup_sgl_metrics,
@@ -69,8 +69,10 @@ async def init_embedding(
     ready_event = asyncio.Event()
 
     handler = EmbeddingWorkerHandler(engine, config, publisher, shutdown_event)
-    health_check_payload = SglangHealthCheckPayload(
-        engine, use_text_input=dynamo_args.use_sglang_tokenizer
+    health_check_payload = SglangEmbeddingHealthCheckPayload(
+        server_args.served_model_name,
+        engine,
+        use_text_input=dynamo_args.use_sglang_tokenizer,
     ).to_dict()
 
     register_model_taint_route(runtime, generate_endpoint)

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
+    pytest.mark.timeout(30),
 ]
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_inputs.py
@@ -13,6 +13,7 @@ pytest.importorskip(
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput  # noqa: E402
 
+from dynamo.sglang.health_check import SglangEmbeddingHealthCheckPayload  # noqa: E402
 from dynamo.sglang.request_handlers.embedding import (  # noqa: E402
     embedding_handler as eh,
 )
@@ -59,6 +60,29 @@ def _handler(*, enable_trace: bool = True) -> eh.EmbeddingWorkerHandler:
     handler.engine = _Engine()
     handler.enable_trace = enable_trace
     return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_text_input", [True, False])
+async def test_health_check_runs_embedding_inference(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    handler = _handler()
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", use_text_input=use_text_input
+    ).to_dict()
+
+    outputs = [output async for output in handler.generate(payload, _Context())]
+
+    assert len(outputs) == 1
+    assert outputs[0]["model"] == "embedding-model"
+    assert len(outputs[0]["data"]) == 1
+    if use_text_input:
+        assert handler.engine.async_encode_calls[0]["prompt"] == "Test"
+        assert handler.engine.tokenizer_manager.requests == []
+    else:
+        [(request, _)] = handler.engine.tokenizer_manager.requests
+        assert request.input_ids == [1]
+        assert handler.engine.async_encode_calls == []
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -9,18 +9,22 @@ no handler reads), and survives DYN_HEALTH_CHECK_PAYLOAD env overrides.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
+    SglangEmbeddingHealthCheckPayload,
     SglangHealthCheckPayload,
 )
+from dynamo.sglang.protocol import EmbeddingRequest
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
+    pytest.mark.fault_tolerance,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -33,6 +37,31 @@ def test_disagg_payload_has_marker():
 def test_decode_payload_has_no_marker():
     # Decode/agg handler doesn't read the marker; payload stays unmarked.
     assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
+
+
+@pytest.mark.parametrize("use_text_input", [True, False])
+def test_embedding_payload_matches_request_schema(monkeypatch, use_text_input):
+    monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=42))
+    )
+    payload = SglangEmbeddingHealthCheckPayload(
+        "embedding-model", engine, use_text_input=use_text_input
+    ).to_dict()
+
+    request = EmbeddingRequest(**payload)
+    assert request.model == "embedding-model"
+    assert request.input == ("Test" if use_text_input else [42])
+
+
+def test_embedding_env_override(monkeypatch):
+    override = {"model": "embedding-model", "input": "custom probe"}
+    monkeypatch.setenv("DYN_HEALTH_CHECK_PAYLOAD", json.dumps(override))
+
+    payload = SglangEmbeddingHealthCheckPayload("embedding-model").to_dict()
+
+    assert payload == override
+    assert EmbeddingRequest(**payload).input == "custom probe"
 
 
 def test_disagg_env_override_preserves_marker(monkeypatch):

--- a/components/src/dynamo/sglang/tests/test_sglang_health_check.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_health_check.py
@@ -39,19 +39,18 @@ def test_decode_payload_has_no_marker():
     assert HEALTH_CHECK_KEY not in SglangHealthCheckPayload().to_dict()
 
 
-@pytest.mark.parametrize("use_text_input", [True, False])
-def test_embedding_payload_matches_request_schema(monkeypatch, use_text_input):
+def test_embedding_payload_uses_engine_bos_token(monkeypatch):
     monkeypatch.delenv("DYN_HEALTH_CHECK_PAYLOAD", raising=False)
     engine = SimpleNamespace(
         tokenizer_manager=SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=42))
     )
     payload = SglangEmbeddingHealthCheckPayload(
-        "embedding-model", engine, use_text_input=use_text_input
+        "embedding-model", engine, use_text_input=False
     ).to_dict()
 
     request = EmbeddingRequest(**payload)
     assert request.model == "embedding-model"
-    assert request.input == ("Test" if use_text_input else [42])
+    assert request.input == [42]
 
 
 def test_embedding_env_override(monkeypatch):

--- a/docs/fern/pages/recipes/kubernetes-templates/dgd/sglang.mdx
+++ b/docs/fern/pages/recipes/kubernetes-templates/dgd/sglang.mdx
@@ -22,6 +22,9 @@ kubectl apply -f agg.yaml
 <Accordion title="agg.yaml · Baseline aggregated serving">
 <Code src="../../../../../../examples/backends/sglang/deploy/agg.yaml" title="agg.yaml" language="yaml" maxLines={0} />
 </Accordion>
+<Accordion title="agg_embed.yaml · Aggregated embedding serving">
+<Code src="../../../../../../examples/backends/sglang/deploy/agg_embed.yaml" title="agg_embed.yaml" language="yaml" maxLines={0} />
+</Accordion>
 <Accordion title="agg_router.yaml · Aggregated with KV-aware routing">
 <Code src="../../../../../../examples/backends/sglang/deploy/agg_router.yaml" title="agg_router.yaml" language="yaml" maxLines={0} />
 </Accordion>

--- a/examples/backends/sglang/deploy/agg_embed.yaml
+++ b/examples/backends/sglang/deploy/agg_embed.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg-embed
+spec:
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - image: my-registry/sglang-runtime:my-tag
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-Embedding-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-Embedding-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: my-registry/sglang-runtime:my-tag
+          name: main
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
+    replicas: 1
+    type: worker

--- a/examples/backends/sglang/deploy/agg_embed.yaml
+++ b/examples/backends/sglang/deploy/agg_embed.yaml
@@ -20,6 +20,8 @@ spec:
       spec:
         containers:
         - args:
+          - --embedding-worker
+          - --use-sglang-tokenizer
           - --model-path
           - Qwen/Qwen3-Embedding-0.6B
           - --served-model-name

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the public APIs of an already running deployment."""
+
+import json
+import logging
+from pathlib import Path
+
+from tests.deploy.dgd_utils import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_REQUEST_TIMEOUT,
+    MIN_RESPONSE_CONTENT_LENGTH,
+    TEST_PROMPT,
+    validate_chat_response,
+)
+from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.utils.client import send_request
+
+logger = logging.getLogger(__name__)
+
+
+def check_deployment_api(
+    base_url: str, model: str, scenario: str, output: Path
+) -> None:
+    """Run shared API cases and retain raw responses even if a contract fails."""
+    output.mkdir(parents=True, exist_ok=True)
+    if scenario == "embedding":
+        for name, inputs, encoding in (
+            ("default", "Hello", None),
+            ("float", "Hello", "float"),
+            ("batch", ["Hello", "World"], "float"),
+        ):
+            payload = {"model": model, "input": inputs}
+            if encoding:
+                payload["encoding_format"] = encoding
+            data = _request(
+                base_url + "/v1/embeddings", payload, output / f"{name}.json"
+            )
+            assert data["model"] == model, data
+            # The example uses Qwen3-Embedding-0.6B's native 1024 dimensions.
+            validate_embedding(data, 2 if name == "batch" else 1, 1024)
+        return
+
+    assert scenario == "chat", scenario
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": TEST_PROMPT}],
+        "temperature": 0.0,
+        "max_tokens": DEFAULT_MAX_TOKENS,
+        "stream": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    url = base_url + "/v1/chat/completions"
+    unary = _request(
+        url,
+        payload,
+        output / "unary.json",
+        min_content_length=MIN_RESPONSE_CONTENT_LENGTH,
+    )
+    _request(url, {**payload, "stream": True}, output / "stream.json")
+    _request(url, {**payload, "max_tokens": 1}, output / "limited.json")
+    prefix = unary["choices"][0]["message"]["content"][:4]
+    assert prefix, "Cannot derive a stop sequence from empty unary output"
+    _request(url, {**payload, "stop": prefix}, output / "stop.json")
+
+
+def _request(url: str, payload: dict, artifact: Path, min_content_length: int = 0):
+    record = {"request": payload}
+    logger.info("Checking deployment API case %s", artifact.stem)
+    try:
+        with send_request(
+            url,
+            payload,
+            timeout=float(DEFAULT_REQUEST_TIMEOUT),
+            method="POST",
+            stream=payload.get("stream", False),
+        ) as response:
+            record["http_status"] = response.status_code
+            if payload.get("stream"):
+                lines = []
+                record["response"] = lines
+
+                def capture():
+                    for line in response.iter_lines():
+                        text = line.decode("utf-8")
+                        lines.append(text)
+                        yield text
+
+                response.raise_for_status()
+                validate_stream(capture())
+                return None
+            record["response"] = response.text
+            response.raise_for_status()
+            if "messages" in payload:
+                return validate_chat_response(
+                    response,
+                    payload["model"],
+                    min_content_length=min_content_length,
+                    max_tokens=payload["max_tokens"],
+                    stop=payload.get("stop"),
+                )
+            return response.json()
+    finally:
+        artifact.write_text(json.dumps(record, indent=2))

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import re
 from pathlib import Path
 
 from tests.deploy.dgd_utils import (
@@ -14,7 +15,11 @@ from tests.deploy.dgd_utils import (
     TEST_PROMPT,
     validate_chat_response,
 )
-from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.deploy.response_checks import (
+    validate_embedding,
+    validate_stop_response,
+    validate_stream,
+)
 from tests.utils.client import send_request
 
 logger = logging.getLogger(__name__)
@@ -67,9 +72,21 @@ def check_deployment_api(
     )
     _request(url, {**payload, "stream": True}, output / "stream.json")
     _request(url, {**payload, "max_tokens": 1}, output / "limited.json")
-    prefix = unary["choices"][0]["message"]["content"][:4]
-    assert prefix, "Cannot derive a stop sequence from empty unary output"
-    _request(url, {**payload, "stop": prefix}, output / "stop.json")
+    content = unary["choices"][0]["message"]["content"]
+    # Use a later word, avoiding a whitespace boundary at the start of output.
+    match = next(
+        (
+            m
+            for m in re.finditer(r"\S+", content)
+            if 0 < m.start() < len(content) // 2
+            and content.find(m.group()) == m.start()
+        ),
+        None,
+    )
+    assert match is not None, "Cannot derive an interior stop sequence"
+    stop = match.group()
+    stopped = _request(url, {**payload, "stop": stop}, output / "stop.json")
+    validate_stop_response(stopped, unary, stop)
 
 
 def _request(url: str, payload: dict, artifact: Path, min_content_length: int = 0):

--- a/tests/deploy/api_checks.py
+++ b/tests/deploy/api_checks.py
@@ -21,10 +21,20 @@ logger = logging.getLogger(__name__)
 
 
 def check_deployment_api(
-    base_url: str, model: str, scenario: str, output: Path
+    base_url: str,
+    model: str,
+    scenario: str,
+    output: Path,
+    *,
+    endpoint: str | None = None,
 ) -> None:
     """Run shared API cases and retain raw responses even if a contract fails."""
     output.mkdir(parents=True, exist_ok=True)
+    if endpoint is None:
+        endpoint = (
+            "/v1/embeddings" if scenario == "embedding" else "/v1/chat/completions"
+        )
+    url = base_url + endpoint
     if scenario == "embedding":
         for name, inputs, encoding in (
             ("default", "Hello", None),
@@ -34,9 +44,7 @@ def check_deployment_api(
             payload = {"model": model, "input": inputs}
             if encoding:
                 payload["encoding_format"] = encoding
-            data = _request(
-                base_url + "/v1/embeddings", payload, output / f"{name}.json"
-            )
+            data = _request(url, payload, output / f"{name}.json")
             assert data["model"] == model, data
             # The example uses Qwen3-Embedding-0.6B's native 1024 dimensions.
             validate_embedding(data, 2 if name == "batch" else 1, 1024)
@@ -51,7 +59,6 @@ def check_deployment_api(
         "stream": False,
         "chat_template_kwargs": {"enable_thinking": False},
     }
-    url = base_url + "/v1/chat/completions"
     unary = _request(
         url,
         payload,

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--frontend-image",
         type=str,
         default=None,
-        help="Frontend container image (used by GAIE and checkpoint deploy tests).",
+        help="Frontend container image override for deployment tests.",
     )
     parser.addoption(
         "--checkpoint-backend",
@@ -453,6 +453,10 @@ def deployment_spec(
     # Override image if provided
     if image:
         spec.set_image(image)
+
+    frontend_image = request.config.getoption("--frontend-image")
+    if frontend_image:
+        spec.set_image(frontend_image, service_name="Frontend")
 
     # Mount the shared model cache onto workers when a PVC is provided (CI on
     # clusters that provision it); otherwise workers download from HuggingFace.

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -104,10 +104,11 @@ def validate_chat_response(
     if stop is not None and content is None:
         content = ""
     assert isinstance(content, str), f"Expected text content: {message}"
-    assert len(content) >= min_content_length, (
-        f"Response content too short: {len(content)} chars (min: {min_content_length}). "
-        f"Content: {content[:200]}"
-    )
+    if stop is None:
+        assert len(content) >= min_content_length, (
+            f"Response content too short: {len(content)} chars (min: {min_content_length}). "
+            f"Content: {content[:200]}"
+        )
 
     assert "model" in data, f"Response missing 'model' field: {data}"
     assert (

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -20,6 +20,7 @@ from kr8s.objects import Pod, Service
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import exceptions
 
+from tests.deploy.response_checks import validate_chat
 from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,8 @@ def validate_chat_response(
     response: requests.Response,
     expected_model: str,
     min_content_length: int = MIN_RESPONSE_CONTENT_LENGTH,
+    max_tokens: int | None = None,
+    stop: str | None = None,
 ) -> dict[str, Any]:
     """Validate the structure and content of a chat completion response.
 
@@ -62,6 +65,8 @@ def validate_chat_response(
         response: HTTP response from the chat completion endpoint
         expected_model: Expected model name in the response
         min_content_length: Minimum required length for response content
+        max_tokens: Optional requested token cap for the completion contract
+        stop: Prefix stop sequence; permits fully suppressed response content
 
     Returns:
         Parsed response JSON on success
@@ -80,6 +85,9 @@ def validate_chat_response(
     except ValueError as e:
         pytest.fail(f"Response is not valid JSON: {e}. Response: {response.text[:500]}")
 
+    if max_tokens is not None:
+        validate_chat(data, max_tokens, stop)
+
     assert "choices" in data, f"Response missing 'choices' field: {data}"
     assert len(data["choices"]) > 0, f"Response has empty 'choices': {data}"
 
@@ -93,6 +101,9 @@ def validate_chat_response(
     assert "content" in message, f"Message missing 'content' field: {message}"
 
     content = message["content"]
+    if stop is not None and content is None:
+        content = ""
+    assert isinstance(content, str), f"Expected text content: {message}"
     assert len(content) >= min_content_length, (
         f"Response content too short: {len(content)} chars (min: {min_content_length}). "
         f"Content: {content[:200]}"

--- a/tests/deploy/dgd_utils.py
+++ b/tests/deploy/dgd_utils.py
@@ -66,7 +66,7 @@ def validate_chat_response(
         expected_model: Expected model name in the response
         min_content_length: Minimum required length for response content
         max_tokens: Optional requested token cap for the completion contract
-        stop: Prefix stop sequence; permits fully suppressed response content
+        stop: Stop sequence; permits empty or shortened response content
 
     Returns:
         Parsed response JSON on success

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -41,10 +41,24 @@ def validate_chat(body, max_tokens, stop=None):
     tokens = body["usage"]["completion_tokens"]
     assert type(tokens) is int and 0 <= tokens <= max_tokens, body
     if stop is not None:
-        assert content is None or content == "", body
+        assert content is None or isinstance(content, str), body
+        assert stop not in (content or ""), body
         assert choice["finish_reason"] == "stop", body
         assert not message.get("refusal") and (not message.get("tool_calls")), body
         assert not message.get("function_call"), body
+
+
+def validate_stop_response(body, baseline, stop):
+    """Require a stopped response to end before the baseline's stop sequence."""
+    content = body["choices"][0]["message"]["content"] or ""
+    original = baseline["choices"][0]["message"]["content"]
+    stop_index = original.index(stop)
+    assert content.strip(), "Interior stop suppressed preceding text"
+    assert original.startswith(content), "Stopped output diverged from baseline"
+    assert len(content) <= stop_index, "Output continued past the stop position"
+    assert (
+        body["usage"]["completion_tokens"] < baseline["usage"]["completion_tokens"]
+    ), "Stop did not reduce generated tokens"
 
 
 def validate_stream(lines):

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response contracts shared by deployment and component compatibility tests."""
+
+import json
+import math
+
+
+def validate_embedding(body, count, dimensions):
+    """Require finite float vectors with the requested shape and indices."""
+    assert body["object"] == "list", body
+    assert len(body["data"]) == count, body
+    for index, item in enumerate(body["data"]):
+        assert item["index"] == index, item
+        assert item["object"] == "embedding", item
+        vector = item["embedding"]
+        assert isinstance(
+            vector, list
+        ), f"Expected float array, got {type(vector).__name__}"
+        assert len(vector) == dimensions, len(vector)
+        assert all(
+            (type(x) in (int, float) and math.isfinite(x) for x in vector)
+        ), "Embedding vector must contain finite numbers"
+
+
+def validate_chat(body, max_tokens, stop=None):
+    """Validate unary chat content, token limits, and derived stop semantics."""
+    assert "error" not in body, body
+    assert len(body["choices"]) == 1, body
+    choice = body["choices"][0]
+    assert choice["index"] == 0, choice
+    assert choice["finish_reason"] in ("stop", "length"), choice
+    message = choice["message"]
+    assert message["role"] == "assistant", message
+    content = message["content"]
+    if stop is None:
+        assert isinstance(content, str), body
+        if max_tokens > 1:
+            assert content.strip(), body
+    tokens = body["usage"]["completion_tokens"]
+    assert type(tokens) is int and 0 <= tokens <= max_tokens, body
+    if stop is not None:
+        assert content is None or content == "", body
+        assert choice["finish_reason"] == "stop", body
+        assert not message.get("refusal") and (not message.get("tool_calls")), body
+        assert not message.get("function_call"), body
+
+
+def validate_stream(lines):
+    """Reject stream errors, malformed ordering, and incomplete termination."""
+    content, finished, done = ([], False, False)
+    for line in lines:
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            assert line.strip() != "event: error", line
+            continue
+        assert line.startswith("data:"), f"Unexpected SSE line: {line}"
+        assert not done, "Data after [DONE]"
+        data = line[5:].strip()
+        if data == "[DONE]":
+            done = True
+            continue
+        chunk = json.loads(data)
+        assert "error" not in chunk, chunk
+        choices = chunk["choices"]
+        assert isinstance(choices, list) and len(choices) <= 1, chunk
+        for choice in choices:
+            assert choice["index"] == 0, choice
+            text = choice.get("delta", {}).get("content")
+            if text is not None:
+                assert isinstance(text, str), "Stream content must be a string"
+            if text:
+                assert not finished, "Content after finish_reason"
+                content.append(text)
+            if choice.get("finish_reason") is not None:
+                assert not finished, "Duplicate finish_reason"
+                assert choice["finish_reason"] in ("stop", "length"), choice
+                finished = True
+    assert done and finished, "Incomplete SSE response"
+    assert "".join(content).strip(), "Empty streamed content"

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -8,7 +8,6 @@ import math
 
 
 def validate_embedding(body, count, dimensions):
-    """Require finite float vectors with the requested shape and indices."""
     assert body["object"] == "list", body
     assert len(body["data"]) == count, body
     for index, item in enumerate(body["data"]):
@@ -25,7 +24,6 @@ def validate_embedding(body, count, dimensions):
 
 
 def validate_chat(body, max_tokens, stop=None):
-    """Validate unary chat content, token limits, and derived stop semantics."""
     assert "error" not in body, body
     assert len(body["choices"]) == 1, body
     choice = body["choices"][0]
@@ -49,7 +47,6 @@ def validate_chat(body, max_tokens, stop=None):
 
 
 def validate_stop_response(body, baseline, stop):
-    """Require a stopped response to end before the baseline's stop sequence."""
     content = body["choices"][0]["message"]["content"] or ""
     original = baseline["choices"][0]["message"]["content"]
     stop_index = original.index(stop)
@@ -62,7 +59,6 @@ def validate_stop_response(body, baseline, stop):
 
 
 def validate_stream(lines):
-    """Reject stream errors, malformed ordering, and incomplete termination."""
     content, finished, done = ([], False, False)
     for line in lines:
         if not line or line.startswith(":"):

--- a/tests/deploy/response_checks.py
+++ b/tests/deploy/response_checks.py
@@ -54,7 +54,8 @@ def validate_stream(lines):
         if not line or line.startswith(":"):
             continue
         if line.startswith("event:"):
-            assert line.strip() != "event: error", line
+            event = line.partition(":")[2].removeprefix(" ")
+            assert event != "error", line
             continue
         assert line.startswith("data:"), f"Unexpected SSE line: {line}"
         assert not done, "Data after [DONE]"

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from tests.deploy import api_checks
+from tests.deploy.conftest import deployment_spec
+from tests.deploy.dgd_utils import validate_chat_response
+from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.utils import client
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.framework_agnostic,
+    pytest.mark.core,
+    pytest.mark.sglang,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
+]
+
+
+def response(content="hello", finish="stop", tokens=1):
+    result = requests.Response()
+    result.status_code = 200
+    result._content_consumed = True
+    result._content = json.dumps(
+        {
+            "model": "model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": finish,
+                    "message": {"role": "assistant", "content": content},
+                }
+            ],
+            "usage": {"completion_tokens": tokens},
+        }
+    ).encode()
+    return result
+
+
+@pytest.mark.parametrize("content", [None, ""])
+def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
+    validate_chat_response(response(content), "model", 0, max_tokens=30, stop="hello")
+    with pytest.raises(AssertionError):
+        validate_chat_response(
+            response("hello"), "model", 0, max_tokens=30, stop="hello"
+        )
+
+
+def test_token_limit_and_finish_reason():
+    validate_chat_response(response("h", "length"), "model", 0, max_tokens=1)
+    with pytest.raises(AssertionError):
+        validate_chat_response(response(tokens=2), "model", 0, max_tokens=1)
+    with pytest.raises(AssertionError):
+        validate_chat_response(response(finish="tool_calls"), "model", 0, max_tokens=30)
+
+
+def test_stream_requires_one_finish_and_done():
+    content = 'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}'
+    finish = 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
+    validate_stream([content, finish, "data: [DONE]"])
+    for lines in (
+        [content, finish],
+        [content, finish, finish, "data: [DONE]"],
+        [content, finish, content, "data: [DONE]"],
+    ):
+        with pytest.raises(AssertionError):
+            validate_stream(lines)
+
+
+def test_embedding_contract_rejects_wire_base64_and_nonfinite_vectors():
+    body = {
+        "object": "list",
+        "data": [{"index": 0, "object": "embedding", "embedding": [0.1, 0.2]}],
+    }
+    validate_embedding(body, 1, 2)
+    for vector in ("base64", [float("nan"), 0.2], [0.1], [True, 0.2]):
+        body["data"][0]["embedding"] = vector
+        with pytest.raises(AssertionError):
+            validate_embedding(body, 1, 2)
+
+
+def test_api_cases_use_shared_client_and_preserve_invalid_response(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    def send(url, payload, **kwargs):
+        calls.append(payload)
+        if payload.get("stream"):
+            result = response()
+            result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
+            return result
+        if "stop" in payload:
+            return response(None)
+        return response("hello " * 20)
+
+    monkeypatch.setattr(api_checks, "send_request", send)
+    api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    assert len(calls) == 4
+    assert calls[-1]["stop"] == "hell"
+    assert (
+        json.loads((tmp_path / "stop.json").read_text())["response"]
+        == response(None).text
+    )
+    monkeypatch.setattr(
+        api_checks, "send_request", lambda *a, **k: response(tokens=100)
+    )
+    with pytest.raises(AssertionError):
+        api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    assert "100" in json.loads((tmp_path / "unary.json").read_text())["response"]
+
+
+def test_embedding_readiness_uses_embedding_payload(monkeypatch):
+    post = Mock(return_value=response())
+    monkeypatch.setattr(client.requests, "post", post)
+    monkeypatch.setattr(client.time, "sleep", lambda _: None)
+    payload = {"model": "model", "input": "test"}
+    assert client.wait_for_model_availability(
+        "http://test", "/v1/embeddings", "model", client.logger, payload=payload
+    )
+    assert post.call_args.kwargs["json"] == payload
+
+
+def test_deploy_fixture_overrides_frontend_separately():
+    root = Path(__file__).resolve().parents[2]
+    options = {"--frontend-image": "frontend:candidate", "--model-cache-pvc": ""}
+    request = SimpleNamespace(config=SimpleNamespace(getoption=options.__getitem__))
+    spec = deployment_spec.__wrapped__(
+        root / "examples/backends/sglang/deploy/agg_embed.yaml",
+        "worker:candidate",
+        "test",
+        request,
+    )
+    assert spec["Frontend"].image == "frontend:candidate"
+    assert spec["decode"].image == "worker:candidate"
+    assert spec["decode"].model == "Qwen/Qwen3-Embedding-0.6B"

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -49,11 +49,14 @@ def response(content="hello", finish="stop", tokens=1):
 
 @pytest.mark.parametrize("content", [None, ""])
 def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
-    validate_chat_response(response(content), "model", 0, max_tokens=30, stop="hello")
+    validate_chat_response(response(content), "model", max_tokens=30, stop="hello")
     with pytest.raises(AssertionError):
-        validate_chat_response(
-            response("hello"), "model", 0, max_tokens=30, stop="hello"
-        )
+        validate_chat_response(response("hello"), "model", max_tokens=30, stop="hello")
+
+
+def test_chat_keeps_default_minimum_length_without_stop():
+    with pytest.raises(AssertionError, match="Response content too short"):
+        validate_chat_response(response("hello"), "model", max_tokens=30)
 
 
 def test_token_limit_and_finish_reason():
@@ -69,6 +72,8 @@ def test_stream_requires_one_finish_and_done():
     finish = 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
     validate_stream([content, finish, "data: [DONE]"])
     for lines in (
+        ["event:error", content, finish, "data: [DONE]"],
+        ["event: error", content, finish, "data: [DONE]"],
         [content, finish],
         [content, finish, finish, "data: [DONE]"],
         [content, finish, content, "data: [DONE]"],
@@ -89,13 +94,14 @@ def test_embedding_contract_rejects_wire_base64_and_nonfinite_vectors():
             validate_embedding(body, 1, 2)
 
 
+@pytest.mark.parametrize("endpoint", [None, "/custom/chat/completions"])
 def test_api_cases_use_shared_client_and_preserve_invalid_response(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, endpoint
 ):
     calls = []
 
     def send(url, payload, **kwargs):
-        calls.append(payload)
+        calls.append((url, payload))
         if payload.get("stream"):
             result = response()
             result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
@@ -105,9 +111,14 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
         return response("hello " * 20)
 
     monkeypatch.setattr(api_checks, "send_request", send)
-    api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+    api_checks.check_deployment_api(
+        "http://test", "model", "chat", tmp_path, endpoint=endpoint
+    )
     assert len(calls) == 4
-    assert calls[-1]["stop"] == "hell"
+    assert all(
+        url == "http://test" + (endpoint or "/v1/chat/completions") for url, _ in calls
+    )
+    assert calls[-1][1]["stop"] == "hell"
     assert (
         json.loads((tmp_path / "stop.json").read_text())["response"]
         == response(None).text
@@ -116,8 +127,38 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
         api_checks, "send_request", lambda *a, **k: response(tokens=100)
     )
     with pytest.raises(AssertionError):
-        api_checks.check_deployment_api("http://test", "model", "chat", tmp_path)
+        api_checks.check_deployment_api(
+            "http://test", "model", "chat", tmp_path, endpoint=endpoint
+        )
     assert "100" in json.loads((tmp_path / "unary.json").read_text())["response"]
+
+
+def test_embedding_api_uses_default_endpoint(monkeypatch, tmp_path):
+    calls = []
+
+    def send(url, payload, **kwargs):
+        calls.append((url, payload))
+        count = len(payload["input"]) if isinstance(payload["input"], list) else 1
+        result = response()
+        result._content = json.dumps(
+            {
+                "model": "model",
+                "object": "list",
+                "data": [
+                    {"index": i, "object": "embedding", "embedding": [0.1] * 1024}
+                    for i in range(count)
+                ],
+            }
+        ).encode()
+        return result
+
+    monkeypatch.setattr(api_checks, "send_request", send)
+    api_checks.check_deployment_api("http://test", "model", "embedding", tmp_path)
+    assert len(calls) == 3
+    assert all(url == "http://test/v1/embeddings" for url, _ in calls)
+    assert "encoding_format" not in calls[0][1]
+    assert calls[1][1]["encoding_format"] == "float"
+    assert calls[2][1]["input"] == ["Hello", "World"]
 
 
 def test_embedding_readiness_uses_embedding_payload(monkeypatch):

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -12,7 +12,11 @@ import requests
 from tests.deploy import api_checks
 from tests.deploy.conftest import deployment_spec
 from tests.deploy.dgd_utils import validate_chat_response
-from tests.deploy.response_checks import validate_embedding, validate_stream
+from tests.deploy.response_checks import (
+    validate_embedding,
+    validate_stop_response,
+    validate_stream,
+)
 from tests.utils import client
 
 pytestmark = [
@@ -44,11 +48,13 @@ def response(content="hello", finish="stop", tokens=1):
     return result
 
 
-@pytest.mark.parametrize("content", [None, ""])
-def test_stop_accepts_suppressed_content_and_rejects_visible_text(content):
-    validate_chat_response(response(content), "model", max_tokens=30, stop="hello")
+@pytest.mark.parametrize(
+    "content,stop", [(None, "hello"), ("", "hello"), ("The", "The ")]
+)
+def test_stop_accepts_shortened_content_and_rejects_stop_sequence(content, stop):
+    validate_chat_response(response(content), "model", max_tokens=30, stop=stop)
     with pytest.raises(AssertionError):
-        validate_chat_response(response("hello"), "model", max_tokens=30, stop="hello")
+        validate_chat_response(response(stop), "model", max_tokens=30, stop=stop)
 
 
 def test_chat_keeps_default_minimum_length_without_stop():
@@ -103,9 +109,14 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
             result = response()
             result._content = b'data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\ndata: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n'
             return result
+        if payload.get("max_tokens") == 1:
+            return response("The", "length", tokens=1)
         if "stop" in payload:
-            return response(None)
-        return response("hello " * 20)
+            return response("The", tokens=2)
+        return response(
+            "The air in the ruins was thick with the scent of damp earth. " * 2,
+            tokens=30,
+        )
 
     monkeypatch.setattr(api_checks, "send_request", send)
     api_checks.check_deployment_api(
@@ -115,10 +126,10 @@ def test_api_cases_use_shared_client_and_preserve_invalid_response(
     assert all(
         url == "http://test" + (endpoint or "/v1/chat/completions") for url, _ in calls
     )
-    assert calls[-1][1]["stop"] == "hell"
+    assert calls[-1][1]["stop"] == "air"
     assert (
         json.loads((tmp_path / "stop.json").read_text())["response"]
-        == response(None).text
+        == response("The", tokens=2).text
     )
     monkeypatch.setattr(
         api_checks, "send_request", lambda *a, **k: response(tokens=100)
@@ -182,3 +193,36 @@ def test_deploy_fixture_overrides_frontend_separately():
     assert spec["Frontend"].image == "frontend:candidate"
     assert spec["decode"].image == "worker:candidate"
     assert spec["decode"].model == "Qwen/Qwen3-Embedding-0.6B"
+    assert "--embedding-worker" in spec["decode"]._get_args()
+    assert "--use-sglang-tokenizer" in spec["decode"]._get_args()
+
+
+@pytest.mark.parametrize("content", ["The", "The "])
+def test_stop_allows_text_before_stop(content):
+    baseline = response("The air in the ruins", tokens=30).json()
+    stopped = response(content, tokens=2)
+    body = validate_chat_response(stopped, "model", max_tokens=30, stop="air")
+    validate_stop_response(body, baseline, "air")
+
+
+@pytest.mark.parametrize(
+    "content,finish,tokens",
+    [
+        (None, "stop", 2),
+        ("", "stop", 2),
+        ("The air", "stop", 2),
+        ("Other", "stop", 2),
+        ("The ", "length", 2),
+        ("The ", "stop", 30),
+        (False, "stop", 2),
+    ],
+)
+def test_stop_rejects_leaked_stop_divergence_and_no_early_termination(
+    content, finish, tokens
+):
+    baseline = response("The air in the ruins", tokens=30).json()
+    with pytest.raises(AssertionError):
+        body = validate_chat_response(
+            response(content, finish, tokens), "model", max_tokens=30, stop="air"
+        )
+        validate_stop_response(body, baseline, "air")

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -19,11 +19,8 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,
-    pytest.mark.framework_agnostic,
     pytest.mark.core,
-    pytest.mark.sglang,
-    pytest.mark.vllm,
-    pytest.mark.trtllm,
+    pytest.mark.parallel,
 ]
 
 

--- a/tests/deploy/test_api_checks.py
+++ b/tests/deploy/test_api_checks.py
@@ -208,7 +208,6 @@ def test_stop_allows_text_before_stop(content):
 @pytest.mark.parametrize(
     "content,finish,tokens",
     [
-        (None, "stop", 2),
         ("", "stop", 2),
         ("The air", "stop", 2),
         ("Other", "stop", 2),

--- a/tests/deploy/test_dgd.py
+++ b/tests/deploy/test_dgd.py
@@ -14,6 +14,7 @@ import logging
 import os
 import subprocess
 import time
+from pathlib import Path
 from typing import Any
 
 import kr8s
@@ -21,6 +22,7 @@ import pytest
 import requests
 import yaml
 
+from tests.deploy.api_checks import check_deployment_api
 from tests.deploy.conftest import DeploymentTarget
 from tests.deploy.dgd_utils import (
     DEFAULT_MAX_TOKENS,
@@ -33,7 +35,8 @@ from tests.deploy.dgd_utils import (
     _get_workspace_dir,
     validate_chat_response,
 )
-from tests.utils.client import send_request, wait_for_model_availability
+from tests.utils.client import wait_for_model_availability
+from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
 
@@ -194,43 +197,34 @@ async def test_deployment(
         base_url = f"http://localhost:{port_forward.local_port}"
         logger.info(f"Port forwarding established: {base_url}")
 
-        # Wait for model to be available
-        endpoint = deployment_spec.endpoint
-        model_ready = wait_for_model_availability(
-            url=base_url,
-            endpoint=endpoint,
-            model=model,
-            logger=logger,
-            max_attempts=30,
+        scenario = "embedding" if profile == "agg_embed" else "chat"
+        endpoint = (
+            "/v1/embeddings" if scenario == "embedding" else deployment_spec.endpoint
         )
-
-        assert (
-            model_ready
-        ), f"Model '{model}' did not become available within the timeout period"
-
-        # Send test request
-        url = f"{base_url}{endpoint}"
-        payload = {
-            "model": model,
-            "messages": [{"role": "user", "content": TEST_PROMPT}],
-            "max_tokens": DEFAULT_MAX_TOKENS,
-            "temperature": DEFAULT_TEMPERATURE,
-            "stream": False,
-        }
+        ready_payload = (
+            {"model": model, "input": "test"} if scenario == "embedding" else None
+        )
+        model_ready = await asyncio.to_thread(
+            wait_for_model_availability,
+            base_url,
+            endpoint,
+            model,
+            logger,
+            max_attempts=30,
+            payload=ready_payload,
+        )
+        assert model_ready, f"Model '{model}' did not become available"
         frontend_log_baseline = (
             len(normalize_log_lines(frontend_pod.logs(container="main")))
             if validate_agg_logging
             else 0
         )
-        response = send_request(
-            url, payload, timeout=float(DEFAULT_REQUEST_TIMEOUT), method="POST"
-        )
-
-        # Validate response
-        validate_chat_response(
-            response=response,
-            expected_model=model,
-            min_content_length=MIN_RESPONSE_CONTENT_LENGTH,
+        await asyncio.to_thread(
+            check_deployment_api,
+            base_url,
+            model,
+            scenario,
+            Path(resolve_test_output_path(request.node.name)) / "responses",
         )
 
         if validate_agg_logging:

--- a/tests/deploy/test_dgd.py
+++ b/tests/deploy/test_dgd.py
@@ -225,6 +225,7 @@ async def test_deployment(
             model,
             scenario,
             Path(resolve_test_output_path(request.node.name)) / "responses",
+            endpoint=endpoint,
         )
 
         if validate_agg_logging:

--- a/tests/utils/client.py
+++ b/tests/utils/client.py
@@ -162,6 +162,7 @@ def wait_for_model_availability(
     max_attempts: int = 15,
     attempt_timeouts: list[float] | None = None,
     headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
 ) -> bool:
     """
     Wait for model to be available by sending test requests.
@@ -174,6 +175,7 @@ def wait_for_model_availability(
         url: Base URL for the service (e.g., "http://localhost:8000")
         endpoint: API endpoint path (e.g., "/v1/chat/completions")
         model: Model name to test
+        payload: Optional endpoint-specific readiness request, such as embedding input.
         logger: Logger instance for output
         max_attempts: Maximum number of attempts to check availability (default: 15)
         attempt_timeouts: List of timeout values for each attempt (default: decreasing from 60s)
@@ -189,12 +191,16 @@ def wait_for_model_availability(
 
     for attempt in range(max_attempts):
         try:
-            test_payload = {
-                "model": model,
-                "messages": [{"role": "user", "content": "test"}],
-                "max_tokens": 1,
-                "stream": False,
-            }
+            test_payload = (
+                payload
+                if payload is not None
+                else {
+                    "model": model,
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1,
+                    "stream": False,
+                }
+            )
 
             timeout_val = attempt_timeouts[min(attempt, len(attempt_timeouts) - 1)]
             logger.debug(


### PR DESCRIPTION
## Summary

Ordinary deploy tests currently use the worker runtime image for the Frontend and only check a unary chat request. Pass the standalone frontend image through the PR/nightly workflows and a dedicated action input, add the SGLang `agg_embed` deployment profile, and share API checks across deployment and compatibility tests.

- Select the endpoint, readiness payload, and explicit chat/embedding checker together. Both checkers receive a complete URL and reuse the shared transport, port-forward retry, and raw response artifacts.
- Validate response schemas with strict OpenAI SDK models, then check request-specific behavior: chat token limits, complete stop prefixes, and stream model/ID/role consistency alongside finish/error/DONE handling.
- Cover embedding default/float/batch output, 128 dimensions, and explicit base64. Check decoded finite float32 values, batch/unary agreement with numeric tolerance, and usage counts/totals. Raw responses stay unchanged in artifacts.
- Include the embedding-specific worker canary fix previously proposed in #14680, which is now closed in favor of this PR.

No N-2 matrix or historical image resolution is introduced here; #14460 will consume the shared helpers.

## Where should the reviewer start?

Start with `tests/deploy/api_checks.py` and `tests/deploy/response_checks.py`, then the selection and retry wiring in `tests/deploy/test_dgd.py`. The workflow-to-action image interface is in `.github/workflows/shared-deploy-test.yml` and `.github/actions/dynamo-deploy-test/action.yml`.

## Related Issues

Relates to DEP #14685, supersedes #14680, and provides shared coverage for #14460.

## Validation

- 55 local CPU tests passed: `tests/deploy/test_api_checks.py` and `tests/deploy/test_dgd_utils.py`, with the repository conftest.
- All 43 API tests also passed under the exact core CPU selector used by PR CI.
- All applicable pre-commit checks passed, including Python format/lint, YAML, action pins, and pytest markers.
- Executed the action's pytest argument construction with a stub runner for both empty and explicit frontend images; both preserve the worker image and marker arguments.
- Live GPU deployment validation was not run on this host and still needs CI. Chat uses four API requests per deployment; embedding uses six requests on the existing one-GPU profile. Live numerical tolerance and timing remain to be confirmed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an aggregated SGLang embedding deployment template for Qwen3-Embedding.
  - Added support for embedding-specific health checks using text or tokenized inputs.
  - Added deployment API validation for embedding and chat-completion requests, including streaming, token limits, and stop sequences.
  - Added configurable frontend image overrides for deployment tests.

- **Documentation**
  - Added the aggregated SGLang embedding template to the Kubernetes deployment documentation.

- **Tests**
  - Expanded automated deployment coverage for embedding services and frontend-enabled framework deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->