### PR TITLE
ci: retry transient compliance export failures

### DIFF
--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -130,7 +130,6 @@ runs:
         GIT_SHA: ${{ inputs.git_sha }}
         EPP_IMAGE: ${{ inputs.epp_image }}
       run: |
-        mkdir -p /tmp/compliance
         # Reuse the warm cache the build just populated by matching ALL the
         # cache-key-affecting build-args the build passed. Otherwise the shared
         # stages rebuild here instead of cache-hitting:
@@ -174,7 +173,8 @@ runs:
         # --build-arg (it would clear the ARG and reintroduce the failure).
         EPP_IMAGE_ARG=""
         [ -n "${EPP_IMAGE:-}" ] && EPP_IMAGE_ARG="--build-arg EPP_IMAGE=${EPP_IMAGE}"
-        docker buildx build \
+        bash "${{ github.action_path }}/extract-with-retry.sh" /tmp/compliance \
+            docker buildx build \
             --builder ${{ inputs.builder_name }} \
             --platform ${{ inputs.platform }} \
             --target compliance_artifact \
@@ -183,7 +183,6 @@ runs:
             --build-arg SCCACHE_BUCKET="${SCCACHE_BUCKET}" \
             --build-arg SCCACHE_REGION="${SCCACHE_REGION}" \
             $EPP_IMAGE_ARG \
-            --output type=local,dest=/tmp/compliance \
             --progress=plain \
             -f "${DOCKERFILE_PATH}" \
             $SECRET_ARGS \

--- a/.github/actions/compliance-extract/extract-with-retry.sh
+++ b/.github/actions/compliance-extract/extract-with-retry.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Retry only transient BuildKit transport failures, preserving each attempt's log.
+set -euo pipefail
+
+destination=$1
+shift
+attempt_root=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/compliance-extract.XXXXXX")
+echo "Compliance extraction logs: ${attempt_root}"
+
+for attempt in 1 2 3; do
+    output="${attempt_root}/output-${attempt}"
+    log="${attempt_root}/attempt-${attempt}.log"
+    mkdir -p "$output"
+    status=0
+    "$@" --output "type=local,dest=${output}" 2>&1 | tee "$log" || status=$?
+    if [ "$status" -eq 0 ]; then
+        # Publish only a complete export; failed attempts never reach consumers.
+        rm -rf -- "$destination"
+        mv -- "$output" "$destination"
+        exit 0
+    fi
+    rm -rf -- "$output"
+
+    # Inspect the terminal build error, not earlier warnings or command output.
+    error=$(grep '^ERROR:' "$log" | tail -n 1 || true)
+    if printf '%s\n' "$error" | grep -Eiq \
+        '(process .*did not complete successfully|401 Unauthorized|403 Forbidden|denied:|manifest unknown)'; then
+        exit "$status"
+    fi
+    if [ "$attempt" -eq 3 ] || ! printf '%s\n' "$error" | grep -Eiq \
+        '(Unavailable:.*error reading from server: (unexpected )?EOF|connection reset by peer|transport is closing|unexpected status.*(502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout))'; then
+        exit "$status"
+    fi
+    delay=10
+    [ "$attempt" -eq 2 ] && delay=30
+    echo "::warning::Compliance extraction attempt ${attempt}/3 failed with a transient transport error; retrying in ${delay}s"
+    sleep "$delay"
+done

