### PR TITLE
fix(responses): preserve raw reasoning_content without an explicit summary request

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -3468,10 +3468,6 @@ thinking
 
     #[test]
     fn test_reasoning_text_preserved_without_explicit_summary_request() {
-        // Regression test for #14069: reasoning.summary is not the only way to
-        // preserve reasoning_content. Whenever the backend returns non-empty
-        // reasoning_content, it should show up as a raw-reasoning output item,
-        // whether or not the request asked for reasoning.summary.
         let unrequested = chat_completion_to_response(
             make_chat_resp_with_reasoning("private reasoning"),
             &ResponseParams::default(),

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -1046,13 +1046,6 @@ pub struct ResponseParams {
 }
 
 impl ResponseParams {
-    fn reasoning_summary_requested(&self) -> bool {
-        self.reasoning
-            .as_ref()
-            .and_then(|reasoning| reasoning.summary)
-            .is_some()
-    }
-
     fn namespace_for_function(&self, name: &str) -> Option<String> {
         let tools = self.tools.as_deref()?;
         if tools
@@ -1158,9 +1151,13 @@ pub fn chat_completion_to_response(
             choice.finish_reason == Some(dynamo_protocols::types::FinishReason::Length);
 
         // Reasoning precedes tool calls so output order matches the decoded turn.
+        //
+        // Raw reasoning_content is preserved whenever the backend returns it, whether
+        // or not the caller asked for reasoning.summary: the backend/parser already did
+        // the work, and dropping it silently loses information the caller can otherwise
+        // only get via reasoning.summary. See issue #14069.
         if let Some(reasoning_text) = choice.message.reasoning_content
             && !reasoning_text.is_empty()
-            && params.reasoning_summary_requested()
         {
             output.push(OutputItem::Reasoning(ReasoningItem {
                 id: Some(format!("rs_{}", Uuid::new_v4().simple())),
@@ -3470,20 +3467,28 @@ thinking
     }
 
     #[test]
-    fn test_reasoning_text_requires_explicit_request() {
+    fn test_reasoning_text_preserved_without_explicit_summary_request() {
+        // Regression test for #14069: reasoning.summary is not the only way to
+        // preserve reasoning_content. Whenever the backend returns non-empty
+        // reasoning_content, it should show up as a raw-reasoning output item,
+        // whether or not the request asked for reasoning.summary.
         let unrequested = chat_completion_to_response(
             make_chat_resp_with_reasoning("private reasoning"),
             &ResponseParams::default(),
             None,
         )
         .unwrap();
-        assert!(
-            unrequested
-                .inner
-                .output
-                .iter()
-                .all(|item| !matches!(item, OutputItem::Reasoning(_)))
-        );
+        let reasoning = unrequested
+            .inner
+            .output
+            .iter()
+            .find_map(|item| match item {
+                OutputItem::Reasoning(reasoning) => Some(reasoning),
+                _ => None,
+            })
+            .expect("reasoning output even without a requested summary");
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "private reasoning");
 
         let params = requested_reasoning_params();
         let requested =

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -1787,9 +1787,6 @@ mod tests {
 
     #[test]
     fn test_reasoning_without_requested_summary_still_streams_raw_reasoning() {
-        // Regression test for #14069: reasoning.summary is not the only way to
-        // preserve reasoning_content. When the backend returns it, the raw-reasoning
-        // lifecycle should stream even without reasoning.summary in the request.
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
 
         let reasoning_events = conv.process_chunk(&reasoning_chunk("private reasoning"));

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -404,10 +404,13 @@ impl ResponseStreamConverter {
                 self.output_limit_reached = true;
             }
 
+            // Raw reasoning_content is preserved whenever the backend returns it, whether
+            // or not the caller asked for reasoning.summary: the backend/parser already did
+            // the work, and dropping it silently loses information the caller can otherwise
+            // only get via reasoning.summary. See issue #14069.
             if let Some(reasoning) = delta.reasoning_content.as_deref()
                 && !reasoning.is_empty()
                 && !self.message_started
-                && self.params.reasoning_summary_requested()
             {
                 self.append_reasoning_delta(reasoning, events);
             }
@@ -1783,13 +1786,28 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_without_requested_summary_emits_no_events() {
+    fn test_reasoning_without_requested_summary_still_streams_raw_reasoning() {
+        // Regression test for #14069: reasoning.summary is not the only way to
+        // preserve reasoning_content. When the backend returns it, the raw-reasoning
+        // lifecycle should stream even without reasoning.summary in the request.
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
 
-        let events = conv.process_chunk(&reasoning_chunk("private reasoning"));
+        let reasoning_events = conv.process_chunk(&reasoning_chunk("private reasoning"));
+        assert_eq!(
+            event_types(&reasoning_events),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
 
-        assert!(events.is_empty());
-        assert!(conv.completed_output().is_empty());
+        let output = conv.completed_output();
+        let OutputItem::Reasoning(reasoning) = &output[0] else {
+            panic!("expected reasoning output even without a requested summary");
+        };
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "private reasoning");
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

Dynamo's Responses API converter silently drops non-empty backend `reasoning_content` whenever the request did not set `reasoning.summary`, even though the raw-reasoning event/output-item lifecycle it builds does not actually depend on summary mode. This PR removes that gate so reasoning is preserved whenever the backend returns it.

## Details:

- `lib/llm/src/protocols/openai/responses/mod.rs`: removed the `reasoning_summary_requested()` gate from the non-streaming reasoning-conversion path (`chat_completion_to_response`), and removed the now-unused `reasoning_summary_requested()` helper.
- `lib/llm/src/protocols/openai/responses/stream_converter.rs`: removed the equivalent gate from the streaming conversion path (`ResponseStreamConverter::append_chunk_events`).
- Updated the two existing tests that had locked in the old (gate-on) behavior to assert the corrected behavior, mirroring the assertions already used by the adjacent, already-passing "summary requested" test cases, since the fix makes both code paths identical regardless of whether `reasoning.summary` was requested.

## Where should the reviewer start?

`lib/llm/src/protocols/openai/responses/mod.rs` around line 1159 (non-streaming) and `lib/llm/src/protocols/openai/responses/stream_converter.rs` around line 411 (streaming) — these are the two gate removals the issue points at directly.

## Related Issues

**🔗 This PR is linked to an issue:**
Closes #14069

## Summary

- Backend `reasoning_content` is now surfaced as a `ReasoningItem` (raw `content`, empty `summary`) whenever the backend returns it, for both `/v1/responses` streaming and non-streaming paths, regardless of whether the request set `reasoning.summary`.
- Removed the now-dead `ResponseParams::reasoning_summary_requested()` helper (no remaining callers after the gate removal).

## Validation

- `cargo test -p dynamo-llm --lib --no-default-features protocols::openai::responses::` (run with `CARGO_PROFILE_TEST_DEBUG=0` to fit the local build machine's memory): **107 passed; 0 failed; 0 ignored**, including both rewritten regression tests:
  - `stream_converter::tests::test_reasoning_without_requested_summary_still_streams_raw_reasoning ... ok`
  - `tests::test_reasoning_text_preserved_without_explicit_summary_request ... ok`
- `cargo check -p dynamo-llm --lib` and `--tests` (default features, i.e. including `block-manager`/CUDA/NIXL): both pass cleanly with no errors, so the change also type-checks under the default feature set used by CI.
- Confirmed via `grep -rn` across `lib/` that `reasoning_summary_requested()` had exactly two call sites before this change (one per file) and no other references anywhere, so removing both gates and the helper itself leaves no dangling references.

Fixes #14069.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved non-empty reasoning content in Responses API results, even when no reasoning summary was explicitly requested.
  - Ensured streamed reasoning content produces the appropriate reasoning events and remains available in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->