### PR TITLE
fix(ci): honor VRAM auto worker count under pytest-xdist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,46 +248,91 @@ def pytest_configure(config: pytest.Config) -> None:
             returncode=2,
         )
 
-    vram_limit = config.getoption("max_vram_gib", default=None)
-    if vram_limit is None:
+    if not _vram_scheduling_requested(config):
         return
-    if config.option.collectonly:
-        return
-    # Delayed: vram_utils requires pynvml, otherwise conftest fails to load
-    # on CPU-only CI runners (e.g. ARM deploy tests) that lack nvidia-ml-py.
-    from tests.utils.pytest_parallel_gpu import _parse_cuda_visible
-    from tests.utils.vram_utils import auto_worker_count, detect_gpus
-
-    gpus = detect_gpus()
-    if gpus:
-        config.stash[_gpu_parallel_gpus_key] = gpus
-
-    # Honour CUDA_VISIBLE_DEVICES to restrict which GPUs the scheduler uses.
-    # NVML always sees all physical GPUs, so we filter here.
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if cvd is not None:
-        config.stash[_gpu_indices_key] = _parse_cuda_visible(cvd, gpus)
-        selected_gpus = [
-            g for g in gpus if g["index"] in config.stash[_gpu_indices_key]
-        ]
-    else:
-        config.stash[_gpu_indices_key] = None  # all GPUs
-        selected_gpus = gpus
+    vram_limit = config.getoption("max_vram_gib")
+    selected_gpus = _detect_selected_gpus(config)
 
     # If -n is set with --max-vram-gib, save the slot count and disable xdist
     # so our subprocess orchestrator handles parallelism instead.
     # xdist's pytest_configure(trylast=True) checks _is_distribution_mode()
     # which reads dist/tx (not numprocesses), so we must also clear dist.
+    # "auto" is normally already resolved by pytest_cmdline_main below; the
+    # string branch here is a fallback for xdist versions that resolve it later.
     numproc = config.getoption("numprocesses", default=None)
     if numproc is not None and numproc != 0:
         if isinstance(numproc, str) or numproc == -1:
