### PR TITLE
fix(vllm-omni): harden generated video output

### DIFF
--- a/components/src/dynamo/common/protocols/video_protocol.py
+++ b/components/src/dynamo/common/protocols/video_protocol.py
@@ -108,6 +108,12 @@ class VideoData(BaseModel):
     b64_json: Optional[str] = None
     """Base64-encoded video (if response_format is 'b64_json')."""
 
+    fps: Optional[int] = None
+    """Actual video frame rate when reported by the model."""
+
+    audio_sample_rate: Optional[int] = None
+    """Muxed audio sample rate when the generated video contains audio."""
+
 
 class NvVideosResponse(BaseModel):
     """Response structure for video generation.

--- a/components/src/dynamo/common/tests/test_video_protocol.py
+++ b/components/src/dynamo/common/tests/test_video_protocol.py
@@ -56,3 +56,19 @@ def test_video_response_wire_shape():
         "created": 0,
         "data": [{"output_format": "mp4", "url": "http://example.com/v.mp4"}],
     }
+
+
+def test_video_response_reports_media_metadata():
+    response = VideoData(
+        output_format="mp4",
+        url="http://example.com/v.mp4",
+        fps=24,
+        audio_sample_rate=32000,
+    )
+
+    assert response.model_dump(exclude_none=True) == {
+        "output_format": "mp4",
+        "url": "http://example.com/v.mp4",
+        "fps": 24,
+        "audio_sample_rate": 32000,
+    }

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -56,6 +56,8 @@ class OmniDiffusionKwargs:
     cache_config: Optional[str] = None
     enable_cache_dit_summary: bool = False
     enable_cpu_offload: bool = False
+    task_type: Optional[str] = None
+    diffusion_attention_backend: Optional[str] = None
     enforce_eager: bool = False
 
 
@@ -190,6 +192,20 @@ class OmniArgGroup(ArgGroup):
             env_var="DYN_OMNI_ENABLE_CPU_OFFLOAD",
             default=False,
             help="Enable CPU offloading for diffusion models to reduce GPU memory usage.",
+        )
+        add_argument(
+            g,
+            flag_name="--task-type",
+            env_var="DYN_OMNI_TASK_TYPE",
+            default=None,
+            help="Model-defined task or checkpoint partition selected at startup.",
+        )
+        add_argument(
+            g,
+            flag_name="--diffusion-attention-backend",
+            env_var="DYN_OMNI_DIFFUSION_ATTENTION_BACKEND",
+            default=None,
+            help="vLLM-Omni diffusion attention backend.",
         )
         add_negatable_bool_argument(
             g,

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -254,9 +254,6 @@ class OmniHandler(BaseOmniHandler):
             media_fs=media_output_fs,
             media_http_url=media_output_http_url,
             default_fps=getattr(config, "default_video_fps", 16),
-            model_config=getattr(
-                getattr(self.engine_client, "model_config", None), "hf_config", None
-            ),
         )
 
         # Audio/TTS handler — composition, not inheritance.

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -253,6 +253,9 @@ class OmniHandler(BaseOmniHandler):
             media_fs=media_output_fs,
             media_http_url=media_output_http_url,
             default_fps=getattr(config, "default_video_fps", 16),
+            model_config=getattr(
+                getattr(self.engine_client, "model_config", None), "hf_config", None
+            ),
         )
 
         # Audio/TTS handler — composition, not inheritance.
@@ -793,5 +796,7 @@ class OmniHandler(BaseOmniHandler):
             sampling_params_list=sampling_params_list,
             request_type=RequestType.VIDEO_GENERATION,
             fps=fps,
+            response_format=req.response_format,
+            output_format=req.output_format,
             lora_request=lora_request,
         )

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import copy
 import functools
 import logging
 import os
@@ -688,6 +689,83 @@ class OmniHandler(BaseOmniHandler):
                 )
         return result if result else [diffusion_sp]
 
+    def _build_video_sampling_params_list(
+        self, req: NvCreateVideoRequest, nvext: VideoNvExt
+    ) -> tuple[list, OmniDiffusionSamplingParams]:
+        """Clone per-stage model defaults and apply explicit video overrides."""
+        defaults = list(self.engine_client.default_sampling_params_list or [])
+        if not defaults:
+            defaults = [OmniDiffusionSamplingParams()]
+            stage_types = ["diffusion"]
+        else:
+            stage_types = [
+                getattr(
+                    self.engine_client.engine.get_stage_metadata(i),
+                    "stage_type",
+                    "llm",
+                )
+                for i in range(len(defaults))
+            ]
+
+        result = []
+        output_sp = None
+        for default, stage_type in zip(defaults, stage_types, strict=True):
+            if stage_type != "diffusion":
+                result.append(
+                    default.clone() if hasattr(default, "clone") else SamplingParams()
+                )
+                continue
+
+            sp = (
+                copy.deepcopy(default)
+                if isinstance(default, OmniDiffusionSamplingParams)
+                else OmniDiffusionSamplingParams()
+            )
+            self._apply_video_sampling_overrides(sp, req, nvext)
+            result.append(sp)
+            output_sp = sp
+
+        if output_sp is None:
+            raise ValueError("Video generation requires a diffusion stage")
+        return result, output_sp
+
+    def _apply_video_sampling_overrides(
+        self,
+        sp: OmniDiffusionSamplingParams,
+        req: NvCreateVideoRequest,
+        nvext: VideoNvExt,
+    ) -> None:
+        """Overlay only fields explicitly supplied by a video request."""
+        if req.size is not None:
+            width, height = parse_size(req.size)
+            sp.width = width
+            sp.height = height
+
+        if nvext.num_frames is not None:
+            sp.num_frames = nvext.num_frames
+        elif req.seconds is not None:
+            model_fps = getattr(sp, "fps", None) or getattr(sp, "frame_rate", None)
+            sp.num_frames = compute_num_frames(
+                num_frames=None,
+                seconds=req.seconds,
+                fps=nvext.fps or model_fps,
+                default_fps=int(
+                    getattr(self.config, "default_video_fps", DEFAULT_VIDEO_FPS)
+                ),
+            )
+
+        if nvext.fps is not None:
+            sp.fps = nvext.fps
+            if hasattr(sp, "frame_rate"):
+                sp.frame_rate = float(nvext.fps)
+
+        self._update_if_not_none(sp, "num_inference_steps", nvext.num_inference_steps)
+        self._update_if_not_none(sp, "guidance_scale", nvext.guidance_scale)
+        self._update_if_not_none(sp, "seed", nvext.seed)
+        self._update_if_not_none(sp, "boundary_ratio", nvext.boundary_ratio)
+        self._update_if_not_none(sp, "guidance_scale_2", nvext.guidance_scale_2)
+        _apply_media_passthrough(sp, req.extra_args)
+
     def _engine_inputs_from_image(self, req: NvCreateImageRequest) -> EngineInputs:
         """Build engine inputs from an NvCreateImageRequest."""
         width, height = parse_size(req.size, default_w=1024, default_h=1024)
@@ -741,16 +819,7 @@ class OmniHandler(BaseOmniHandler):
                 attached to the prompt via ``multi_modal_data`` so vllm-omni's
                 I2V pipeline pre-process can use it.
         """
-        width, height = parse_size(req.size)
         nvext = req.nvext or VideoNvExt()
-
-        num_frames = compute_num_frames(
-            num_frames=nvext.num_frames,
-            seconds=req.seconds,
-            fps=nvext.fps,
-            default_fps=DEFAULT_VIDEO_FPS,
-        )
-        fps = nvext.fps if nvext.fps is not None else DEFAULT_VIDEO_FPS
 
         prompt = OmniTextPrompt(prompt=req.prompt)
         if nvext.negative_prompt is not None:
@@ -764,38 +833,32 @@ class OmniHandler(BaseOmniHandler):
                 image.size[1],
             )
 
-        sp = OmniDiffusionSamplingParams(
-            height=height,
-            width=width,
-            num_frames=num_frames,
+        sampling_params_list, output_sp = self._build_video_sampling_params_list(
+            req, nvext
         )
-        self._update_if_not_none(sp, "num_inference_steps", nvext.num_inference_steps)
-        self._update_if_not_none(sp, "guidance_scale", nvext.guidance_scale)
-        sp.seed = (
-            nvext.seed if nvext.seed is not None else random.randint(0, 2**32 - 1)
-        )
-        self._update_if_not_none(sp, "boundary_ratio", nvext.boundary_ratio)
-        self._update_if_not_none(sp, "guidance_scale_2", nvext.guidance_scale_2)
-        self._update_if_not_none(sp, "fps", fps)
-        _apply_media_passthrough(sp, req.extra_args)
-
-        sampling_params_list = self._build_sampling_params_list(sp)
         lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)
