### PR TITLE
fix(vllm): forward sidecar allowed token IDs

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -9014,6 +9014,8 @@ mod tests {
 
     #[test]
     fn test_backend_extra_args_preserves_nvext_and_sampling_extensions() {
+        use crate::engines::ValidateRequest;
+
         let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "hi"}],
@@ -9057,6 +9059,56 @@ mod tests {
             extra_args["sampling_options"]["logprob_token_ids"],
             serde_json::json!([14, 15])
         );
+
+        // Exercise the public request validators before converting backend args:
+        // a converter-only test misses null being rejected by the frontend.
+        for chat in [true, false] {
+            for (allowed_token_ids, valid) in [
+                (None, true),
+                (Some(serde_json::json!(null)), true),
+                (Some(serde_json::json!([10, 11])), true),
+                (Some(serde_json::json!([])), false),
+                (Some(serde_json::json!("bad")), false),
+                (Some(serde_json::json!([-1])), false),
+            ] {
+                let mut body = if chat {
+                    serde_json::json!({
+                        "model": "test-model",
+                        "messages": [{"role": "user", "content": "hi"}]
+                    })
+                } else {
+                    serde_json::json!({"model": "test-model", "prompt": [1, 2, 3]})
+                };
+                if let Some(value) = &allowed_token_ids {
+                    body["allowed_token_ids"] = value.clone();
+                }
+                let result = if chat {
+                    let request: NvCreateChatCompletionRequest =
+                        serde_json::from_value(body).unwrap();
+                    ValidateRequest::validate(&request)
+                        .map(|()| OpenAIPreprocessor::backend_extra_args(&request, false, None))
+                } else {
+                    let request: NvCreateCompletionRequest = serde_json::from_value(body).unwrap();
+                    ValidateRequest::validate(&request)
+                        .map(|()| OpenAIPreprocessor::backend_extra_args(&request, false, None))
+                };
+                if valid {
+                    let extra_args = result.unwrap_or_else(|error| {
+                        panic!("chat={chat}, allowed_token_ids={allowed_token_ids:?}: {error:?}")
+                    });
+                    assert_eq!(
+                        extra_args
+                            .as_ref()
+                            .and_then(|extra| extra.get("sampling_options"))
+                            .and_then(|sampling| sampling.get("allowed_token_ids")),
+                        allowed_token_ids.as_ref()
+                    );
+                } else {
+                    let error = result.expect_err("invalid allowlist must fail before dispatch");
+                    assert!(error.to_string().contains("allowed_token_ids"));
+                }
+            }
+        }
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -156,8 +156,14 @@ fn validate_no_unsupported_fields_with_ignore(
         anyhow::bail!("`detokenize` must be a boolean");
     }
     if let Some(value) = unsupported_fields.get("allowed_token_ids") {
-        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
-            .map_err(|_| anyhow::anyhow!("`allowed_token_ids` must be an array of token IDs"))?;
+        // Match vLLM's Python API: null is unrestricted, but an empty list is invalid.
+        let ids: Option<Vec<crate::types::TokenIdType>> = serde_json::from_value(value.clone())
+            .map_err(|_| {
+                anyhow::anyhow!("`allowed_token_ids` must be an array of token IDs or null")
+            })?;
+        if ids.is_some_and(|ids| ids.is_empty()) {
+            anyhow::bail!("`allowed_token_ids` must not be empty");
+        }
     }
     if let Some(value) = unsupported_fields.get("bad_words_token_ids") {
         serde_json::from_value::<Vec<Vec<crate::types::TokenIdType>>>(value.clone()).map_err(

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -82,6 +82,7 @@ pub(crate) fn build_generate_request(
     let encoder_result = request.encoder_result;
     let mut extra_args = request.extra_args;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
+    let allowed_token_ids = consume_sampling_passthrough(&mut extra_args)?;
     if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
         // These fields are already represented by token_ids and media.
         extra.remove("messages");
@@ -109,7 +110,7 @@ pub(crate) fn build_generate_request(
             frequency_penalty: sampling.frequency_penalty.unwrap_or(0.0),
             repetition_penalty: sampling.repetition_penalty.unwrap_or(0.0),
             logit_bias: Default::default(),
-            allowed_token_ids: Vec::new(),
+            allowed_token_ids,
             structured_output: structured_output(sampling.guided_decoding)?,
         }),
         stopping: Some(pb::StoppingCriteria {
@@ -149,6 +150,45 @@ pub(crate) fn data_parallel_rank(
         DisaggregationMode::Prefill => routing.prefill_dp_rank.or(routing.dp_rank),
         DisaggregationMode::Aggregated | DisaggregationMode::Decode => routing.dp_rank,
     })
+}
+
+fn consume_sampling_passthrough(
+    extra_args: &mut Option<serde_json::Value>,
+) -> Result<Vec<u32>, DynamoError> {
+    let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() else {
+        return Ok(Vec::new());
+    };
+    let Some(sampling) = extra.remove("sampling_options") else {
+        return Ok(Vec::new());
+    };
+    let serde_json::Value::Object(mut sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.sampling_options must be a JSON object",
+        ));
+    };
+    for key in sampling.keys() {
+        if key != "allowed_token_ids" {
+            return Err(client::invalid_argument(format!(
+                "extra_args.sampling_options.{key} is not supported by vLLM gRPC"
+            )));
+        }
+    }
+    match sampling.remove("allowed_token_ids") {
+        None | Some(serde_json::Value::Null) => Ok(Vec::new()),
+        Some(value) => {
+            let ids: Vec<u32> = serde_json::from_value(value).map_err(|error| {
+                client::invalid_argument(format!(
+                    "extra_args.sampling_options.allowed_token_ids must be an array of unsigned 32-bit token IDs: {error}"
+                ))
+            })?;
+            if ids.is_empty() {
+                return Err(client::invalid_argument(
+                    "extra_args.sampling_options.allowed_token_ids must not be empty",
+                ));
+            }
+            Ok(ids)
+        }
+    }
 }
 
 fn consume_redundant_nvext(

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -1104,6 +1104,9 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 
     let mut routed_request = serde_json::to_value(request()).expect("serialize request");
     routed_request["routing"] = json!({"dp_rank": 1, "cache_salt": "cache-salt"});
+    // The frontend carries backend-native sampling controls in this envelope.
+    // They must reach gRPC without discarding adjacent routing/KV options.
+    routed_request["extra_args"]["sampling_options"] = json!({"allowed_token_ids": [42, 43]});
     let outputs = collect(
         &engine,
         serde_json::from_value(routed_request).expect("deserialize routed request"),
@@ -1135,6 +1138,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     );
     assert_eq!(sampling.seed, Some(123));
     let decoding = sent.decoding.as_ref().unwrap();
+    assert_eq!(decoding.allowed_token_ids, [42, 43]);
     assert_eq!(
         (
             decoding.presence_penalty,
@@ -2138,6 +2142,19 @@ async fn unsupported_features_fail_before_rpc_submission() {
     mismatched_cache_salt.extra_args.as_mut().unwrap()["nvext"]["cache_salt"] =
         json!("different-cache-salt");
     requests.push(mismatched_cache_salt);
+
+    // An empty allowlist cannot become the protobuf default (no constraint),
+    // and consuming the envelope must not silently drop unsupported siblings.
+    for sampling in [
+        json!({"allowed_token_ids": []}),
+        json!({"allowed_token_ids": [42], "bad_words_token_ids": [[43]]}),
+        json!({"allowed_token_ids": [42], "detokenize": false}),
+        json!({"allowed_token_ids": [42], "logprob_token_ids": [43]}),
+    ] {
+        let mut unsupported = request();
+        unsupported.extra_args.as_mut().unwrap()["sampling_options"] = sampling;
+        requests.push(unsupported);
+    }
 
     for unsupported in requests {
         let context = dynamo_backend_common::testing::mock_context();


### PR DESCRIPTION
## Summary

The vLLM sidecar rejects the frontend's `allowed_token_ids` sampling envelope instead of forwarding it to the existing gRPC field. Consume that supported field and forward its token IDs, while retaining rejection of unsupported siblings.

Match vLLM Python HTTP at public request validation too: omission and explicit `null` mean unrestricted generation; a nonempty list restricts sampling; an empty list is invalid and returns HTTP 400 before dispatch. Previously the shared frontend validator rejected `null`, and empty-list rejection happened too late in the sidecar. This shared validation applies to Chat and Completions across backends.

The field is a vLLM extension to the OpenAI-compatible API. General backend-error HTTP mapping and tokenizer-versus-model vocabulary bounds remain separate concerns.

## Validation

- Extended the existing public-validator/preprocessor regression for both Chat and Completions. Omitted/null/nonempty values pass and preserve their values; empty, malformed, and negative-ID values fail validation. The regression fails against the previous draft on `null`.
- On upstream base `b3d4176dc2`, 15 focused request/validator/passthrough tests pass. All 31 sidecar library tests pass, including real fake-server gRPC forwarding/rejection checks. The sidecar and current-source HttpFrontend launcher build successfully.
- Live Qwen3-0.6B, paired vLLM 0.29.0 (`98dff2a81d`), one RTX 6000 Ada: all eight public Dynamo HTTP cases pass across Chat and Completions. Omission/null/nonempty return 200, empty returns 400, and null/omission text is identical. `[198]` produces exactly 24 newline tokens, matching the actual Python HTTP reference on both APIs. The isolated native runtime contains the selected-logprob amendment, which does not affect these allowlist requests.
- Formatting, whitespace checks, and two independent source reviews pass.

AI assistance was used. This PR remains a draft.
