### PR TITLE
fix(vllm-omni): strengthen MiniMax-H3 qualification

### DIFF
--- a/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
@@ -112,13 +112,13 @@ class TestDiffusionParallelConfigCoverage:
         config = _make_config()
         config.diffusion = dataclasses.replace(
             OmniDiffusionKwargs(),
-            task_type="t2va",
+            task_type="fl2va",
             diffusion_attention_backend="TRTLLM_ATTN",
         )
 
         kwargs = _build_kwargs(config)
 
-        assert kwargs["task_type"] == "t2va"
+        assert kwargs["task_type"] == "fl2va"
         assert kwargs["diffusion_attention_backend"] == "TRTLLM_ATTN"
 
     def test_lora_disabled_resolves_no_capacity(self):

--- a/docs/fern/pages/reference/backends/vllm-omni-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-omni-configuration.mdx
@@ -58,6 +58,7 @@ These are the vLLM-Omni orchestration flags. The omni worker also accepts the sa
 <ParamField path="--enable-cpu-offload" type="flag">
   Enable CPU offloading for diffusion models.
 </ParamField>
+
 ## Diffusion Cache
 
 <ParamField path="--cache-backend" type="cache_dit | tea_cache">

--- a/docs/fern/pages/use-cases/diffusion/workflows/text-to-video.md
+++ b/docs/fern/pages/use-cases/diffusion/workflows/text-to-video.md
@@ -56,27 +56,51 @@ The response returns a video URL or base64 data depending on `response_format` (
 
 ## MiniMax-H3
 
-The initial MiniMax-H3 qualification serves text-to-video-and-audio (T2VA) with
-one aggregated diffusion worker. The launcher passes `--task-type t2va`, which
+**Experimental.** The initial MiniMax-H3 qualification serves text-to-video-and-audio (T2VA) with
+one aggregated diffusion worker. The launcher passes `--task-type fl2va`, which
 loads only H3's FL2VA checkpoint partition. Dynamo's standard image stays on
 its VP9-only media stack, so build the opt-in video-audio overlay to mux H.264
 video and AAC audio:
 
 ```bash
+export DYN_H3_DYNAMO_REVISION="$(git rev-parse HEAD)"
+export DYN_H3_BASE_IMAGE="dynamo:${DYN_H3_DYNAMO_REVISION}-vllm-runtime"
+export DYN_H3_IMAGE="dynamo:minimax-h3-${DYN_H3_DYNAMO_REVISION}"
+
+python container/render.py --framework vllm --target runtime --output-short-filename
+docker build -t "$DYN_H3_BASE_IMAGE" -f container/rendered.Dockerfile .
 docker build \
-  --build-arg BASE_IMAGE=<dynamo-vllm-local-dev-image> \
+  --build-arg BASE_IMAGE="$DYN_H3_BASE_IMAGE" \
   -f examples/backends/vllm/omni/video_audio.Dockerfile \
-  -t dynamo-vllm-minimax-h3 .
+  -t "$DYN_H3_IMAGE" .
+export DYN_H3_IMAGE_REF="$(docker image inspect --format '{{.Id}}' "$DYN_H3_IMAGE")"
 ```
 
-Launch the four-B200 profile. It uses four-way Ulysses and text-encoder tensor
+Start a shell with exactly four B200 GPUs visible. The commands pass the tested
+source revision and image ID into the qualification record:
+
+```bash
+container/run.sh \
+  --image "$DYN_H3_IMAGE" \
+  --gpus device=0,1,2,3 \
+  --mount-workspace \
+  -e DYN_H3_DYNAMO_REVISION \
+  -e DYN_H3_IMAGE_REF \
+  -e DYN_H3_MODEL \
+  -e DYN_H3_MODEL_REVISION \
+  -e HF_TOKEN \
+  -it
+```
+
+Launch the profile inside the container. It uses four-way Ulysses and text-encoder tensor
 parallelism while keeping VAE patch parallelism at one, so small supported
 resolutions such as 448x256 still have at least one tile per participating
 rank. Larger resolutions can opt into four-way VAE patch parallelism with
 `DYN_H3_VAE_PATCH_PARALLEL_SIZE=4`:
 
 ```bash
-bash examples/backends/vllm/launch/agg_omni_minimax_h3.sh
+bash examples/backends/vllm/launch/agg_omni_minimax_h3.sh \
+  > /tmp/dynamo-minimax-h3.log 2>&1 &
 ```
 
 Run the supplied end-to-end qualification against the same worker. It requests
@@ -96,6 +120,7 @@ bash examples/backends/vllm/launch/validate_omni_minimax_h3.sh
   "response_format": "url",
   "output_format": "mp4",
   "nvext": {
+    "fps": 24,
     "num_inference_steps": 50,
     "seed": 42
   },
@@ -107,13 +132,15 @@ bash examples/backends/vllm/launch/validate_omni_minimax_h3.sh
 }
 ```
 
-The request deliberately omits `fps`, so the upstream H3 pipeline keeps its
-native 24-FPS default. Dynamo preserves unrecognized top-level video fields and
-the vLLM-Omni adapter merges them into the pipeline's `extra_args`, where the
-upstream model validates them. Client libraries that expose an `extra_body`
-option can use it to add these top-level fields; do not send a literal nested
-`extra_body` object. Generated responses report `fps` and `audio_sample_rate`
-for each MP4.
+The launcher pins model revision `42ed227ee7df40d41602854ae760620d6eb651fe`.
+Set `DYN_H3_MODEL_REVISION` to test another revision. Dynamo preserves
+unrecognized top-level video fields and the vLLM-Omni adapter merges them into
+the pipeline's `extra_args`, where the upstream model validates them. Client
+libraries that expose an `extra_body` option can use it to add these top-level
+fields; do not send a literal nested `extra_body` object. Generated responses
+report `fps` and `audio_sample_rate` for each MP4. The qualification output
+records the exact Dynamo revision, container image ID, model revision, package
+versions, visible GPU models, request, media checksum, and stream probe data.
 
 First/last-frame FL2VA and reference-driven Ref2VA are not part of this initial
 qualification. They additionally require typed image, video, and audio input

--- a/examples/backends/vllm/launch/agg_omni_minimax_h3.sh
+++ b/examples/backends/vllm/launch/agg_omni_minimax_h3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Launch one aggregated vLLM-Omni worker that serves MiniMax-H3 T2VA.
@@ -9,7 +9,11 @@ trap 'echo Cleaning up...; kill 0' EXIT
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
+# MiniMax-H3 uses the four visible B200s for diffusion parallelism. The
+# text-generation KV-cache flags from gpu_utils.sh do not apply to this worker.
+
 MODEL="${DYN_H3_MODEL:-MiniMaxAI/MiniMax-H3}"
+MODEL_REVISION="${DYN_H3_MODEL_REVISION:-42ed227ee7df40d41602854ae760620d6eb651fe}"
 ULYSSES_DEGREE="${DYN_H3_ULYSSES_DEGREE:-4}"
 TEXT_ENCODER_TP_SIZE="${DYN_H3_TEXT_ENCODER_TP_SIZE:-4}"
 # H3's native patch-parallel VAE requires at least one spatial tile per rank.
@@ -30,6 +34,14 @@ while [[ $# -gt 0 ]]; do
             MODEL="$2"
             shift 2
             ;;
+        --model-revision)
+            if [[ $# -lt 2 || "$2" == --* ]]; then
+                echo "Error: --model-revision requires a value" >&2
+                exit 1
+            fi
+            MODEL_REVISION="$2"
+            shift 2
+            ;;
         *)
             EXTRA_ARGS+=("$1")
             shift
@@ -39,7 +51,7 @@ done
 
 command -v ffmpeg >/dev/null
 command -v ffprobe >/dev/null
-ffmpeg -hide_banner -encoders 2>/dev/null | grep libx264rgb >/dev/null
+ffmpeg -hide_banner -encoders 2>/dev/null | grep -E '(^| )libx264( |$)' >/dev/null
 python -c 'import av; av.codec.Codec("h264", "w"); av.codec.Codec("aac", "w")'
 
 export VLLM_WORKER_MULTIPROC_METHOD="${VLLM_WORKER_MULTIPROC_METHOD:-spawn}"
@@ -57,6 +69,7 @@ curl -sS http://localhost:${HTTP_PORT}/v1/videos \\
     "response_format": "url",
     "output_format": "mp4",
     "nvext": {
+      "fps": 24,
       "num_inference_steps": 50,
       "seed": 42
     },
@@ -70,16 +83,20 @@ CURL
 
 python -m dynamo.frontend &
 
-sleep 2
+if ! wait_for_ready "http://localhost:${HTTP_PORT}/health" 60; then
+    echo "Frontend failed to become ready; stopping launch." >&2
+    exit 1
+fi
 
 echo "Starting MiniMax-H3 T2VA Omni worker..."
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
     python -m dynamo.vllm.omni \
     --model "$MODEL" \
+    --revision "$MODEL_REVISION" \
     --output-modalities video \
     --media-output-fs-url file:///tmp/dynamo_media \
     --trust-remote-code \
-    --task-type t2va \
+    --task-type fl2va \
     --ulysses-degree "$ULYSSES_DEGREE" \
     --text-encoder-tp-size "$TEXT_ENCODER_TP_SIZE" \
     --vae-patch-parallel-size "$VAE_PATCH_PARALLEL_SIZE" \

--- a/examples/backends/vllm/launch/validate_omni_minimax_h3.sh
+++ b/examples/backends/vllm/launch/validate_omni_minimax_h3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Qualify MiniMax-H3 T2VA against one already-running aggregated worker.
@@ -7,6 +7,7 @@ set -euo pipefail
 
 API_URL="${DYN_H3_API_URL:-http://127.0.0.1:8000/v1/videos}"
 MODEL="${DYN_H3_MODEL:-MiniMaxAI/MiniMax-H3}"
+MODEL_REVISION="${DYN_H3_MODEL_REVISION:-42ed227ee7df40d41602854ae760620d6eb651fe}"
 QUAL_DIR="${DYN_H3_QUAL_DIR:-/tmp/dynamo_minimax_h3_qualification}"
 OUTPUT_DIR="$QUAL_DIR/outputs"
 CASE_NAME="cat-playing-canon-in-d-grand-piano"
@@ -16,6 +17,22 @@ VIDEO_FILE="$OUTPUT_DIR/${CASE_NAME}.mp4"
 PROBE_FILE="$OUTPUT_DIR/${CASE_NAME}.ffprobe.json"
 SOURCE_FILE="$OUTPUT_DIR/${CASE_NAME}.source-url.txt"
 SHA_FILE="$OUTPUT_DIR/${CASE_NAME}.sha256"
+HARDWARE_FILE="$OUTPUT_DIR/${CASE_NAME}.hardware.json"
+METADATA_FILE="$OUTPUT_DIR/${CASE_NAME}.qualification.json"
+AUDIO_STATS_FILE="$OUTPUT_DIR/${CASE_NAME}.audio-stats.txt"
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+DYNAMO_REVISION="${DYN_H3_DYNAMO_REVISION:-$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)}"
+IMAGE_REF="${DYN_H3_IMAGE_REF:-}"
+
+if [[ -z "$DYNAMO_REVISION" ]]; then
+    echo "Set DYN_H3_DYNAMO_REVISION to the tested Dynamo commit" >&2
+    exit 1
+fi
+if [[ -z "$IMAGE_REF" ]]; then
+    echo "Set DYN_H3_IMAGE_REF to the tested container image ID or digest" >&2
+    exit 1
+fi
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -29,6 +46,7 @@ jq -n \
         response_format: "url",
         output_format: "mp4",
         nvext: {
+            fps: 24,
             num_inference_steps: 50,
             seed: 42
         },
@@ -38,6 +56,35 @@ jq -n \
         flow_shift: 12.0,
         audio_flow_shift: 3.0
     }' > "$REQUEST_FILE"
+
+python3 - "$HARDWARE_FILE" <<'PY'
+import json
+import sys
+
+import torch
+
+devices = [torch.cuda.get_device_name(index) for index in range(torch.cuda.device_count())]
+if len(devices) != 4:
+    raise SystemExit(f"Expected exactly 4 visible GPUs, found {len(devices)}: {devices}")
+if any("B200" not in device.upper() for device in devices):
+    raise SystemExit(f"Expected 4 B200 GPUs, found: {devices}")
+
+with open(sys.argv[1], "w", encoding="utf-8") as output:
+    json.dump({"visible_gpu_count": len(devices), "devices": devices}, output, indent=2)
+    output.write("\n")
+PY
+
+models_url="${API_URL%/v1/videos}/v1/models"
+echo "Waiting for MiniMax-H3 to register with the frontend..."
+for _ in $(seq 1 360); do
+    if curl -fsS --max-time 10 "$models_url" | jq -e \
+        --arg model "$MODEL" '.data[]? | select(.id == $model)' >/dev/null; then
+        break
+    fi
+    sleep 10
+done
+curl -fsS --max-time 10 "$models_url" | jq -e \
+    --arg model "$MODEL" '.data[]? | select(.id == $model)' >/dev/null
 
 echo "Generating a 10-second MiniMax-H3 T2VA sample..."
 curl -fsS --max-time 7200 "$API_URL" \
@@ -55,7 +102,7 @@ cp "$media_path" "$VIDEO_FILE"
 printf '%s\n' "$media_url" > "$SOURCE_FILE"
 
 ffprobe -v error \
-    -show_entries stream=codec_type,codec_name,width,height,sample_rate,channels,r_frame_rate \
+    -show_entries stream=codec_type,codec_name,width,height,sample_rate,channels,r_frame_rate,start_time,duration \
     -show_entries format=duration,size \
     -of json "$VIDEO_FILE" > "$PROBE_FILE"
 
@@ -66,23 +113,71 @@ expected_height="${expected_size#*x}"
 jq -e \
     --argjson expected_width "$expected_width" \
     --argjson expected_height "$expected_height" '
-    any(.streams[];
-        .codec_type == "video" and
-        .codec_name == "h264" and
-        .r_frame_rate == "24/1" and
-        .width == $expected_width and
-        .height == $expected_height
-    ) and
-    any(.streams[]; .codec_type == "audio" and .codec_name == "aac" and .sample_rate == "32000" and .channels == 2) and
+    def abs: if . < 0 then -. else . end;
+    ([.streams[] | select(.codec_type == "video")][0]) as $video |
+    ([.streams[] | select(.codec_type == "audio")][0]) as $audio |
+    ($video.codec_name == "h264") and
+    ($video.r_frame_rate == "24/1") and
+    ($video.width == $expected_width) and
+    ($video.height == $expected_height) and
+    ($audio.codec_name == "aac") and
+    ($audio.sample_rate == "32000") and
+    ($audio.channels == 2) and
+    ((($video.start_time | tonumber) - ($audio.start_time | tonumber)) | abs) <= 0.10 and
+    (((($video.start_time | tonumber) + ($video.duration | tonumber)) -
+       (($audio.start_time | tonumber) + ($audio.duration | tonumber))) | abs) <= 0.25 and
     ((.format.duration | tonumber) >= 9.5 and (.format.duration | tonumber) <= 10.6) and
     ((.format.size | tonumber) > 0)
 ' "$PROBE_FILE" >/dev/null
 
-if ffmpeg -hide_banner -i "$VIDEO_FILE" -map 0:a:0 -af volumedetect -f null - \
-    2>&1 | grep -q 'mean_volume: -inf'; then
+ffmpeg -v error -i "$VIDEO_FILE" -map 0:v:0 -map 0:a:0 -f null -
+ffmpeg -hide_banner -i "$VIDEO_FILE" -map 0:a:0 -af volumedetect -f null - \
+    > /dev/null 2> "$AUDIO_STATS_FILE"
+if grep -q 'mean_volume: -inf' "$AUDIO_STATS_FILE"; then
     echo "Generated audio is silent" >&2
     exit 1
 fi
 
 sha256sum "$VIDEO_FILE" > "$SHA_FILE"
+export DYNAMO_REVISION IMAGE_REF MODEL MODEL_REVISION
+python3 - "$METADATA_FILE" "$HARDWARE_FILE" "$REQUEST_FILE" <<'PY'
+import importlib.metadata
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+
+def version(distribution):
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+with open(sys.argv[2], encoding="utf-8") as source:
+    hardware = json.load(source)
+with open(sys.argv[3], encoding="utf-8") as source:
+    request = json.load(source)
+
+metadata = {
+    "qualified_at": datetime.now(timezone.utc).isoformat(),
+    "dynamo_revision": os.environ["DYNAMO_REVISION"],
+    "container_image": os.environ["IMAGE_REF"],
+    "model": os.environ["MODEL"],
+    "model_revision": os.environ["MODEL_REVISION"],
+    "package_versions": {
+        "ai-dynamo": version("ai-dynamo"),
+        "vllm": version("vllm"),
+        "vllm-omni": version("vllm-omni"),
+        "av": version("av"),
+    },
+    "hardware": hardware,
+    "request": request,
+}
+with open(sys.argv[1], "w", encoding="utf-8") as output:
+    json.dump(metadata, output, indent=2)
+    output.write("\n")
+PY
 echo "MiniMax-H3 T2VA qualification passed: $VIDEO_FILE"
+echo "Qualification metadata: $METADATA_FILE"


### PR DESCRIPTION
## Summary

- Strengthen the MiniMax-H3 qualification without mixing model-specific behavior into the universal video-output fix.
- Pin the qualified H3 model revision and use the FL2VA checkpoint partition required by the tested T2VA path.
- Record Dynamo, image, model, package, and GPU metadata in qualification artifacts.
- Verify full media decode, H.264/AAC stream properties, A/V synchronization, duration, non-silent audio, and checksum.
- Avoid the `pipefail`/SIGPIPE codec-probe failure and wait for frontend health before starting the worker.

## Validation

- `bash -n` passed for both H3 scripts.
- `python3 docs/fern/scripts/docs_lint.py` passed with zero errors.
- `pre-commit run --files` passed for all files in this PR.
- The final stack passed a four-B200 Kubernetes qualification using MiniMax-H3 revision `42ed227ee7df40d41602854ae760620d6eb651fe` and image digest `sha256:5b820b31f5a4b9b14eed29952623787756a38b283e2e73e35b82f96c6af86f5a`.
- Output: 10.125 seconds, 448x256 H.264 at 24 FPS, synchronized non-silent AAC-LC at 32 kHz stereo, generated in 24.206 seconds.

## Stack

Review from bottom to top:

1. #13707 — preserve generated video audio
2. #13708 — pass model-specific video parameters
3. #13589 — qualify MiniMax-H3 T2VA on B200
4. #14691 — universal video-output hardening
5. **#14692** — H3-specific qualification corrections