+
+        model_fps = getattr(output_sp, "fps", None) or getattr(
+            output_sp, "frame_rate", None
+        )
+        output_fps = int(
+            model_fps or getattr(self.config, "default_video_fps", DEFAULT_VIDEO_FPS)
+        )
 
         logger.info(
             "Video diffusion request: prompt='%s...', size=%sx%s, frames=%s, fps=%s",
             req.prompt[:50],
-            width,
-            height,
-            num_frames,
-            fps,
+            getattr(output_sp, "width", None),
+            getattr(output_sp, "height", None),
+            getattr(output_sp, "num_frames", None),
+            model_fps,
         )
 
         return EngineInputs(
             prompt=prompt,
             sampling_params_list=sampling_params_list,
             request_type=RequestType.VIDEO_GENERATION,
-            fps=fps,
+            fps=output_fps,
             response_format=req.response_format,
             output_format=req.output_format,
             lora_request=lora_request,

--- a/components/src/dynamo/vllm/omni/output_formatter.py
+++ b/components/src/dynamo/vllm/omni/output_formatter.py
@@ -14,6 +14,7 @@ import logging
 import struct
 import time
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, Dict, Optional
@@ -21,6 +22,11 @@ from typing import Any, Dict, Optional
 import numpy as np
 import soundfile as sf
 import torch
+
+try:
+    from vllm_omni.diffusion.utils.media_utils import mux_video_audio_bytes
+except (ImportError, OSError):
+    mux_video_audio_bytes = None  # type: ignore[assignment]
 
 from dynamo.common.protocols.audio_protocol import AudioData, NvAudioSpeechResponse
 from dynamo.common.protocols.image_protocol import ImageData, NvImagesResponse
@@ -37,6 +43,8 @@ from dynamo.vllm.handlers import build_prompt_tokens_details
 from dynamo.vllm.omni.utils import is_empty_payload
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_AUDIO_SAMPLE_RATE = 24000
 
 
 @dataclass
@@ -116,11 +124,16 @@ class DiffusionFormatter:
         media_fs: Any,
         media_http_url: Optional[str],
         default_fps: int = 16,
+        model_config: Any = None,
     ) -> None:
         self._model_name = model_name
         self._media_fs = media_fs
         self._media_http_url = media_http_url
         self._default_fps = default_fps