-            config.stash[_gpu_slots_key] = (
-                auto_worker_count(selected_gpus, vram_limit) if selected_gpus else 1
+            config.stash[_gpu_slots_key] = _vram_auto_worker_count(
+                selected_gpus, vram_limit
             )
         else:
             config.stash[_gpu_slots_key] = int(numproc)
         config.option.numprocesses = 0
         config.option.dist = "no"
+
+
+def _vram_scheduling_requested(config: pytest.Config) -> bool:
+    """True when --max-vram-gib is set for a real (non --collect-only) run."""
+    if config.getoption("max_vram_gib", default=None) is None:
+        return False
+    return not config.option.collectonly
+
+
+def _detect_selected_gpus(config: pytest.Config) -> list[dict]:
+    """Detect GPUs once per session and return those the scheduler may use.
+
+    Populates the GPU stash keys on first call so pytest_cmdline_main and
+    pytest_configure share one NVML probe.
+    """
+    # Delayed: vram_utils requires pynvml, otherwise conftest fails to load
+    # on CPU-only CI runners (e.g. ARM deploy tests) that lack nvidia-ml-py.
+    from tests.utils.pytest_parallel_gpu import _parse_cuda_visible
+    from tests.utils.vram_utils import detect_gpus
+
+    if _gpu_indices_key not in config.stash:
+        gpus = detect_gpus()
+        if gpus:
+            config.stash[_gpu_parallel_gpus_key] = gpus
+        # Honour CUDA_VISIBLE_DEVICES to restrict which GPUs the scheduler uses.
+        # NVML always sees all physical GPUs, so we filter here.
+        cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+        config.stash[_gpu_indices_key] = (
+            _parse_cuda_visible(cvd, gpus) if cvd is not None else None  # None = all
+        )
+
+    gpus = config.stash.get(_gpu_parallel_gpus_key, [])
+    indices = config.stash[_gpu_indices_key]
+    if indices is None:
+        return gpus
+    return [g for g in gpus if g["index"] in indices]
+
+
+def _vram_auto_worker_count(selected_gpus: list[dict], vram_limit: float) -> int:
+    # Delayed: see the pynvml note in _detect_selected_gpus.
+    from tests.utils.vram_utils import auto_worker_count
+
+    return auto_worker_count(selected_gpus, vram_limit) if selected_gpus else 1
+
+
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_cmdline_main(config: pytest.Config):
+    """Resolve ``-n auto`` from GPU VRAM before pytest-xdist resolves it from CPUs.
+
+    xdist (>= 3.x) turns "auto"/"logical" into an integer CPU count in its own
+    tryfirst pytest_cmdline_main, which runs before pytest_configure; by then the
+    VRAM-aware branch in pytest_configure only ever sees the host CPU count. A
+    hook wrapper runs ahead of every plain hookimpl regardless of registration
+    order, so this is the one place the "auto" request is still observable.
+
+    Explicit numeric ``-n`` values are left untouched. The CPU/cgroup ceiling is
+    applied later by run_parallel (see effective_cpu_budget).
+    """
+    if _vram_scheduling_requested(config):
+        if config.getoption("numprocesses", default=None) in ("auto", "logical"):
+            config.option.numprocesses = _vram_auto_worker_count(
+                _detect_selected_gpus(config), config.getoption("max_vram_gib")
+            )
+    return (yield)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/utils/test_xdist_auto_worker_count.py
+++ b/tests/utils/test_xdist_auto_worker_count.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for resolving ``-n auto`` from GPU VRAM ahead of pytest-xdist.
+
+pytest-xdist converts ``-n auto`` to a CPU count in its own tryfirst
+``pytest_cmdline_main``. ``tests/conftest.py`` must observe the "auto" request
+before that conversion so ``--max-vram-gib`` runs get the VRAM-derived slot
+count. These tests drive a real pytest session (pytester, in-process) with the
+real xdist plugin loaded and read ``numprocesses`` after both hooks have run.
+No GPU or ``pynvml`` required -- GPU detection is stubbed.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.utils import vram_utils
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+pytest_plugins = ["pytester"]
+
+_FAKE_GPUS = [
+    {"index": 0, "name": "fake-80g", "total_mib": 80 * 1024},
+    {"index": 1, "name": "fake-80g", "total_mib": 80 * 1024},
+]
+_VRAM_LIMIT = 10.0
+# 2 GPUs x int(80 GiB * 0.85 / 10 GiB) = 2 x 6
+_EXPECTED_AUTO_SLOTS = vram_utils.auto_worker_count(_FAKE_GPUS, _VRAM_LIMIT)
+# Sentinel returned in place of xdist's CPU-count probe, so a value resolved by
+# xdist (rather than by the conftest) is unambiguous on any host.
+_XDIST_CPU_SENTINEL = 777
+
+# pytest_cmdline_main here is plain priority: pluggy calls it after every
+# tryfirst impl (xdist's conversion and the conftest wrapper) and, because it
+# is registered after _pytest.main, before pytest's own session runner.
+# Returning an exit code short-circuits the firstresult hook so no session runs.
+_RECORDER_PLUGIN = f"""
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True, optionalhook=True)
+def pytest_xdist_auto_num_workers(config):
+    return {_XDIST_CPU_SENTINEL}
+
+
+def pytest_cmdline_main(config):
+    print(f"RECORDED_NUMPROCESSES={{config.option.numprocesses!r}}")
+    return 0
+"""
+
+
+@pytest.fixture
+def fake_gpus(monkeypatch):
+    monkeypatch.setattr(vram_utils, "detect_gpus", lambda: list(_FAKE_GPUS))
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+
+@pytest.fixture
+def run_cmdline(pytester, monkeypatch):
+    """Run the real tests/conftest.py + xdist through pytest_cmdline_main."""
+    conftest_path = Path(__file__).parents[1] / "conftest.py"
+    pytester.makeconftest(conftest_path.read_text())
+    pytester.makepyfile(xdist_recorder=_RECORDER_PLUGIN)
+    pytester.syspathinsert()
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
+    def _run(*args: str):
+        result = pytester.runpytest(
+            "-o", "addopts=", "-p", "xdist.plugin", "-p", "xdist_recorder", *args
+        )
+        assert result.ret == 0, result.stderr.str()
+        match = re.search(r"RECORDED_NUMPROCESSES=(.+)", result.stdout.str())
+        assert match, result.stdout.str()
+        return ast.literal_eval(match.group(1))
+
+    return _run
+
+
+def test_auto_resolves_to_vram_slot_count_before_xdist(run_cmdline, fake_gpus):
+    numproc = run_cmdline("-n", "auto", f"--max-vram-gib={_VRAM_LIMIT}")
+    assert numproc == _EXPECTED_AUTO_SLOTS
+
+
+def test_logical_resolves_like_auto(run_cmdline, fake_gpus):
+    numproc = run_cmdline("-n", "logical", f"--max-vram-gib={_VRAM_LIMIT}")
+    assert numproc == _EXPECTED_AUTO_SLOTS
+
+
+def test_auto_honours_cuda_visible_devices(run_cmdline, fake_gpus, monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    numproc = run_cmdline("-n", "auto", f"--max-vram-gib={_VRAM_LIMIT}")
+    assert numproc == _EXPECTED_AUTO_SLOTS // 2
+
+
+def test_explicit_numeric_n_is_untouched(run_cmdline, fake_gpus):
+    numproc = run_cmdline("-n", "3", f"--max-vram-gib={_VRAM_LIMIT}")
+    assert numproc == 3
+
+
+def test_auto_without_max_vram_gib_is_left_to_xdist(run_cmdline, fake_gpus):
+    numproc = run_cmdline("-n", "auto")
+    assert numproc == _XDIST_CPU_SENTINEL
+
+
+def test_auto_with_collect_only_is_left_to_xdist(run_cmdline, fake_gpus):
+    numproc = run_cmdline(
+        "--collect-only", "-n", "auto", f"--max-vram-gib={_VRAM_LIMIT}"
+    )
+    assert numproc == _XDIST_CPU_SENTINEL
+
+
+def test_auto_without_gpus_falls_back_to_one_slot(run_cmdline, monkeypatch):
+    monkeypatch.setattr(vram_utils, "detect_gpus", lambda: [])
+    numproc = run_cmdline("-n", "auto", f"--max-vram-gib={_VRAM_LIMIT}")
+    assert numproc == 1
+
+
+def test_conftest_hook_is_a_tryfirst_wrapper():
+    """Guard the ordering guarantee relative to xdist's tryfirst hookimpl."""
+    import xdist.plugin
+
+    from tests import conftest
+
+    ours = conftest.pytest_cmdline_main.pytest_impl  # type: ignore[attr-defined]
+    theirs = xdist.plugin.pytest_cmdline_main.pytest_impl  # type: ignore[attr-defined]
+    assert theirs.get("tryfirst") and not theirs.get("wrapper")
+    assert ours.get("tryfirst") and ours.get("wrapper")


### PR DESCRIPTION
## Overview:

pytest-xdist 3.x converts `-n auto` to a CPU count in its tryfirst `pytest_cmdline_main`, before `tests/conftest.py`'s `pytest_configure` runs, so the VRAM-aware `auto_worker_count()` path never fired and `--max-vram-gib` runs got the host CPU count instead.

## Details:

Add a `wrapper=True, tryfirst=True` `pytest_cmdline_main` in `tests/conftest.py` that resolves `auto`/`logical` to `auto_worker_count()` when `--max-vram-gib` is set (non `--collect-only`); explicit numeric `-n` values are untouched and the CPU/cgroup ceiling in `run_parallel` still applies. GPU detection is factored into `_detect_selected_gpus()` and shared with `pytest_configure`, which keeps its string branch as a fallback. New pytester tests run the real conftest with the real xdist plugin and check the resolved value after both hooks.

## Where should the reviewer start?

- `tests/conftest.py` — `pytest_cmdline_main` and `_detect_selected_gpus`
- `tests/utils/test_xdist_auto_worker_count.py`

## Validation

- `pytest tests/utils/test_xdist_auto_worker_count.py` — 8 passed (5 fail without the conftest change)
- `pytest tests/utils/test_pytest_parallel_gpu.py tests/test_default_markers.py` — 35 passed

## Related Issues

- Closes #14268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
