### PR TITLE
fix(planner): weight frontend histogram averages by observations

### DIFF
--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -176,9 +176,8 @@ class PrometheusAPIClient:
         use underscores, so dashes are normalized before building the PromQL filter.
 
         When model_name is provided (frontend source): queries per-model metrics
-        via increase(metric_sum)/increase(metric_count), filtered by model and
-        dynamo_namespace labels. The dynamo_frontend_ prefix is prepended
-        automatically if absent.
+        by summing histogram increases per model and dynamo_namespace before
+        dividing. The dynamo_frontend_ prefix is prepended automatically if absent.
 
         Returns:
             Average metric value, or 0 if no data/error.
@@ -213,7 +212,13 @@ class PrometheusAPIClient:
                     full_metric_name = (
                         f"{prometheus_names.name_prefix.FRONTEND}_{full_metric_name}"
                     )
-                query = f"increase({full_metric_name}_sum[{interval}])/increase({full_metric_name}_count[{interval}])"
+                # Aggregate observations, not per-instance averages: idle
+                # instances contribute zero count increases, and busy instances
+                # retain their weight. Keep model/namespace labels for filtering.
+                query = (
+                    f"sum by (model, dynamo_namespace) (increase({full_metric_name}_sum[{interval}])) / "
+                    f"sum by (model, dynamo_namespace) (increase({full_metric_name}_count[{interval}]))"
+                )
                 result = self.prom.custom_query(query=query)
                 if not result:
                     logger.warning(
@@ -221,7 +226,6 @@ class PrometheusAPIClient:
                     )
                     return 0
                 metrics_containers = parse_frontend_metric_containers(result)
-                values = []
                 for container in metrics_containers:
                     # Frontend lowercases model names for Prometheus labels so we need to do case-insensitive comparison
                     if (
@@ -229,13 +233,15 @@ class PrometheusAPIClient:
                         and container.metric.model.lower() == model_name.lower()
                         and container.metric.dynamo_namespace == self.dynamo_namespace
                     ):
-                        values.append(container.value[1])
-                if not values:
-                    logger.warning(
-                        f"No prometheus metric data available for {full_metric_name} with model {model_name} and dynamo namespace {self.dynamo_namespace}, use 0 instead"
-                    )
-                    return 0
-                return sum(values) / len(values)
+                        return container.value[1]
+                logger.warning(
+                    "No prometheus metric data available for %s with model %s "
+                    "and dynamo namespace %s, use 0 instead",
+                    full_metric_name,
+                    model_name,
+                    self.dynamo_namespace,
+                )
+                return 0
         except Exception as e:
             logger.error(f"Error getting {operation_name}: {e}")
             return 0

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -335,24 +335,52 @@ def test_get_average_metric_with_validation_error():
         assert result == 25.5
 
 
-def test_get_average_metric_multiple_matching_containers(mock_prometheus_result):
-    """Test _get_average_metric with multiple matching containers returns average"""
-    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+def test_frontend_histogram_query_and_model_namespace_selection():
+    client = _mocked_frontend_client("target_namespace")
+    client.prom.custom_query.return_value = [
+        {
+            "metric": {"model": "other", "dynamo_namespace": "target_namespace"},
+            "value": [0, "9999"],
+        },
+        {
+            "metric": {"model": "target_model", "dynamo_namespace": "other"},
+            "value": [0, "9999"],
+        },
+        {
+            "metric": {
+                "model": "target_model",
+                "dynamo_namespace": "target_namespace",
+            },
+            "value": [0, "199"],
+        },
+    ]
 
-    with patch.object(client.prom, "custom_query") as mock_query:
-        # Use containers 1, 2, 3 which all match target criteria
-        mock_query.return_value = mock_prometheus_result[1:]
+    result = client.get_avg_input_sequence_tokens("60s", "TARGET_MODEL")
 
-        result = client._get_average_metric(
-            full_metric_name="test_metric",
-            interval="60s",
-            operation_name="test operation",
-            model_name="target_model",
+    client.prom.custom_query.assert_called_once_with(
+        query=(
+            "sum by (model, dynamo_namespace) "
+            "(increase(dynamo_frontend_input_sequence_tokens_sum[60s])) / "
+            "sum by (model, dynamo_namespace) "
+            "(increase(dynamo_frontend_input_sequence_tokens_count[60s]))"
         )
+    )
+    assert result == 199.0
 
-        # Average of 42.7, 35.5, and 15.5 (using value[1] from each container)
-        expected = (42.7 + 35.5 + 15.5) / 3
-        assert result == expected
+
+def test_frontend_histogram_preserves_nan_result():
+    client = _mocked_frontend_client("target_namespace")
+    client.prom.custom_query.return_value = [
+        {
+            "metric": {
+                "model": "target_model",
+                "dynamo_namespace": "target_namespace",
+            },
+            "value": [0, "NaN"],
+        }
+    ]
+
+    assert math.isnan(client.get_avg_input_sequence_tokens("60s", "target_model"))
 
 
 def test_get_avg_request_count_uses_started_requests():


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Planner gives each frontend's histogram average equal weight, regardless of how many requests it handled. With frontend-sourced metrics, this produces incorrect averages under uneven traffic. An idle frontend can also introduce `NaN`, causing Planner to skip a window in which other frontends served requests.

This change sums histogram increases by `model` and `dynamo_namespace` before dividing the total sum by the total count. An idle frontend then contributes zero observations rather than an undefined per-instance average. When the entire window has zero requests, the collector still uses its existing logic to convert undefined averages to zero.

## Details:

<!-- Describe the changes made in this PR. -->
I checked controlled counter samples with `promtool` and passed the corresponding query results through the production Python collector using mocked Prometheus responses. This validates aggregation and collection, not cluster autoscaling.

For two frontends serving the same model and namespace, 495 requests with 100 input tokens and 5 requests with 10,000 input tokens should produce:

```text
(495 × 100 + 5 × 10,000) / 500 = 199
```

Before the fix, the collector instead reported 5,050.

Actual collector log messages, with timestamps and logger prefixes omitted:

**Before:**

```text
Observed num_req: 500.00 isl: 5050.00 osl: 1.00 kv_hit_rate: n/a accept_length: n/a
```

**After:**

```text
Observed num_req: 500.00 isl: 199.00 osl: 1.00 kv_hit_rate: n/a accept_length: n/a
```

Here, `isl` is the average input-token count. Unrelated metrics were held constant.

With 495 requests of 100 input tokens on one frontend and no new observations on the other, the collector changed from discarding the window to reporting the expected average:

**Before:**

```text
Metrics contain None or NaN values, skipping
```

**After:**

```text
Observed num_req: 495.00 isl: 100.00 osl: 1.00 kv_hit_rate: n/a accept_length: n/a
```

The added unit tests check the grouped query and model/namespace selection. They also verify that the metrics client returns an undefined query result unchanged, leaving zero-request normalization to the collector.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
* `components/src/dynamo/planner/monitoring/traffic_metrics.py`: `_get_average_metric`.
* `components/src/dynamo/planner/tests/unit/test_prometheus.py`: regression coverage.

## Related Issues



**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Frontend histogram metrics now provide request-weighted average values across instances, grouped by model and namespace.
  - Matching metric results are reported directly for more consistent monitoring output.
  - Missing model or namespace data now produces a structured warning and returns zero instead of an unavailable result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->