+        self._default_audio_sample_rate = (
+            self._extract_audio_sample_rate_from_config(model_config)
+            or DEFAULT_AUDIO_SAMPLE_RATE
+        )
 
     async def format(
         self, stage_output: Any, request_id: str, *, request_type: Any, **ctx: Any
@@ -128,17 +141,18 @@ class DiffusionFormatter:
         images = (
             stage_output.images if hasattr(stage_output, "images") else stage_output
         )
-        if is_empty_payload(images):
-            return None
 
         if request_type == RequestType.VIDEO_GENERATION:
             return await self._encode_video(
                 images,
                 request_id,
+                multimodal_output=self._extract_multimodal_output(stage_output),
                 fps=ctx.get("fps", self._default_fps),
                 response_format=ctx.get("response_format"),
                 output_format=ctx.get("output_format"),
             )
+        if is_empty_payload(images):
+            return None
         return await self._encode_image(
             images,
             request_id,
@@ -148,48 +162,88 @@ class DiffusionFormatter:
 
     async def _encode_video(
         self,
-        images: list,
+        images: Any,
         request_id: str,
         fps: int,
+        multimodal_output: dict[str, Any] | None = None,
         response_format: Optional[str] = None,
         output_format: Optional[str] = None,
     ) -> Dict[str, Any] | None:
-        output_format = output_format or "mp4"
+        requested_output_format = output_format
+        output_format = "mp4"
         response_format = response_format or "url"
         if response_format not in ("url", "b64_json"):
             raise ValueError(
                 f"Unsupported response_format: {response_format!r}; expected 'url' or 'b64_json'"
             )
-        if output_format != "mp4":
-            raise ValueError(
-                f"Unsupported output_format: {output_format!r}; only 'mp4' is supported"
+        if requested_output_format not in (None, "mp4"):
+            logger.warning(
+                "Ignoring unsupported video output_format hint %r; encoding MP4",
+                requested_output_format,
             )
         try:
             start_time = time.time()
-            # Encode with the in-tree VP9 (libvpx-vp9) encoder rather
-            # than diffusers.export_to_video, whose imageio backend defaults to the
-            # H.264 codec that the codec-compliant image no longer ships (it would
-            # fail with "No valid H.264 encoder was found"). encode_to_video_bytes
-            # is the same shared helper the TRT-LLM video handler uses; VP9-in-mp4
-            # is valid and decodes with our VP8/VP9 allowlist.
-            frames_np = frames_to_numpy(normalize_video_frames(images))
-            video_bytes = await asyncio.to_thread(
-                encode_to_video_bytes, frames_np, fps=fps, output_format=output_format
+            multimodal_output = multimodal_output or {}
+            videos = self._split_video_outputs(images, multimodal_output)
+            if not videos:
+                raise ValueError("No video outputs found in generation result")
+            resolved_fps = self._resolve_int_metadata(
+                multimodal_output, "fps", "video"
+            ) or int(fps)
+            audio_sample_rate = self._resolve_audio_sample_rate(multimodal_output)
+            audio_outputs = self._split_audio_outputs(
+                multimodal_output.get("audio"), len(videos)
             )
 
-            if response_format == "b64_json":
+            data = []
+            for index, (video, audio) in enumerate(
+                zip(videos, audio_outputs, strict=True)
+            ):
+                frames_np = self._video_to_numpy_frames(video)
+                if audio is None:
+                    # The codec-compliant standard image retains its existing
+                    # royalty-free VP9 path for silent video models.
+                    video_bytes = await asyncio.to_thread(
+                        encode_to_video_bytes,
+                        frames_np,
+                        fps=resolved_fps,
+                        output_format=output_format,
+                    )
+                else:
+                    if mux_video_audio_bytes is None:
+                        raise RuntimeError(
+                            "Generated audio requires PyAV with H.264 and AAC encoders; "
+                            "use the video-audio codec overlay"
+                        )
+                    audio_np = self._audio_to_numpy(audio)
+                    video_bytes = await asyncio.to_thread(
+                        mux_video_audio_bytes,
+                        frames_np,
+                        audio_np,
+                        fps=float(resolved_fps),
+                        audio_sample_rate=audio_sample_rate,
+                    )
+
                 video_data = VideoData(
                     output_format=output_format,
-                    b64_json=base64.b64encode(video_bytes).decode("utf-8"),
+                    fps=resolved_fps,
+                    audio_sample_rate=audio_sample_rate if audio is not None else None,
                 )
-            else:
-                video_url = await upload_to_fs(
-                    self._media_fs,
-                    f"videos/{request_id}.{output_format}",
-                    video_bytes,
-                    self._media_http_url,
-                )
-                video_data = VideoData(output_format=output_format, url=video_url)
+                if response_format == "b64_json":
+                    video_data.b64_json = base64.b64encode(video_bytes).decode("utf-8")
+                else:
+                    filename = (
+                        f"videos/{request_id}.{output_format}"
+                        if len(videos) == 1
+                        else f"videos/{request_id}/{index}.{output_format}"
+                    )
+                    video_data.url = await upload_to_fs(
+                        self._media_fs,
+                        filename,
+                        video_bytes,
+                        self._media_http_url,
+                    )
+                data.append(video_data)
 
             return NvVideosResponse(
                 id=request_id,
@@ -198,7 +252,7 @@ class DiffusionFormatter:
                 status="completed",
                 progress=100,
                 created=int(time.time()),
-                data=[video_data],
+                data=data,
                 inference_time_s=time.time() - start_time,
             ).model_dump()
         except Exception as e:
@@ -213,6 +267,251 @@ class DiffusionFormatter:
                 data=[],
                 error=str(e),
             ).model_dump()
+
+    @staticmethod
+    def _extract_multimodal_output(stage_output: Any) -> dict[str, Any]:
+        multimodal_output = getattr(stage_output, "multimodal_output", None)
+        if isinstance(multimodal_output, Mapping):
+            return dict(multimodal_output)
+
+        request_output = getattr(stage_output, "request_output", None)
+        if isinstance(request_output, dict):
+            multimodal_output = request_output.get("multimodal_output")
+            if multimodal_output is None:
+                multimodal_output = request_output.get("_multimodal_output")
+        elif request_output is not None:
+            multimodal_output = getattr(request_output, "multimodal_output", None)
+            if multimodal_output is None:
+                multimodal_output = getattr(request_output, "_multimodal_output", None)
+        return dict(multimodal_output) if isinstance(multimodal_output, Mapping) else {}
+
+    @staticmethod
+    def _split_video_outputs(
+        images: Any, multimodal_output: dict[str, Any]
+    ) -> list[Any]:
+        videos = images
+        if is_empty_payload(videos):
+            videos = multimodal_output.get("video")
+        if videos is None:
+            return []
+        if isinstance(videos, (np.ndarray, torch.Tensor)):
+            if videos.ndim == 5:
+                return [videos[index] for index in range(videos.shape[0])]
+            return [videos]
+        if isinstance(videos, (list, tuple)):
+            videos = list(videos)
+            if not videos:
+                return []
+            first = videos[0]
+            if isinstance(first, (np.ndarray, torch.Tensor)) and first.ndim == 5:
+                flattened: list[Any] = []
+                for batch in videos:
+                    if (
+                        not isinstance(batch, (np.ndarray, torch.Tensor))
+                        or batch.ndim != 5
+                    ):
+                        raise ValueError("Video output batches must all be 5-D")
+                    flattened.extend(batch[index] for index in range(batch.shape[0]))
+                return flattened
+            if isinstance(first, (np.ndarray, torch.Tensor)) and first.ndim == 4:
+                return videos
+            if isinstance(first, list):
+                return videos
+            return [videos]
+        return [videos]
+
+    @staticmethod
+    def _video_to_numpy_frames(video: Any) -> np.ndarray:
+        """Normalize one video to uint8 ``(frames, height, width, channels)``."""
+        if isinstance(video, torch.Tensor):
+            video = video.detach().float().cpu().numpy()
+
+        if isinstance(video, np.ndarray):
+            if video.ndim == 3:
+                video = video[None, ...]
+            if video.ndim != 4:
+                raise ValueError(
+                    f"Expected a 4-D video tensor, got shape {video.shape}"
+                )
+            if video.shape[-1] in (1, 3, 4):
+                frames = video
+            elif video.shape[0] in (1, 3, 4):
+                # vLLM-Omni's channel-first 4-D convention is CFHW. Prefer
+                # that interpretation when both leading dimensions are
+                # channel-sized; FCHW remains unambiguous for other frame
+                # counts.
+                frames = video.transpose(1, 2, 3, 0)
+            elif video.shape[1] in (1, 3, 4):
+                frames = video.transpose(0, 2, 3, 1)
+            else:
+                raise ValueError(
+                    "Video tensor must use CFHW, FCHW, or FHWC channel layout, "
+                    f"got shape {video.shape}"
+                )
+            if frames.shape[-1] == 1:
+                frames = np.repeat(frames, 3, axis=-1)
+            elif frames.shape[-1] == 4:
+                frames = frames[..., :3]
+            if np.issubdtype(frames.dtype, np.floating) and frames.min(initial=0.0) < 0:
+                frames = (frames + 1.0) / 2.0
+            return frames_to_numpy(list(np.ascontiguousarray(frames)))
+
+        frames = normalize_video_frames(video if isinstance(video, list) else [video])
+        normalized = []
+        for frame in frames:
+            if isinstance(frame, torch.Tensor):
+                frame = frame.detach().float().cpu().numpy()
+            if isinstance(frame, np.ndarray) and frame.ndim == 3:
+                if frame.shape[-1] in (1, 3, 4):
+                    pass
+                elif frame.shape[0] in (1, 3, 4):
+                    frame = frame.transpose(1, 2, 0)
+                else:
+                    raise ValueError(
+                        "Video frame must use CHW or HWC channel layout, "
+                        f"got shape {frame.shape}"
+                    )
+                if frame.shape[-1] == 1:
+                    frame = np.repeat(frame, 3, axis=-1)
+                elif frame.shape[-1] == 4:
+                    frame = frame[..., :3]
+                if (
+                    np.issubdtype(frame.dtype, np.floating)
+                    and frame.min(initial=0.0) < 0
+                ):
+                    frame = (frame + 1.0) / 2.0
+            normalized.append(frame)
+        return frames_to_numpy(normalized)
+
+    @staticmethod
+    def _split_audio_outputs(audio: Any, expected_count: int) -> list[Any | None]:
+        if audio is None:
+            return [None] * expected_count
+        if isinstance(audio, (np.ndarray, torch.Tensor)):
+            if audio.ndim > 1 and audio.shape[0] == expected_count:
+                return [audio[index] for index in range(expected_count)]
+            if expected_count == 1:
+                return [audio]
+        if isinstance(audio, (list, tuple)):
+            if len(audio) == expected_count:
+                return list(audio)
+            if expected_count == 1:
+                return [audio]
+        return [audio] + [None] * (expected_count - 1)
+
+    @staticmethod
+    def _audio_to_numpy(audio: Any) -> np.ndarray:
+        if isinstance(audio, torch.Tensor):
+            return audio.detach().float().cpu().numpy()
+        if isinstance(audio, np.ndarray):
+            return audio.astype(np.float32, copy=False)
+        return np.asarray(audio, dtype=np.float32)
+
+    @staticmethod
+    def _resolve_int_metadata(
+        multimodal_output: dict[str, Any],
+        key: str,
+        metadata_section: str,
+        metadata_key: str | None = None,
+    ) -> int | None:
+        value = multimodal_output.get(key)
+        if value is None:
+            metadata = multimodal_output.get("metadata")
+            if isinstance(metadata, Mapping):
+                section = metadata.get(metadata_section)
+                if isinstance(section, Mapping):
+                    value = section.get(metadata_key or key)
+        if value is None:
+            return None
+        try:
+            resolved = int(value.item() if hasattr(value, "item") else value)
+        except (TypeError, ValueError):
+            return None
+        return resolved if resolved > 0 else None
+
+    def _resolve_audio_sample_rate(self, multimodal_output: dict[str, Any]) -> int:
+        for key in ("audio_sample_rate", "sample_rate", "sampling_rate", "sr"):
+            sample_rate = self._coerce_positive_int(multimodal_output.get(key))
+            if sample_rate is not None:
+                return sample_rate
+
+        metadata = multimodal_output.get("metadata")
+        audio_metadata = (
+            metadata.get("audio") if isinstance(metadata, Mapping) else None
+        )
+        if isinstance(audio_metadata, Mapping):
+            for key in (
+                "audio_sample_rate",
+                "sample_rate",
+                "sampling_rate",
+                "sr",
+            ):
+                sample_rate = self._coerce_positive_int(audio_metadata.get(key))
+                if sample_rate is not None:
+                    return sample_rate
+
+        return self._default_audio_sample_rate
+
+    @classmethod
+    def _extract_audio_sample_rate_from_config(
+        cls, config: Any, seen: set[int] | None = None
+    ) -> int | None:
+        if config is None:
+            return None
+
+        seen = seen or set()
+        if id(config) in seen:
+            return None
+        seen.add(id(config))
+
+        if isinstance(config, Mapping):
+            values = config
+        else:
+            values = getattr(config, "__dict__", {})
+            if not isinstance(values, Mapping):
+                return None
+
+        for key in (
+            "output_sampling_rate",
+            "audio_sample_rate",
+            "sample_rate",
+            "sampling_rate",
+        ):
+            sample_rate = cls._coerce_positive_int(values.get(key))
+            if sample_rate is not None:
+                return sample_rate
+
+        for component_name in ("vocoder", "audio_vae"):
+            component = values.get(component_name)
+            sample_rate = cls._extract_audio_sample_rate_from_config(component, seen)
+            if sample_rate is not None:
+                return sample_rate
+            if isinstance(component, Mapping):
+                component_config = component.get("config")
+            else:
+                component_values = getattr(component, "__dict__", {})
+                component_config = (
+                    component_values.get("config")
+                    if isinstance(component_values, Mapping)
+                    else None
+                )
+            sample_rate = cls._extract_audio_sample_rate_from_config(
+                component_config, seen
+            )
+            if sample_rate is not None:
+                return sample_rate
+
+        return None
+
+    @staticmethod
+    def _coerce_positive_int(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            resolved = int(value.item() if hasattr(value, "item") else value)
+        except (TypeError, ValueError):
+            return None
+        return resolved if resolved > 0 else None
 
     async def _encode_image(
         self,
@@ -726,12 +1025,15 @@ class OutputFormatter:
         media_fs: Any = None,
         media_http_url: Optional[str] = None,
         default_fps: int = 16,
+        model_config: Any = None,
     ) -> None:
+        diffusion_formatter = DiffusionFormatter(
+            model_name, media_fs, media_http_url, default_fps, model_config
+        )
         self._formatters: Dict[str, Any] = {
             "text": TextFormatter(model_name),
-            "image": DiffusionFormatter(
-                model_name, media_fs, media_http_url, default_fps
-            ),
+            "image": diffusion_formatter,
+            "video": diffusion_formatter,
             "audio": AudioFormatter(model_name, media_fs, media_http_url),
         }
 

--- a/components/src/dynamo/vllm/omni/output_formatter.py
+++ b/components/src/dynamo/vllm/omni/output_formatter.py
@@ -124,16 +124,11 @@ class DiffusionFormatter:
         media_fs: Any,
         media_http_url: Optional[str],
         default_fps: int = 16,
-        model_config: Any = None,
     ) -> None:
         self._model_name = model_name
         self._media_fs = media_fs
         self._media_http_url = media_http_url
         self._default_fps = default_fps
-        self._default_audio_sample_rate = (
-            self._extract_audio_sample_rate_from_config(model_config)
-            or DEFAULT_AUDIO_SAMPLE_RATE
-        )
 
     async def format(
         self, stage_output: Any, request_id: str, *, request_type: Any, **ctx: Any
@@ -169,17 +164,15 @@ class DiffusionFormatter:
         response_format: Optional[str] = None,
         output_format: Optional[str] = None,
     ) -> Dict[str, Any] | None:
-        requested_output_format = output_format
-        output_format = "mp4"
+        output_format = output_format or "mp4"
         response_format = response_format or "url"
         if response_format not in ("url", "b64_json"):
             raise ValueError(
                 f"Unsupported response_format: {response_format!r}; expected 'url' or 'b64_json'"
             )
-        if requested_output_format not in (None, "mp4"):
-            logger.warning(
-                "Ignoring unsupported video output_format hint %r; encoding MP4",
-                requested_output_format,
+        if output_format != "mp4":
+            raise ValueError(
+                f"Unsupported output_format: {output_format!r}; only 'mp4' is supported"
             )
         try:
             start_time = time.time()
@@ -335,19 +328,24 @@ class DiffusionFormatter:
                 )
             if video.shape[-1] in (1, 3, 4):
                 frames = video
-            elif video.shape[0] in (1, 3, 4):
-                # vLLM-Omni's channel-first 4-D convention is CFHW. Prefer
-                # that interpretation when both leading dimensions are
-                # channel-sized; FCHW remains unambiguous for other frame
-                # counts.
-                frames = video.transpose(1, 2, 3, 0)
-            elif video.shape[1] in (1, 3, 4):
-                frames = video.transpose(0, 2, 3, 1)
             else:
-                raise ValueError(
-                    "Video tensor must use CFHW, FCHW, or FHWC channel layout, "
-                    f"got shape {video.shape}"
-                )
+                is_cfhw = video.shape[0] in (1, 3, 4)
+                is_fchw = video.shape[1] in (1, 3, 4)
+                if is_cfhw and is_fchw:
+                    raise ValueError(
+                        "Ambiguous channel-first video tensor; expected an "
+                        "unambiguous CFHW or FCHW shape, "
+                        f"got {video.shape}"
+                    )
+                if is_cfhw:
+                    frames = video.transpose(1, 2, 3, 0)
+                elif is_fchw:
+                    frames = video.transpose(0, 2, 3, 1)
+                else:
+                    raise ValueError(
+                        "Video tensor must use CFHW, FCHW, or FHWC channel layout, "
+                        f"got shape {video.shape}"
+                    )
             if frames.shape[-1] == 1:
                 frames = np.repeat(frames, 3, axis=-1)
             elif frames.shape[-1] == 4:
@@ -388,7 +386,7 @@ class DiffusionFormatter:
         if audio is None:
             return [None] * expected_count
         if isinstance(audio, (np.ndarray, torch.Tensor)):
-            if audio.ndim > 1 and audio.shape[0] == expected_count:
+            if audio.ndim >= 3 and audio.shape[0] == expected_count:
                 return [audio[index] for index in range(expected_count)]
             if expected_count == 1:
                 return [audio]
@@ -397,7 +395,9 @@ class DiffusionFormatter:
                 return list(audio)
             if expected_count == 1:
                 return [audio]
-        return [audio] + [None] * (expected_count - 1)
+        raise ValueError(
+            f"Expected {expected_count} audio outputs for {expected_count} videos"
+        )
 
     @staticmethod
     def _audio_to_numpy(audio: Any) -> np.ndarray:
@@ -450,58 +450,7 @@ class DiffusionFormatter:
                 if sample_rate is not None:
                     return sample_rate
 
-        return self._default_audio_sample_rate
-
-    @classmethod
-    def _extract_audio_sample_rate_from_config(
-        cls, config: Any, seen: set[int] | None = None
-    ) -> int | None:
-        if config is None:
-            return None
-
-        seen = seen or set()
-        if id(config) in seen:
-            return None
-        seen.add(id(config))
-
-        if isinstance(config, Mapping):
-            values = config
-        else:
-            values = getattr(config, "__dict__", {})
-            if not isinstance(values, Mapping):
-                return None
-
-        for key in (
-            "output_sampling_rate",
-            "audio_sample_rate",
-            "sample_rate",
-            "sampling_rate",
-        ):
-            sample_rate = cls._coerce_positive_int(values.get(key))
-            if sample_rate is not None:
-                return sample_rate
-
-        for component_name in ("vocoder", "audio_vae"):
-            component = values.get(component_name)
-            sample_rate = cls._extract_audio_sample_rate_from_config(component, seen)
-            if sample_rate is not None:
-                return sample_rate
-            if isinstance(component, Mapping):
-                component_config = component.get("config")
-            else:
-                component_values = getattr(component, "__dict__", {})
-                component_config = (
-                    component_values.get("config")
-                    if isinstance(component_values, Mapping)
-                    else None
-                )
-            sample_rate = cls._extract_audio_sample_rate_from_config(
-                component_config, seen
-            )
-            if sample_rate is not None:
-                return sample_rate
-
-        return None
+        return DEFAULT_AUDIO_SAMPLE_RATE
 
     @staticmethod
     def _coerce_positive_int(value: Any) -> int | None:
@@ -1025,10 +974,9 @@ class OutputFormatter:
         media_fs: Any = None,
         media_http_url: Optional[str] = None,
         default_fps: int = 16,
-        model_config: Any = None,
     ) -> None:
         diffusion_formatter = DiffusionFormatter(
-            model_name, media_fs, media_http_url, default_fps, model_config
+            model_name, media_fs, media_http_url, default_fps
         )
         self._formatters: Dict[str, Any] = {
             "text": TextFormatter(model_name),

--- a/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
@@ -108,6 +108,19 @@ class TestDiffusionParallelConfigCoverage:
 
         assert kwargs["output_modalities"] == ["image"]
 
+    def test_model_defined_diffusion_fields_forwarded_to_async_omni(self):
+        config = _make_config()
+        config.diffusion = dataclasses.replace(
+            OmniDiffusionKwargs(),
+            task_type="t2va",
+            diffusion_attention_backend="TRTLLM_ATTN",
+        )
+
+        kwargs = _build_kwargs(config)
+
+        assert kwargs["task_type"] == "t2va"
+        assert kwargs["diffusion_attention_backend"] == "TRTLLM_ATTN"
+
     def test_lora_disabled_resolves_no_capacity(self):
         config = _make_config()
         handler = BaseOmniHandler.__new__(BaseOmniHandler)

--- a/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
@@ -49,6 +49,7 @@ def _make_handler(stage_types=("diffusion",)):
     config.model = "test-model"
     config.served_model_name = None
     config.output_modalities = ["text"]
+    config.default_video_fps = 16
     config.enable_lora = False  # Disable LoRA for tests unless explicitly set
     config.engine_args = SimpleNamespace(enable_lora=False)
     handler.config = config
@@ -262,6 +263,102 @@ class TestI2VEngineInputs:
         assert sp.boundary_ratio == 0.875
         assert sp.guidance_scale_2 == 1.0
         assert sp.num_inference_steps == 40
+
+    @pytest.mark.asyncio
+    async def test_video_preserves_each_stage_default_and_merges_passthrough(self):
+        handler = _make_handler(stage_types=("diffusion", "diffusion"))
+        (
+            first_default,
+            second_default,
+        ) = handler.engine_client.default_sampling_params_list
+        first_default.num_frames = 209
+        first_default.seed = 7
+        first_default.extra_args = {"stage": "first", "flow_shift": 11.0}
+        second_default.num_frames = 243
+        second_default.seed = 8
+        second_default.extra_args = {"stage": "second", "flow_shift": 10.0}
+        req = NvCreateVideoRequest(
+            prompt="cat playing piano",
+            model="video-model",
+            nvext=VideoNvExt(num_inference_steps=50),
+            extra_args={
+                "media_passthrough": {
+                    "task": "t2va",
+                    "duration": 10.0,
+                    "flow_shift": 12.0,
+                    "audio_flow_shift": 3.0,
+                }
+            },
+        )
+
+        result = await handler.build_engine_inputs(req, RequestType.VIDEO_GENERATION)
+        first, second = result.sampling_params_list
+
+        assert (first.num_frames, first.seed) == (209, 7)
+        assert (second.num_frames, second.seed) == (243, 8)
+        assert first.extra_args == {
+            "stage": "first",
+            "flow_shift": 12.0,
+            "task": "t2va",
+            "duration": 10.0,
+            "audio_flow_shift": 3.0,
+        }
+        assert second.extra_args == {
+            "stage": "second",
+            "flow_shift": 12.0,
+            "task": "t2va",
+            "duration": 10.0,
+            "audio_flow_shift": 3.0,
+        }
+        assert first_default.extra_args == {"stage": "first", "flow_shift": 11.0}
+        assert second_default.extra_args == {"stage": "second", "flow_shift": 10.0}
+
+    @pytest.mark.asyncio
+    async def test_video_passthrough_does_not_leak_between_requests(self):
+        handler = _make_handler()
+        first = NvCreateVideoRequest(
+            prompt="first",
+            model="video-model",
+            extra_args={"media_passthrough": {"task": "t2va"}},
+        )
+        second = NvCreateVideoRequest(prompt="second", model="video-model")
+
+        first_inputs = await handler.build_engine_inputs(
+            first, RequestType.VIDEO_GENERATION
+        )
+        second_inputs = await handler.build_engine_inputs(
+            second, RequestType.VIDEO_GENERATION
+        )
+
+        assert first_inputs.sampling_params_list[0].extra_args == {"task": "t2va"}
+        assert second_inputs.sampling_params_list[0].extra_args == {}
+
+    @pytest.mark.asyncio
+    async def test_explicit_video_fields_override_model_defaults(self):
+        handler = _make_handler()
+        model_defaults = handler.engine_client.default_sampling_params_list[0]
+        model_defaults.width = 1024
+        model_defaults.height = 576
+        model_defaults.num_frames = 209
+        model_defaults.fps = None
+        model_defaults.seed = 7
+        req = NvCreateVideoRequest(
+            prompt="cat",
+            model="video-model",
+            size="448x256",
+            seconds=10,
+            nvext=VideoNvExt(fps=24, seed=42),
+        )
+
+        result = await handler.build_engine_inputs(req, RequestType.VIDEO_GENERATION)
+        sp = result.sampling_params_list[0]
+
+        assert (sp.width, sp.height) == (448, 256)
+        assert sp.num_frames == 240
+        assert sp.fps == 24
+        assert sp.frame_rate == 24.0
+        assert sp.seed == 42
+        assert result.fps == 24
 
     async def test_media_passthrough_reaches_sampling_params(self):
         """A top-level SDK extra_body field, nested by the frontend under

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -220,7 +220,7 @@ class TestDiffusionFormatterImage:
 
 class TestDiffusionFormatterVideo:
     @pytest.mark.asyncio
-    async def test_empty_frames_returns_none(self):
+    async def test_empty_frames_returns_video_error(self):
         from dynamo.common.utils.output_modalities import RequestType
 
         f = _make_diffusion_formatter()
@@ -229,7 +229,9 @@ class TestDiffusionFormatterVideo:
         result = await f.format(
             stage, "req-1", request_type=RequestType.VIDEO_GENERATION
         )
-        assert result is None
+        assert result["object"] == "video"
+        assert result["status"] == "failed"
+        assert "No video outputs" in result["error"]
 
     @pytest.mark.asyncio
     async def test_error_returns_failed_status(self):
@@ -243,6 +245,272 @@ class TestDiffusionFormatterVideo:
             chunk = await f._encode_video([MagicMock()], "req-1", fps=16)
         assert chunk["status"] == "failed"
         assert "boom" in chunk["error"]
+
+    @pytest.mark.asyncio
+    async def test_muxes_video_audio_and_reports_metadata(self):
+        from dynamo.common.utils.output_modalities import RequestType
+
+        f = _make_diffusion_formatter()
+        stage = SimpleNamespace(
+            images=[np.zeros((2, 4, 4, 3), dtype=np.float32)],
+            multimodal_output={
+                "audio": np.zeros((1, 2, 128), dtype=np.float32),
+                "fps": 24,
+                "audio_sample_rate": 32000,
+            },
+        )
+        with patch(
+            "dynamo.vllm.omni.output_formatter.mux_video_audio_bytes",
+            return_value=b"muxed-mp4",
+        ) as mux:
+            result = await f.format(
+                stage,
+                "req-video-audio",
+                request_type=RequestType.VIDEO_GENERATION,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        assert result["data"][0]["fps"] == 24
+        assert result["data"][0]["audio_sample_rate"] == 32000
+        assert result["data"][0]["b64_json"] is not None
+        assert mux.call_count == 1
+        assert mux.call_args.kwargs["fps"] == 24.0
+        assert mux.call_args.kwargs["audio_sample_rate"] == 32000
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("sample_rate_key", "sample_rate"),
+        [("sample_rate", 22050), ("sampling_rate", 44100), ("sr", 16000)],
+    )
+    async def test_uses_audio_sample_rate_aliases(self, sample_rate_key, sample_rate):
+        from dynamo.common.utils.output_modalities import RequestType
+
+        f = _make_diffusion_formatter()
+        stage = SimpleNamespace(
+            images=[np.zeros((2, 4, 4, 3), dtype=np.float32)],
+            multimodal_output={
+                "audio": np.zeros((1, 2, 128), dtype=np.float32),
+                sample_rate_key: sample_rate,
+            },
+        )
+        with patch(
+            "dynamo.vllm.omni.output_formatter.mux_video_audio_bytes",
+            return_value=b"muxed-mp4",
+        ) as mux:
+            result = await f.format(
+                stage,
+                "req-video-audio",
+                request_type=RequestType.VIDEO_GENERATION,
+                response_format="b64_json",
+            )
+
+        assert result["data"][0]["audio_sample_rate"] == sample_rate
+        assert mux.call_args.kwargs["audio_sample_rate"] == sample_rate
+
+    @pytest.mark.asyncio
+    async def test_uses_model_audio_sample_rate_then_generic_fallback(self):
+        configured = DiffusionFormatter(
+            model_name="test-model",
+            media_fs=None,
+            media_http_url=None,
+            model_config=SimpleNamespace(
+                audio_vae=SimpleNamespace(config=SimpleNamespace(sampling_rate=48000))
+            ),
+        )
+        audio = {"audio": np.zeros((1, 2, 128), dtype=np.float32)}
+        video = [np.zeros((2, 4, 4, 3), dtype=np.float32)]
+
+        with patch(
+            "dynamo.vllm.omni.output_formatter.mux_video_audio_bytes",
+            return_value=b"muxed-mp4",
+        ) as mux:
+            configured_result = await configured._encode_video(
+                video,
+                "req-configured-rate",
+                fps=24,
+                multimodal_output=audio,
+                response_format="b64_json",
+            )
+            fallback_result = await _make_diffusion_formatter()._encode_video(
+                video,
+                "req-fallback-rate",
+                fps=24,
+                multimodal_output=audio,
+                response_format="b64_json",
+            )
+
+        assert configured_result["data"][0]["audio_sample_rate"] == 48000
+        assert fallback_result["data"][0]["audio_sample_rate"] == 24000
+        assert [call.kwargs["audio_sample_rate"] for call in mux.call_args_list] == [
+            48000,
+            24000,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_returns_every_generated_video(self):
+        from dynamo.common.utils.output_modalities import RequestType
+
+        f = _make_diffusion_formatter()
+        videos = [np.zeros((2, 4, 4, 3), dtype=np.float32) for _ in range(2)]
+        stage = SimpleNamespace(
+            images=videos,
+            multimodal_output={
+                "audio": np.zeros((2, 2, 128), dtype=np.float32),
+                "metadata": {
+                    "video": {"fps": 24},
+                    "audio": {"sample_rate": 32000},
+                },
+            },
+        )
+        with patch(
+            "dynamo.vllm.omni.output_formatter.mux_video_audio_bytes",
+            return_value=b"muxed-mp4",
+        ) as mux:
+            result = await f.format(
+                stage,
+                "req-video-audio",
+                request_type=RequestType.VIDEO_GENERATION,
+                response_format="b64_json",
+            )
+
+        assert len(result["data"]) == 2
+        assert mux.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_silent_video_keeps_vp9_encoder(self):
+        f = _make_diffusion_formatter()
+        with (
+            patch(
+                "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+                return_value=b"vp9-mp4",
+            ) as vp9,
+            patch("dynamo.vllm.omni.output_formatter.mux_video_audio_bytes") as mux,
+        ):
+            result = await f._encode_video(
+                [np.zeros((4, 4, 3), dtype=np.float32)],
+                "req-silent",
+                fps=16,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        assert result["data"][0]["audio_sample_rate"] is None
+        vp9.assert_called_once()
+        mux.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_output_format_hint_falls_back_to_mp4(self):
+        f = _make_diffusion_formatter()
+        with patch(
+            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+            return_value=b"vp9-mp4",
+        ) as encode:
+            result = await f._encode_video(
+                [np.zeros((4, 4, 3), dtype=np.float32)],
+                "req-output-hint",
+                fps=16,
+                response_format="b64_json",
+                output_format="webm",
+            )
+
+        assert result["status"] == "completed"
+        assert result["data"][0]["output_format"] == "mp4"
+        assert encode.call_args.kwargs["output_format"] == "mp4"
+
+    @pytest.mark.asyncio
+    async def test_normalizes_direct_fchw_torch_video(self):
+        f = _make_diffusion_formatter()
+        video = torch.zeros((2, 3, 8, 10), dtype=torch.float32)
+
+        with patch(
+            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+            return_value=b"vp9-mp4",
+        ) as encode:
+            result = await f._encode_video(
+                video,
+                "req-tensor",
+                fps=16,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        frames = encode.call_args.args[0]
+        assert frames.shape == (2, 8, 10, 3)
+        assert frames.dtype == np.uint8
+
+    @pytest.mark.asyncio
+    async def test_splits_direct_bfchw_torch_videos(self):
+        f = _make_diffusion_formatter()
+        videos = torch.zeros((2, 2, 3, 8, 10), dtype=torch.float32)
+
+        with patch(
+            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+            return_value=b"vp9-mp4",
+        ) as encode:
+            result = await f._encode_video(
+                videos,
+                "req-tensor-batch",
+                fps=16,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        assert len(result["data"]) == 2
+        assert encode.call_count == 2
+        assert all(
+            call.args[0].shape == (2, 8, 10, 3) for call in encode.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_splits_list_wrapped_bfhwc_numpy_videos(self):
+        f = _make_diffusion_formatter()
+        videos = [np.zeros((2, 2, 8, 10, 3), dtype=np.float32)]
+
+        with patch(
+            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+            return_value=b"vp9-mp4",
+        ) as encode:
+            result = await f._encode_video(
+                videos,
+                "req-numpy-batch",
+                fps=16,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        assert len(result["data"]) == 2
+        assert encode.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("as_tensor", [False, True])
+    @pytest.mark.parametrize("num_frames", [1, 3, 4, 8])
+    async def test_normalizes_cfhw_negative_one_to_one_video(
+        self, as_tensor, num_frames
+    ):
+        f = _make_diffusion_formatter()
+        video = np.linspace(-1.0, 1.0, num=3 * num_frames * 16 * 16, dtype=np.float32)
+        video = video.reshape(3, num_frames, 16, 16)
+        if as_tensor:
+            video = torch.from_numpy(video)
+
+        with patch(
+            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
+            return_value=b"vp9-mp4",
+        ) as encode:
+            result = await f._encode_video(
+                video,
+                "req-cfhw",
+                fps=16,
+                response_format="b64_json",
+            )
+
+        assert result["status"] == "completed"
+        frames = encode.call_args.args[0]
+        assert frames.shape == (num_frames, 16, 16, 3)
+        assert frames.dtype == np.uint8
+        assert frames.min() == 0
+        assert frames.max() == 255
 
 
 class TestBuildCompletionUsage:

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -275,6 +275,7 @@ class TestDiffusionFormatterVideo:
         assert result["data"][0]["audio_sample_rate"] == 32000
         assert result["data"][0]["b64_json"] is not None
         assert mux.call_count == 1
+        assert mux.call_args.args[1].shape == (2, 128)
         assert mux.call_args.kwargs["fps"] == 24.0
         assert mux.call_args.kwargs["audio_sample_rate"] == 32000
 
@@ -309,15 +310,7 @@ class TestDiffusionFormatterVideo:
         assert mux.call_args.kwargs["audio_sample_rate"] == sample_rate
 
     @pytest.mark.asyncio
-    async def test_uses_model_audio_sample_rate_then_generic_fallback(self):
-        configured = DiffusionFormatter(
-            model_name="test-model",
-            media_fs=None,
-            media_http_url=None,
-            model_config=SimpleNamespace(
-                audio_vae=SimpleNamespace(config=SimpleNamespace(sampling_rate=48000))
-            ),
-        )
+    async def test_uses_default_audio_sample_rate_when_metadata_is_absent(self):
         audio = {"audio": np.zeros((1, 2, 128), dtype=np.float32)}
         video = [np.zeros((2, 4, 4, 3), dtype=np.float32)]
 
@@ -325,14 +318,7 @@ class TestDiffusionFormatterVideo:
             "dynamo.vllm.omni.output_formatter.mux_video_audio_bytes",
             return_value=b"muxed-mp4",
         ) as mux:
-            configured_result = await configured._encode_video(
-                video,
-                "req-configured-rate",
-                fps=24,
-                multimodal_output=audio,
-                response_format="b64_json",
-            )
-            fallback_result = await _make_diffusion_formatter()._encode_video(
+            result = await _make_diffusion_formatter()._encode_video(
                 video,
                 "req-fallback-rate",
                 fps=24,
@@ -340,12 +326,8 @@ class TestDiffusionFormatterVideo:
                 response_format="b64_json",
             )
 
-        assert configured_result["data"][0]["audio_sample_rate"] == 48000
-        assert fallback_result["data"][0]["audio_sample_rate"] == 24000
-        assert [call.kwargs["audio_sample_rate"] for call in mux.call_args_list] == [
-            48000,
-            24000,
-        ]
+        assert result["data"][0]["audio_sample_rate"] == 24000
+        assert mux.call_args.kwargs["audio_sample_rate"] == 24000
 
     @pytest.mark.asyncio
     async def test_returns_every_generated_video(self):
@@ -400,23 +382,16 @@ class TestDiffusionFormatterVideo:
         mux.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_unsupported_output_format_hint_falls_back_to_mp4(self):
+    async def test_unsupported_output_format_is_rejected(self):
         f = _make_diffusion_formatter()
-        with patch(
-            "dynamo.vllm.omni.output_formatter.encode_to_video_bytes",
-            return_value=b"vp9-mp4",
-        ) as encode:
-            result = await f._encode_video(
+        with pytest.raises(ValueError, match="only 'mp4' is supported"):
+            await f._encode_video(
                 [np.zeros((4, 4, 3), dtype=np.float32)],
                 "req-output-hint",
                 fps=16,
                 response_format="b64_json",
                 output_format="webm",
             )
-
-        assert result["status"] == "completed"
-        assert result["data"][0]["output_format"] == "mp4"
-        assert encode.call_args.kwargs["output_format"] == "mp4"
 
     @pytest.mark.asyncio
     async def test_normalizes_direct_fchw_torch_video(self):
@@ -484,7 +459,7 @@ class TestDiffusionFormatterVideo:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("as_tensor", [False, True])
-    @pytest.mark.parametrize("num_frames", [1, 3, 4, 8])
+    @pytest.mark.parametrize("num_frames", [2, 8])
     async def test_normalizes_cfhw_negative_one_to_one_video(
         self, as_tensor, num_frames
     ):
@@ -511,6 +486,17 @@ class TestDiffusionFormatterVideo:
         assert frames.dtype == np.uint8
         assert frames.min() == 0
         assert frames.max() == 255
+
+    @pytest.mark.parametrize("shape", [(4, 3, 8, 10), (3, 4, 8, 10)])
+    def test_rejects_ambiguous_channel_first_video(self, shape):
+        with pytest.raises(ValueError, match="Ambiguous channel-first"):
+            DiffusionFormatter._video_to_numpy_frames(np.zeros(shape, dtype=np.float32))
+
+    def test_rejects_mismatched_audio_batch(self):
+        with pytest.raises(ValueError, match="Expected 2 audio outputs"):
+            DiffusionFormatter._split_audio_outputs(
+                np.zeros((2, 128), dtype=np.float32), expected_count=2
+            )
 
 
 class TestBuildCompletionUsage:

--- a/docs/fern/pages/reference/backends/vllm-omni-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-omni-configuration.mdx
@@ -31,6 +31,12 @@ These are the vLLM-Omni orchestration flags. The omni worker also accepts the sa
 <ParamField path="--default-video-fps" type="int" default="16">
   Default frames per second for generated videos.
 </ParamField>
+<ParamField path="--task-type" type="string">
+  Model-defined startup task or checkpoint partition.
+</ParamField>
+<ParamField path="--diffusion-attention-backend" type="string">
+  Default diffusion attention backend, such as `TRTLLM_ATTN` or `FLASH_ATTN`.
+</ParamField>
 
 ## Memory & Performance
 
@@ -52,7 +58,6 @@ These are the vLLM-Omni orchestration flags. The omni worker also accepts the sa
 <ParamField path="--enable-cpu-offload" type="flag">
   Enable CPU offloading for diffusion models.
 </ParamField>
-
 ## Diffusion Cache
 
 <ParamField path="--cache-backend" type="cache_dit | tea_cache">
@@ -75,6 +80,12 @@ These are the vLLM-Omni orchestration flags. The omni worker also accepts the sa
 </ParamField>
 <ParamField path="--cfg-parallel-size" type="int" default="1">
   GPUs for classifier-free guidance parallelism (1 or 2).
+</ParamField>
+<ParamField path="--vae-patch-parallel-size" type="int" default="1">
+  Ranks used for VAE patch or tile parallelism.
+</ParamField>
+<ParamField path="--text-encoder-tp-size" type="int" default="1">
+  Tensor-parallel ranks used by the diffusion text encoder.
 </ParamField>
 
 ## Disaggregated Mode

--- a/docs/fern/pages/use-cases/diffusion/workflows/text-to-video.md
+++ b/docs/fern/pages/use-cases/diffusion/workflows/text-to-video.md
@@ -20,6 +20,7 @@ Text-to-video generation runs a vLLM-Omni worker with `--output-modalities video
 |---|---|
 | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` | Default model (1 GPU) |
 | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | |
+| `MiniMaxAI/MiniMax-H3` | Joint 24-FPS video and 32-kHz stereo audio; 4 B200 GPUs recommended |
 
 To run a non-default model, pass `--model` to the launch script:
 
@@ -52,6 +53,71 @@ curl -s http://localhost:8000/v1/videos \
 ```
 
 The response returns a video URL or base64 data depending on `response_format` (e.g. `{"object": "video", "status": "completed", "data": [{"url": "file:///tmp/dynamo_media/videos/req-abc123.mp4"}]}`).
+
+## MiniMax-H3
+
+The initial MiniMax-H3 qualification serves text-to-video-and-audio (T2VA) with
+one aggregated diffusion worker. The launcher passes `--task-type t2va`, which
+loads only H3's FL2VA checkpoint partition. Dynamo's standard image stays on
+its VP9-only media stack, so build the opt-in video-audio overlay to mux H.264
+video and AAC audio:
+
+```bash
+docker build \
+  --build-arg BASE_IMAGE=<dynamo-vllm-local-dev-image> \
+  -f examples/backends/vllm/omni/video_audio.Dockerfile \
+  -t dynamo-vllm-minimax-h3 .
+```
+
+Launch the four-B200 profile. It uses four-way Ulysses and text-encoder tensor
+parallelism while keeping VAE patch parallelism at one, so small supported
+resolutions such as 448x256 still have at least one tile per participating
+rank. Larger resolutions can opt into four-way VAE patch parallelism with
+`DYN_H3_VAE_PATCH_PARALLEL_SIZE=4`:
+
+```bash
+bash examples/backends/vllm/launch/agg_omni_minimax_h3.sh
+```
+
+Run the supplied end-to-end qualification against the same worker. It requests
+a 10-second clip, then verifies a non-empty H.264 stream at 24 FPS and a
+non-silent 32-kHz stereo AAC stream:
+
+```bash
+export DYN_H3_QUAL_DIR=/tmp/dynamo_minimax_h3_qualification
+bash examples/backends/vllm/launch/validate_omni_minimax_h3.sh
+```
+
+```json
+{
+  "model": "MiniMaxAI/MiniMax-H3",
+  "prompt": "A cat playing Canon in D on a grand piano.",
+  "size": "448x256",
+  "response_format": "url",
+  "output_format": "mp4",
+  "nvext": {
+    "num_inference_steps": 50,
+    "seed": 42
+  },
+  "task": "t2va",
+  "duration": 10.0,
+  "flow_shift": 12.0,
+  "audio_flow_shift": 3.0,
+  "aspect_ratio": "16:9"
+}
+```
+
+The request deliberately omits `fps`, so the upstream H3 pipeline keeps its
+native 24-FPS default. Dynamo preserves unrecognized top-level video fields and
+the vLLM-Omni adapter merges them into the pipeline's `extra_args`, where the
+upstream model validates them. Client libraries that expose an `extra_body`
+option can use it to add these top-level fields; do not send a literal nested
+`extra_body` object. Generated responses report `fps` and `audio_sample_rate`
+for each MP4.
+
+First/last-frame FL2VA and reference-driven Ref2VA are not part of this initial
+qualification. They additionally require typed image, video, and audio input
+references.
 
 ## Request Parameters (`nvext`)
 

--- a/examples/backends/vllm/launch/agg_omni_minimax_h3.sh
+++ b/examples/backends/vllm/launch/agg_omni_minimax_h3.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Launch one aggregated vLLM-Omni worker that serves MiniMax-H3 T2VA.
+set -euo pipefail
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="${DYN_H3_MODEL:-MiniMaxAI/MiniMax-H3}"
+ULYSSES_DEGREE="${DYN_H3_ULYSSES_DEGREE:-4}"
+TEXT_ENCODER_TP_SIZE="${DYN_H3_TEXT_ENCODER_TP_SIZE:-4}"
+# H3's native patch-parallel VAE requires at least one spatial tile per rank.
+# Keep it single-rank by default so small supported resolutions (for example,
+# 448x256) do not leave ranks with empty tile lists. Larger workloads may opt
+# into the full DiT group size explicitly.
+VAE_PATCH_PARALLEL_SIZE="${DYN_H3_VAE_PATCH_PARALLEL_SIZE:-1}"
+ATTENTION_BACKEND="${DYN_H3_ATTENTION_BACKEND:-TRTLLM_ATTN}"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                echo "Error: --model requires a value" >&2
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+command -v ffmpeg >/dev/null
+command -v ffprobe >/dev/null
+ffmpeg -hide_banner -encoders 2>/dev/null | grep libx264rgb >/dev/null
+python -c 'import av; av.codec.Codec("h264", "w"); av.codec.Codec("aac", "w")'
+
+export VLLM_WORKER_MULTIPROC_METHOD="${VLLM_WORKER_MULTIPROC_METHOD:-spawn}"
+export VLLM_OMNI_VIDEO_SYNC_TIMEOUT="${VLLM_OMNI_VIDEO_SYNC_TIMEOUT:-3600}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner --no-curl "Launching MiniMax-H3 T2VA (4 GPUs)" "$MODEL" "$HTTP_PORT"
+print_curl_footer <<CURL
+curl -sS http://localhost:${HTTP_PORT}/v1/videos \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "model": "${MODEL}",
+    "prompt": "A cat playing Canon in D on a grand piano.",
+    "size": "448x256",
+    "response_format": "url",
+    "output_format": "mp4",
+    "nvext": {
+      "num_inference_steps": 50,
+      "seed": 42
+    },
+    "task": "t2va",
+    "duration": 10.0,
+    "aspect_ratio": "16:9",
+    "flow_shift": 12.0,
+    "audio_flow_shift": 3.0
+  }' | jq
+CURL
+
+python -m dynamo.frontend &
+
+sleep 2
+
+echo "Starting MiniMax-H3 T2VA Omni worker..."
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --output-modalities video \
+    --media-output-fs-url file:///tmp/dynamo_media \
+    --trust-remote-code \
+    --task-type t2va \
+    --ulysses-degree "$ULYSSES_DEGREE" \
+    --text-encoder-tp-size "$TEXT_ENCODER_TP_SIZE" \
+    --vae-patch-parallel-size "$VAE_PATCH_PARALLEL_SIZE" \
+    --vae-use-tiling \
+    --diffusion-attention-backend "$ATTENTION_BACKEND" \
+    "${EXTRA_ARGS[@]}" &
+
+wait_any_exit

--- a/examples/backends/vllm/launch/validate_omni_minimax_h3.sh
+++ b/examples/backends/vllm/launch/validate_omni_minimax_h3.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qualify MiniMax-H3 T2VA against one already-running aggregated worker.
+set -euo pipefail
+
+API_URL="${DYN_H3_API_URL:-http://127.0.0.1:8000/v1/videos}"
+MODEL="${DYN_H3_MODEL:-MiniMaxAI/MiniMax-H3}"
+QUAL_DIR="${DYN_H3_QUAL_DIR:-/tmp/dynamo_minimax_h3_qualification}"
+OUTPUT_DIR="$QUAL_DIR/outputs"
+CASE_NAME="cat-playing-canon-in-d-grand-piano"
+REQUEST_FILE="$OUTPUT_DIR/${CASE_NAME}.request.json"
+RESPONSE_FILE="$OUTPUT_DIR/${CASE_NAME}.response.json"
+VIDEO_FILE="$OUTPUT_DIR/${CASE_NAME}.mp4"
+PROBE_FILE="$OUTPUT_DIR/${CASE_NAME}.ffprobe.json"
+SOURCE_FILE="$OUTPUT_DIR/${CASE_NAME}.source-url.txt"
+SHA_FILE="$OUTPUT_DIR/${CASE_NAME}.sha256"
+
+mkdir -p "$OUTPUT_DIR"
+
+jq -n \
+    --arg model "$MODEL" \
+    --arg prompt "A photorealistic orange tabby cat seated at a polished black grand piano, visibly pressing the keys with both front paws while performing Pachelbel's Canon in D. Elegant concert hall, cinematic lighting, realistic paw and key motion, synchronized clear solo grand-piano audio playing the recognizable Canon in D melody, no speech, no other instruments." \
+    '{
+        model: $model,
+        prompt: $prompt,
+        size: "448x256",
+        response_format: "url",
+        output_format: "mp4",
+        nvext: {
+            num_inference_steps: 50,
+            seed: 42
+        },
+        task: "t2va",
+        duration: 10.0,
+        aspect_ratio: "16:9",
+        flow_shift: 12.0,
+        audio_flow_shift: 3.0
+    }' > "$REQUEST_FILE"
+
+echo "Generating a 10-second MiniMax-H3 T2VA sample..."
+curl -fsS --max-time 7200 "$API_URL" \
+    -H 'Content-Type: application/json' \
+    --data-binary "@$REQUEST_FILE" > "$RESPONSE_FILE"
+jq -e '.status == "completed" and (.data | length) >= 1' "$RESPONSE_FILE" >/dev/null
+
+media_url="$(jq -er '.data[0].url' "$RESPONSE_FILE")"
+media_path="${media_url#file://}"
+if [[ ! -s "$media_path" ]]; then
+    echo "Missing generated video: $media_path" >&2
+    exit 1
+fi
+cp "$media_path" "$VIDEO_FILE"
+printf '%s\n' "$media_url" > "$SOURCE_FILE"
+
+ffprobe -v error \
+    -show_entries stream=codec_type,codec_name,width,height,sample_rate,channels,r_frame_rate \
+    -show_entries format=duration,size \
+    -of json "$VIDEO_FILE" > "$PROBE_FILE"
+
+expected_size="$(jq -er '.size' "$REQUEST_FILE")"
+expected_width="${expected_size%x*}"
+expected_height="${expected_size#*x}"
+
+jq -e \
+    --argjson expected_width "$expected_width" \
+    --argjson expected_height "$expected_height" '
+    any(.streams[];
+        .codec_type == "video" and
+        .codec_name == "h264" and
+        .r_frame_rate == "24/1" and
+        .width == $expected_width and
+        .height == $expected_height
+    ) and
+    any(.streams[]; .codec_type == "audio" and .codec_name == "aac" and .sample_rate == "32000" and .channels == 2) and
+    ((.format.duration | tonumber) >= 9.5 and (.format.duration | tonumber) <= 10.6) and
+    ((.format.size | tonumber) > 0)
+' "$PROBE_FILE" >/dev/null
+
+if ffmpeg -hide_banner -i "$VIDEO_FILE" -map 0:a:0 -af volumedetect -f null - \
+    2>&1 | grep -q 'mean_volume: -inf'; then
+    echo "Generated audio is silent" >&2
+    exit 1
+fi
+
+sha256sum "$VIDEO_FILE" > "$SHA_FILE"
+echo "MiniMax-H3 T2VA qualification passed: $VIDEO_FILE"

--- a/examples/backends/vllm/omni/video_audio.Dockerfile
+++ b/examples/backends/vllm/omni/video_audio.Dockerfile
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Opt-in development and qualification overlay for vLLM-Omni models that
+# generate joint video and audio. The standard Dynamo image intentionally
+# remains on its royalty-free VP9-only media stack.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ffmpeg \
+    && ln -sf /usr/bin/ffmpeg /usr/local/bin/ffmpeg \
+    && ln -sf /usr/bin/ffprobe /usr/local/bin/ffprobe \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install \
+        --python /opt/dynamo/venv/bin/python \
+        --no-deps \
+        av==18.0.0 \
+    && ffmpeg -hide_banner -encoders 2>/dev/null | grep -q libx264rgb \
+    && /opt/dynamo/venv/bin/python -c \
+        'import av; av.codec.Codec("h264", "w"); av.codec.Codec("aac", "w")'
+
+RUN /opt/dynamo/venv/bin/python <<'PY'
+import io
+
+import av
+import numpy as np
+from vllm_omni.diffusion.utils.media_utils import mux_video_audio_bytes
+
+fps = 24
+sample_rate = 32000
+frames = np.zeros((4, 16, 16, 3), dtype=np.uint8)
+waveform = np.zeros((2, sample_rate // 4), dtype=np.float32)
+payload = mux_video_audio_bytes(
+    frames,
+    waveform,
+    fps=fps,
+    audio_sample_rate=sample_rate,
+)
+with av.open(io.BytesIO(payload), mode="r") as container:
+    video = container.streams.video[0]
+    audio = container.streams.audio[0]
+    assert video.codec_context.name == "h264"
+    assert int(video.average_rate) == fps
+    assert audio.codec_context.name == "aac"
+    assert audio.codec_context.sample_rate == sample_rate
+PY
+
+USER dynamo

--- a/examples/backends/vllm/omni/video_audio.Dockerfile
+++ b/examples/backends/vllm/omni/video_audio.Dockerfile
@@ -1,10 +1,22 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Opt-in development and qualification overlay for vLLM-Omni models that
 # generate joint video and audio. The standard Dynamo image intentionally
 # remains on its royalty-free VP9-only media stack.
-ARG BASE_IMAGE
+ARG BASE_IMAGE=dynamo:latest-vllm-runtime
 FROM ${BASE_IMAGE}
 
 USER root
@@ -17,14 +29,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN uv pip install \
-        --python /opt/dynamo/venv/bin/python \
+        --system \
         --no-deps \
         av==18.0.0 \
-    && ffmpeg -hide_banner -encoders 2>/dev/null | grep -q libx264rgb \
-    && /opt/dynamo/venv/bin/python -c \
+    && ffmpeg -hide_banner -encoders 2>/dev/null | grep -Eq '(^| )libx264( |$)' \
+    && python3 -c \
         'import av; av.codec.Codec("h264", "w"); av.codec.Codec("aac", "w")'
 
-RUN /opt/dynamo/venv/bin/python <<'PY'
+RUN python3 <<'PY'
 import io
 
 import av

--- a/lib/llm/src/protocols/openai/videos.rs
+++ b/lib/llm/src/protocols/openai/videos.rs
@@ -91,6 +91,14 @@ pub struct VideoData {
     /// Base64-encoded video (if response_format is "b64_json")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub b64_json: Option<String>,
+
+    /// Actual video frame rate when reported by the model
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fps: Option<i32>,
+
+    /// Muxed audio sample rate when the generated video contains audio
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_sample_rate: Option<i32>,
 }
 
 /// Response structure for video generation
@@ -345,6 +353,8 @@ mod tests {
             output_format: "mp4".into(),
             url: None,
             b64_json: Some("abc==".into()),
+            fps: None,
+            audio_sample_rate: None,
         };
         let json = serde_json::to_string(&d).unwrap();
         assert!(!json.contains("url"));
@@ -357,11 +367,28 @@ mod tests {
             output_format: "webm".into(),
             url: Some("http://x/v.webm".into()),
             b64_json: None,
+            fps: None,
+            audio_sample_rate: None,
         };
         let json = serde_json::to_string(&d).unwrap();
         let d2: VideoData = serde_json::from_str(&json).unwrap();
         assert_eq!(d2.output_format, "webm");
         assert_eq!(d2.url.as_deref(), Some("http://x/v.webm"));
         assert!(d2.b64_json.is_none());
+    }
+
+    #[test]
+    fn video_data_round_trip_with_media_metadata() {
+        let d = VideoData {
+            output_format: "mp4".into(),
+            url: Some("http://x/v.mp4".into()),
+            b64_json: None,
+            fps: Some(24),
+            audio_sample_rate: Some(32000),
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let d2: VideoData = serde_json::from_str(&json).unwrap();
+        assert_eq!(d2.fps, Some(24));
+        assert_eq!(d2.audio_sample_rate, Some(32000));
     }
 }


### PR DESCRIPTION
## Summary

- Harden vLLM-Omni video output handling for every video model, independent of MiniMax-H3.
- Reject unsupported output formats instead of returning MP4 under a mismatched format contract.
- Reject ambiguous channel-first tensors and mismatched audio batches instead of silently guessing or dropping audio.
- Resolve audio sample rate from emitted output metadata, with a documented 24-kHz fallback.
- Make the opt-in H.264/AAC codec overlay build against the current Dynamo vLLM runtime layout.

## Validation

- `pre-commit run --files` passed for all files in this PR.
- Python compile validation passed.
- The final stack passed a four-B200 MiniMax-H3 T2VA Kubernetes qualification using image digest `sha256:5b820b31f5a4b9b14eed29952623787756a38b283e2e73e35b82f96c6af86f5a`.
- The qualification produced a 10.125-second 448x256 H.264 video with synchronized, non-silent 32-kHz stereo AAC in 24.206 seconds.
- Local pytest was unavailable in the workspace venv; the image build and end-to-end qualification exercised the runtime path.

## Stack

Review from bottom to top:

1. #13707 — preserve generated video audio
2. #13708 — pass model-specific video parameters
3. #13589 — qualify MiniMax-H3 T2VA on B200
4. **#14691** — universal video-output hardening
5. #14692 — H3-specific qualification corrections
