### PR TITLE
fix(vllm-sidecar): preserve buffered empty text deltas

### DIFF
--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -795,9 +795,11 @@ impl ResponseState {
             } else {
                 token_ids
             },
-            text: if self.mode.is_prefill() || self.mode.is_encode() || text.is_empty() {
+            text: if self.mode.is_prefill() || self.mode.is_encode() {
                 None
             } else {
+                // vLLM may buffer text while matching stop strings. Preserve an
+                // empty delta so the frontend does not detokenize its IDs again.
                 Some(text)
             },
             index: Some(0),

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -32,6 +32,7 @@ use crate::proto as pb;
 
 #[derive(Clone, Default)]
 struct FakeVllm {
+    sequence_outputs: Option<Vec<pb::SequenceOutput>>,
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
     data_parallel_rank_metadata: Arc<Mutex<Vec<Option<String>>>>,
     peers: Arc<Mutex<Vec<SocketAddr>>>,
@@ -169,6 +170,7 @@ impl pb::inference_server::Inference for FakeVllm {
         let first_token_pending = self.first_token_pending.clone();
         let release_first_token = self.release_first_token.clone();
         let dropped = self.server_stream_dropped.clone();
+        let sequence_outputs = self.sequence_outputs.clone();
 
         let stream = async_stream::try_stream! {
             let _drop_signal = DropSignal(dropped);
@@ -219,6 +221,13 @@ impl pb::inference_server::Inference for FakeVllm {
                     json_to_struct(encoder_handoff).expect("encoder handoff")
                 });
                 yield encode_response(ec);
+            } else if let Some(outputs) = sequence_outputs {
+                for output in outputs {
+                    yield pb::GenerateResponse {
+                        prompt_info: None,
+                        outputs: Some(output),
+                    };
+                }
             } else {
                 let kv = is_prefill.then(|| {
                     json_to_struct(handoff.clone()).expect("encode handoff")
@@ -1045,6 +1054,71 @@ async fn encode_startup_rejects_non_multimodal_engine() {
             .to_string()
             .contains("encode mode requires a multimodal engine")
     );
+}
+
+#[tokio::test]
+async fn generation_preserves_empty_engine_text_while_stop_text_is_buffered() {
+    // Empty engine text must stay present, or the frontend detokenizes these
+    // IDs before vLLM releases the buffered text and duplicates the prefix.
+    let outputs = [
+        (vec![42], ""),
+        (vec![43], " buffered text"),
+        (Vec::new(), ""),
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, (token_ids, text))| pb::SequenceOutput {
+        num_tokens: token_ids.len() as u32,
+        token_ids,
+        text: text.to_string(),
+        finish_info: (index == 2).then_some(pb::FinishInfo {
+            num_output_tokens: 2,
+            finish_reason: pb::finish_info::FinishReason::Length as i32,
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+    .collect();
+    let server = FakeServer::start(FakeVllm {
+        sequence_outputs: Some(outputs),
+        ..Default::default()
+    })
+    .await;
+
+    for mode in [DisaggregationMode::Aggregated, DisaggregationMode::Decode] {
+        let engine = engine(&server.endpoint, mode, 1, model_info());
+        engine.start(0).await.expect("start");
+        let mut request = if mode.is_decode() {
+            decode_request()
+        } else {
+            request()
+        };
+        request.output_options = OutputOptions::default();
+        request.stop_conditions.max_tokens = Some(2);
+        let outputs = collect(&engine, request).await;
+
+        assert_eq!(
+            outputs
+                .iter()
+                .map(|output| output.text.as_deref())
+                .collect::<Vec<_>>(),
+            [Some(""), Some(" buffered text"), Some("")],
+            "{mode}: preserve engine text presence, including the empty terminal"
+        );
+        assert_eq!(outputs[0].token_ids, [42]);
+        assert_eq!(outputs[1].token_ids, [43]);
+        assert!(outputs[2].token_ids.is_empty());
+        assert_eq!(outputs[2].finish_reason, Some(FinishReason::Length));
+        assert_eq!(
+            outputs[2]
+                .completion_usage
+                .as_ref()
+                .unwrap()
+                .completion_tokens,
+            2
+        );
+        engine.cleanup().await.expect("cleanup");
+    }
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -1058,8 +1058,10 @@ async fn encode_startup_rejects_non_multimodal_engine() {
 
 #[tokio::test]
 async fn generation_preserves_empty_engine_text_while_stop_text_is_buffered() {
-    // Empty engine text must stay present, or the frontend detokenizes these
-    // IDs before vLLM releases the buffered text and duplicates the prefix.
+    // Example: vLLM emits token 42 with `text: ""` while buffering a long,
+    // nonmatching stop string, then emits token 43 with `text: " buffered text"`.
+    // Expect the first delta to remain `Some("")`, so the frontend waits for
+    // vLLM's buffered text instead of detokenizing token 42 and duplicating it.
     let outputs = [
         (vec![42], ""),
         (vec![43], " buffered text"),


### PR DESCRIPTION
## Summary

A long nonmatching stop string can duplicate completion text through the vLLM sidecar. Native vLLM buffers text while checking stop strings, but the sidecar changes an empty text delta to `None`. The frontend then detokenizes those token IDs itself and appends the text again when vLLM releases its buffer.

Concrete example from the regression fixture: vLLM first sends `SequenceOutput { token_ids: vec![42], text: "" }`, then sends `SequenceOutput { token_ids: vec![43], text: " buffered text" }`. For aggregated and decode output, the first response must become `LLMEngineOutput { token_ids: vec![42], text: Some("") }`. `Some("")` tells the frontend that vLLM owns the text for token 42, so it waits for the buffered text instead of detokenizing 42 and duplicating the completion prefix.

Preserve `Some("")` for aggregated and decode output, including empty terminal deltas. Prefill and encoder output handling stays unchanged.

## Validation

- Existing fake-gRPC fixture extended to cover buffered text in aggregated and decode modes; the regression fails against the original converter and passes with this change.
- All 32 vLLM sidecar library tests pass; formatting and commit hooks pass.
- Live Qwen3-0.6B on the paired vLLM 0.29.0 runtime, current-source Dynamo frontend: with `temperature=0`, `max_tokens=24`, and a 100-character nonmatching stop string, fixed output exactly equals the no-stop control. Original sidecar duplicates a prefix while still reporting 24 output tokens.
- Live ordinary streaming, short nonmatching stops, matching stops, visible stop strings, and `min_tokens=24` checks also pass.

Single-GPU functional validation; no throughput or multi-GPU qualification claim.

September 11 refresh: rebased without a semantic change onto `b3d4176dc2`; all 32 sidecar library tests pass again, including `generation_preserves_empty_engine_text_while_stop_text_is_buffered`; formatting and whitespace checks pass. Independent review verified patch equivalence. An additional actual Python HTTP reference on the same paired vLLM 0.29.0/Qwen3-0.6B runtime confirms plain, buffered long-stop nonstream, and reassembled long-stop SSE text are equal through both Chat and Completions. The earlier native comparison used Rust HTTP with Python EngineCore. The compatibility requirement here is final text and detokenization ownership; identical SSE chunk boundaries are not asserted.

AI assistance was used. This remains a draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming responses now preserve intentionally empty text updates from the engine, improving consistency when processing incremental output.
  - Aggregated and decoded generation now retain empty text, buffered content, token information, completion status, and usage details correctly.
  - Empty updates remain excluded where text output is not applicable, such as prefill and encode modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