--- a/.github/actions/compliance-extract/test_extract_with_retry.py
+++ b/.github/actions/compliance-extract/test_extract_with_retry.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the real retry wrapper with a fake BuildKit command and sleep."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("extract-with-retry.sh")
+TRANSIENT = "ERROR: failed to build: failed to solve: Unavailable: error reading from server: EOF"
+
+
+class ExtractRetryTest(unittest.TestCase):
+    def run_extract(self, errors):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for index, error in enumerate(errors, 1):
+                (root / f"error-{index}").write_text(error)
+            fake = root / "build"
+            fake.write_text(
+                """#!/usr/bin/env bash
+set -eu
+count=0
+[ ! -f "$STATE/count" ] || count=$(cat "$STATE/count")
+count=$((count + 1))
+echo "$count" > "$STATE/count"
+for arg in "$@"; do
+    case "$arg" in type=local,dest=*) output=${arg#type=local,dest=} ;; esac
+done
+mkdir -p "$output"
+echo "$count" > "$output/attempt-$count"
+error="$STATE/error-$count"
+if [ -s "$error" ]; then
+    cat "$error"
+    exit 7
+fi
+"""
+            )
+            fake.chmod(0o755)
+            sleep = root / "sleep"
+            sleep.write_text('#!/usr/bin/env bash\necho "$1" >> "$STATE/delays"\n')
+            sleep.chmod(0o755)
+            destination = root / "result"
+            env = dict(
+                os.environ,
+                STATE=temp,
+                RUNNER_TEMP=temp,
+                PATH=temp + os.pathsep + os.environ["PATH"],
+            )
+            result = subprocess.run(
+                ["bash", str(SCRIPT), str(destination), str(fake)],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            count = int((root / "count").read_text())
+            delays = (
+                (root / "delays").read_text().splitlines()
+                if (root / "delays").exists()
+                else []
+            )
+            files = sorted(p.name for p in destination.glob("*"))
+            logs = list(root.glob("compliance-extract.*/attempt-*.log"))
+            self.assertEqual(len(logs), count)
+            return result.returncode, count, delays, files
+
+    def test_success(self):
+        self.assertEqual(self.run_extract([""]), (0, 1, [], ["attempt-1"]))
+
+    def test_transient_recovers_without_partial_files(self):
+        self.assertEqual(
+            self.run_extract([TRANSIENT, ""]), (0, 2, ["10"], ["attempt-2"])
+        )
+
+    def test_third_attempt_recovers(self):
+        self.assertEqual(
+            self.run_extract([TRANSIENT, TRANSIENT, ""]),
+            (0, 3, ["10", "30"], ["attempt-3"]),
+        )
+
+    def test_exhaustion_preserves_failure(self):
+        self.assertEqual(self.run_extract([TRANSIENT] * 3), (7, 3, ["10", "30"], []))
+
+    def test_deterministic_errors_do_not_retry(self):
+        for error in [
+            "ERROR: failed to solve: process did not complete: exit code: 1",
+            "ERROR: failed to authorize: 401 Unauthorized",
+            "ERROR: manifest unknown",
+            "No solution found when resolving dependencies",
+        ]:
+            with self.subTest(error=error):
+                self.assertEqual(self.run_extract([error]), (7, 1, [], []))
+
+    def test_earlier_transient_does_not_mask_terminal_failure(self):
+        self.assertEqual(
+            self.run_extract([TRANSIENT + "\nERROR: manifest unknown"]), (7, 1, [], [])
+        )
+
+    def test_other_transport_errors_recover(self):
+        for error in [
+            "ERROR: failed to solve: connection reset by peer",
+            "ERROR: failed to solve: rpc error: transport is closing",
+            "ERROR: failed to solve: unexpected status from HEAD request: 503 Service Unavailable",
+        ]:
+            with self.subTest(error=error):
+                self.assertEqual(
+                    self.run_extract([error, ""]), (0, 2, ["10"], ["attempt-2"])
+                )
+
+    def test_build_command_containing_transport_text_does_not_retry(self):
+        error = 'ERROR: process "echo connection reset by peer" did not complete successfully: exit code: 1'
+        self.assertEqual(self.run_extract([error]), (7, 1, [], []))
+
+    def test_permanent_error_after_retry_stops(self):
+        self.assertEqual(
+            self.run_extract([TRANSIENT, "ERROR: manifest unknown"]), (7, 2, ["10"], [])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/compliance-extract/test_extract_with_retry.py
+++ b/.github/actions/compliance-extract/test_extract_with_retry.py
@@ -15,6 +15,7 @@ TRANSIENT = "ERROR: failed to build: failed to solve: Unavailable: error reading
 
 class ExtractRetryTest(unittest.TestCase):
     def run_extract(self, errors):
+        """Run the wrapper with scripted failures and inspect retries and output."""
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             for index, error in enumerate(errors, 1):

--- a/.github/actions/compliance-extract/test_extract_with_retry.py
+++ b/.github/actions/compliance-extract/test_extract_with_retry.py
@@ -15,7 +15,6 @@ TRANSIENT = "ERROR: failed to build: failed to solve: Unavailable: error reading
 
 class ExtractRetryTest(unittest.TestCase):
     def run_extract(self, errors):
-        """Run the wrapper with scripted failures and inspect retries and output."""
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             for index, error in enumerate(errors, 1):
@@ -74,12 +73,6 @@ fi
     def test_transient_recovers_without_partial_files(self):
         self.assertEqual(
             self.run_extract([TRANSIENT, ""]), (0, 2, ["10"], ["attempt-2"])
-        )
-
-    def test_third_attempt_recovers(self):
-        self.assertEqual(
-            self.run_extract([TRANSIENT, TRANSIENT, ""]),
-            (0, 3, ["10", "30"], ["attempt-3"]),
         )
 
     def test_exhaustion_preserves_failure(self):

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,6 +198,12 @@ repos:
       # be a second copy to keep in sync. Full scan is well under 0.1s.
       files: ^\.github/
       pass_filenames: false
+    - id: compliance-extract-selftest
+      name: Test compliance export retries
+      entry: python3 .github/actions/compliance-extract/test_extract_with_retry.py
+      language: python
+      pass_filenames: false
+      files: ^(\.github/actions/compliance-extract/|\.pre-commit-config\.yaml$)
     - id: check-action-pins-selftest
       name: Self-test the action-pin matcher
       entry: python3 scripts/check_action_pins.py --test


### PR DESCRIPTION
## Overview

### Summary

The Planner image build in #14377 succeeded, but the subsequent compliance export failed while BuildKit resolved `ghcr.io/astral-sh/uv:0.12.0` with `Unavailable: error reading from server: EOF`. That made the build job fail and skipped its downstream tests. [Failure logs](https://github.com/ai-dynamo/dynamo/actions/runs/34554919492/job/103125496160).

## Details

Add bounded retries to the shared `/compliance/` export: at most three attempts, with 10s and 30s delays, for narrowly matched transient transport errors in the final BuildKit error. Compilation failures, explicit authorization denials, missing manifests, and unrecognized errors fail immediately; exhausted retries retain a failing exit status.

Each attempt exports to a fresh temporary directory. Only a successful export replaces the destination, and every attempt's output remains in the job log. This is an independent CI fix based on main; it does not depend on #14377 or change its Planner code, job dependencies, or compliance requirements.

## Where should the reviewer start?

Start with `.github/actions/compliance-extract/extract-with-retry.sh` for error classification and output isolation, then `.pre-commit-config.yaml` for the regression-test hook. The existing Pre Merge pre-commit job runs this hook automatically; the tests use only Python's standard library and Bash.

## Related Issues

- [x] Confirmed — no related issue.
- Related PR: #14377, where the original compliance export failure occurred.

## Validation

- 8 regression tests passed: immediate success, retry recovery, retry exhaustion, deterministic failures, final-error classification, and partial-output isolation. Tests execute the real Bash wrapper with fake BuildKit and sleep commands.
- Bash syntax and action YAML parsing passed.
- Black 23.1.0, isort, Flake8 7.3.0, Ruff 0.5.2, and `git diff --check` passed.
- Live remote BuildKit/registry recovery has not been exercised locally.

Run the regression suite with `python3 .github/actions/compliance-extract/test_extract_with_retry.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compliance extraction reliability by retrying recognized temporary build transport failures.
  * Prevented incomplete or partial extraction results from replacing successful output.
  * Preserved immediate failure handling for permanent, authorization, and unrecognized errors.
  * Added clearer per-attempt logging to support troubleshooting.

* **Tests**
  * Added coverage for successful extraction, retry behavior, exhausted retries, permanent failures, cleanup, and output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
The `compliance-extract-selftest` pre-commit hook passes all 8 tests. Temporarily disabling retries makes the same hook fail; restoring the wrapper makes it pass again. Verified selection for the action, wrapper, tests, and hook configuration, with unrelated files skipped.
