### PR TITLE
fix(operator): decouple snapshot compatibility hash

### DIFF
--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -68,14 +68,19 @@ runs:
       run: |
         make check
 
-    - name: Test Go/Python DGD override boundary
+    - name: Test Go/Python integration boundaries
       if: ${{ inputs.component == 'operator' }}
       shell: bash
       env:
         DYNAMO_RUN_DGD_OVERRIDE_GO_INTEGRATION: "1"
+        DYNAMO_REQUIRE_SNAPSHOT_ENV_PARITY: "1"
         PYTHONPATH: ${{ github.workspace }}/components/src
       run: |
         go version
+        go -C deploy/operator test \
+          ./internal/checkpoint \
+          -run '^TestSnapshotRestoreEnvironmentNamesMatchPythonRuntime$' \
+          -count=1
         python -m pytest \
           -c /dev/null \
           --confcutdir=components/src/dynamo/profiler/tests/integration \

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -225,6 +225,8 @@ operator:
   - 'components/src/dynamo/profiler/utils/dgd_override.py'
   - 'components/src/dynamo/profiler/tests/integration/test_dgd_override_go_integration.py'
   - 'components/src/dynamo/profiler/utils/dgdr_*'
+  # The operator check also owns the Go/Python snapshot environment contract test.
+  - 'components/src/dynamo/common/snapshot/**'
 
 snapshot:
   - 'deploy/checkpoint-placeholder/**'

--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -6,9 +6,16 @@
 package checkpoint
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"sort"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -34,4 +41,181 @@ func ValidateCheckpointCompatibility(experimental *nvidiacomv1beta1.Experimental
 	}
 
 	return violations
+}
+
+// snapshotRestoreEnvironmentNames must match the environment restored by
+// components/src/dynamo/common/snapshot/restore_context.py. Those values name
+// the destination Pod and runtime, so they are intentionally not part of a
+// portable snapshot's compatibility identity.
+var snapshotRestoreEnvironmentNames = map[string]struct{}{
+	"CONTAINER_NAME":                        {},
+	"DYN_COMPONENT":                         {},
+	"DYN_DISCOVERY_BACKEND":                 {},
+	"DYN_EVENT_PLANE":                       {},
+	"DYN_EVENT_PLANE_HOST":                  {},
+	"DYN_GMS_USE_V1":                        {},
+	"DYN_HEALTH_CHECK_ENABLED":              {},
+	"DYN_KUBE_DISCOVERY_MODE":               {},
+	"DYN_NAMESPACE":                         {},
+	"DYN_NAMESPACE_WORKER_SUFFIX":           {},
+	"DYN_PARENT_DGD_K8S_NAME":               {},
+	"DYN_PARENT_DGD_K8S_NAMESPACE":          {},
+	"DYN_REQUEST_PLANE":                     {},
+	"DYN_SYSTEM_HEALTH_PATH":                {},
+	"DYN_SYSTEM_HOST":                       {},
+	"DYN_SYSTEM_LIVE_PATH":                  {},
+	"DYN_SYSTEM_PORT":                       {},
+	"DYN_SYSTEM_STARTING_HEALTH_STATUS":     {},
+	"DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS": {},
+	"DYN_TCP_RESPONSE_STREAM_HOST":          {},
+	"DYN_TCP_RESPONSE_STREAM_PORT":          {},
+	"DYN_TCP_RPC_HOST":                      {},
+	"DYN_TCP_RPC_PORT":                      {},
+	"DYN_VLLM_GMS_SHADOW_MODE":              {},
+	"ENGINE_ID":                             {},
+	"ETCD_ENDPOINTS":                        {},
+	"FAILOVER_LOCK_PATH":                    {},
+	"MODEL_EXPRESS_URL":                     {},
+	"NATS_SERVER":                           {},
+	"POD_NAME":                              {},
+	"POD_NAMESPACE":                         {},
+	"POD_UID":                               {},
+	"PROMETHEUS_ENDPOINT":                   {},
+}
+
+type snapshotCompatibilityContract struct {
+	Version               string                     `json:"version"`
+	BackendFramework      string                     `json:"backendFramework"`
+	GMSMode               string                     `json:"gmsMode"`
+	TargetContainer       corev1.Container           `json:"targetContainer"`
+	InitContainers        []corev1.Container         `json:"initContainers,omitempty"`
+	Volumes               []corev1.Volume            `json:"volumes,omitempty"`
+	HostNetwork           bool                       `json:"hostNetwork,omitempty"`
+	HostPID               bool                       `json:"hostPID,omitempty"`
+	HostIPC               bool                       `json:"hostIPC,omitempty"`
+	ShareProcessNamespace *bool                      `json:"shareProcessNamespace,omitempty"`
+	SecurityContext       *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	RuntimeClassName      *string                    `json:"runtimeClassName,omitempty"`
+}
+
+// ComputeSnapshotCompatibilityHash returns the portable v1 compatibility
+// identity for one captured process. It deliberately excludes rollout and
+// graph-incarnation identity, along with restore-time environment that Dynamo
+// refreshes in the destination Pod.
+func ComputeSnapshotCompatibilityHash(
+	podTemplate *corev1.PodTemplateSpec,
+	targetContainerName string,
+	backendFramework string,
+	gmsMode string,
+) (string, error) {
+	if podTemplate == nil {
+		return "", fmt.Errorf("snapshot compatibility pod template is required")
+	}
+	if targetContainerName == "" {
+		return "", fmt.Errorf("snapshot compatibility target container is required")
+	}
+
+	var target *corev1.Container
+	for i := range podTemplate.Spec.Containers {
+		if podTemplate.Spec.Containers[i].Name == targetContainerName {
+			target = podTemplate.Spec.Containers[i].DeepCopy()
+			break
+		}
+	}
+	if target == nil {
+		return "", fmt.Errorf("snapshot compatibility target container %q not found", targetContainerName)
+	}
+
+	contract := snapshotCompatibilityContract{
+		Version:               consts.SnapshotCompatibilityVersion,
+		BackendFramework:      backendFramework,
+		GMSMode:               gmsMode,
+		TargetContainer:       canonicalSnapshotContainer(*target, false),
+		HostNetwork:           podTemplate.Spec.HostNetwork,
+		HostPID:               podTemplate.Spec.HostPID,
+		HostIPC:               podTemplate.Spec.HostIPC,
+		ShareProcessNamespace: podTemplate.Spec.ShareProcessNamespace,
+		SecurityContext:       podTemplate.Spec.SecurityContext,
+		RuntimeClassName:      podTemplate.Spec.RuntimeClassName,
+	}
+	for _, container := range podTemplate.Spec.InitContainers {
+		contract.InitContainers = append(contract.InitContainers, canonicalSnapshotContainer(container, true))
+	}
+	contract.Volumes = snapshotCompatibilityVolumes(&podTemplate.Spec, target)
+	sort.Slice(contract.Volumes, func(i, j int) bool { return contract.Volumes[i].Name < contract.Volumes[j].Name })
+
+	data, err := json.Marshal(contract)
+	if err != nil {
+		return "", fmt.Errorf("marshal snapshot compatibility contract: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func snapshotCompatibilityVolumes(podSpec *corev1.PodSpec, target *corev1.Container) []corev1.Volume {
+	referenced := make(map[string]struct{})
+	addContainerVolumes := func(container *corev1.Container) {
+		for _, mount := range container.VolumeMounts {
+			referenced[mount.Name] = struct{}{}
+		}
+		for _, device := range container.VolumeDevices {
+			referenced[device.Name] = struct{}{}
+		}
+	}
+	addContainerVolumes(target)
+	for i := range podSpec.InitContainers {
+		addContainerVolumes(&podSpec.InitContainers[i])
+	}
+
+	volumes := make([]corev1.Volume, 0, len(referenced))
+	for _, volume := range podSpec.Volumes {
+		if _, used := referenced[volume.Name]; used {
+			volumes = append(volumes, *volume.DeepCopy())
+		}
+	}
+	return volumes
+}
+
+func canonicalSnapshotContainer(container corev1.Container, keepName bool) corev1.Container {
+	container = *container.DeepCopy()
+	if !keepName {
+		container.Name = ""
+	}
+
+	env := container.Env[:0]
+	for _, variable := range container.Env {
+		if _, restored := snapshotRestoreEnvironmentNames[variable.Name]; !restored {
+			env = append(env, variable)
+		}
+	}
+	container.Env = env
+	sort.SliceStable(container.Env, func(i, j int) bool { return container.Env[i].Name < container.Env[j].Name })
+	sort.SliceStable(container.VolumeMounts, func(i, j int) bool {
+		if container.VolumeMounts[i].MountPath != container.VolumeMounts[j].MountPath {
+			return container.VolumeMounts[i].MountPath < container.VolumeMounts[j].MountPath
+		}
+		return container.VolumeMounts[i].Name < container.VolumeMounts[j].Name
+	})
+	sort.SliceStable(container.VolumeDevices, func(i, j int) bool {
+		if container.VolumeDevices[i].DevicePath != container.VolumeDevices[j].DevicePath {
+			return container.VolumeDevices[i].DevicePath < container.VolumeDevices[j].DevicePath
+		}
+		return container.VolumeDevices[i].Name < container.VolumeDevices[j].Name
+	})
+
+	// Health and termination policy affect Kubernetes lifecycle, not whether a
+	// captured process image can resume in this container.
+	container.ImagePullPolicy = ""
+	container.Lifecycle = nil
+	container.LivenessProbe = nil
+	container.ReadinessProbe = nil
+	container.StartupProbe = nil
+	container.Ports = nil
+	container.TerminationMessagePath = ""
+	container.TerminationMessagePolicy = ""
+	container.ResizePolicy = nil
+	container.Stdin = false
+	container.StdinOnce = false
+	container.TTY = false
+	return container
 }

--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -88,6 +88,7 @@ type snapshotCompatibilityContract struct {
 	Version               string                     `json:"version"`
 	BackendFramework      string                     `json:"backendFramework"`
 	GMSMode               string                     `json:"gmsMode"`
+	GMSDeviceClassName    string                     `json:"gmsDeviceClassName,omitempty"`
 	TargetContainer       corev1.Container           `json:"targetContainer"`
 	InitContainers        []corev1.Container         `json:"initContainers,omitempty"`
 	Volumes               []corev1.Volume            `json:"volumes,omitempty"`
@@ -113,6 +114,7 @@ func ComputeSnapshotCompatibilityHash(
 	targetContainerName string,
 	backendFramework string,
 	gmsMode string,
+	gmsDeviceClassName string,
 ) (string, error) {
 	if podTemplate == nil {
 		return "", fmt.Errorf("snapshot compatibility pod template is required")
@@ -136,6 +138,7 @@ func ComputeSnapshotCompatibilityHash(
 		Version:               consts.SnapshotCompatibilityVersion,
 		BackendFramework:      backendFramework,
 		GMSMode:               gmsMode,
+		GMSDeviceClassName:    gmsDeviceClassName,
 		TargetContainer:       canonicalSnapshotContainer(*target, false),
 		HostNetwork:           podTemplate.Spec.HostNetwork,
 		HostPID:               podTemplate.Spec.HostPID,

--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -224,7 +224,6 @@ func canonicalSnapshotContainer(container corev1.Container, keepName bool) corev
 
 	// Health and termination policy affect Kubernetes lifecycle, not whether a
 	// captured process image can resume in this container.
-	container.ImagePullPolicy = ""
 	container.Lifecycle = nil
 	container.LivenessProbe = nil
 	container.ReadinessProbe = nil

--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -43,10 +43,11 @@ func ValidateCheckpointCompatibility(experimental *nvidiacomv1beta1.Experimental
 	return violations
 }
 
-// snapshotRestoreEnvironmentNames must match the environment restored by
-// components/src/dynamo/common/snapshot/restore_context.py. Those values name
-// the destination Pod and runtime, so they are intentionally not part of a
-// portable snapshot's compatibility identity.
+// snapshotRestoreEnvironmentNames must match KUBERNETES_REQUIRED_ENV_NAMES,
+// KUBERNETES_OPTIONAL_ENV_NAMES, and RESTORE_RUNTIME_ENV_NAMES in
+// components/src/dynamo/common/snapshot/constants.py. Those values name the
+// destination Pod and runtime, so they are intentionally not part of a portable
+// snapshot's compatibility identity.
 var snapshotRestoreEnvironmentNames = map[string]struct{}{
 	"CONTAINER_NAME":                        {},
 	"DYN_COMPONENT":                         {},
@@ -96,6 +97,11 @@ type snapshotCompatibilityContract struct {
 	ShareProcessNamespace *bool                      `json:"shareProcessNamespace,omitempty"`
 	SecurityContext       *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	RuntimeClassName      *string                    `json:"runtimeClassName,omitempty"`
+	NodeName              string                     `json:"nodeName,omitempty"`
+	NodeSelector          map[string]string          `json:"nodeSelector,omitempty"`
+	NodeAffinity          *corev1.NodeAffinity       `json:"nodeAffinity,omitempty"`
+	SchedulerName         string                     `json:"schedulerName,omitempty"`
+	ResourceClaims        []corev1.PodResourceClaim  `json:"resourceClaims,omitempty"`
 }
 
 // ComputeSnapshotCompatibilityHash returns the portable v1 compatibility
@@ -137,7 +143,18 @@ func ComputeSnapshotCompatibilityHash(
 		ShareProcessNamespace: podTemplate.Spec.ShareProcessNamespace,
 		SecurityContext:       podTemplate.Spec.SecurityContext,
 		RuntimeClassName:      podTemplate.Spec.RuntimeClassName,
+		NodeName:              podTemplate.Spec.NodeName,
+		NodeSelector:          podTemplate.Spec.NodeSelector,
+		SchedulerName:         podTemplate.Spec.SchedulerName,
+		ResourceClaims:        podTemplate.Spec.ResourceClaims,
 	}
+	if podTemplate.Spec.Affinity != nil {
+		contract.NodeAffinity = podTemplate.Spec.Affinity.NodeAffinity
+	}
+	contract.ResourceClaims = append([]corev1.PodResourceClaim(nil), contract.ResourceClaims...)
+	sort.Slice(contract.ResourceClaims, func(i, j int) bool {
+		return contract.ResourceClaims[i].Name < contract.ResourceClaims[j].Name
+	})
 	for _, container := range podTemplate.Spec.InitContainers {
 		contract.InitContainers = append(contract.InitContainers, canonicalSnapshotContainer(container, true))
 	}
@@ -182,14 +199,13 @@ func canonicalSnapshotContainer(container corev1.Container, keepName bool) corev
 		container.Name = ""
 	}
 
-	env := container.Env[:0]
+	env := make([]corev1.EnvVar, 0, len(container.Env))
 	for _, variable := range container.Env {
 		if _, restored := snapshotRestoreEnvironmentNames[variable.Name]; !restored {
 			env = append(env, variable)
 		}
 	}
 	container.Env = env
-	sort.SliceStable(container.Env, func(i, j int) bool { return container.Env[i].Name < container.Env[j].Name })
 	sort.SliceStable(container.VolumeMounts, func(i, j int) bool {
 		if container.VolumeMounts[i].MountPath != container.VolumeMounts[j].MountPath {
 			return container.VolumeMounts[i].MountPath < container.VolumeMounts[j].MountPath

--- a/deploy/operator/internal/checkpoint/compatibility.go
+++ b/deploy/operator/internal/checkpoint/compatibility.go
@@ -98,14 +98,16 @@ type snapshotCompatibilityContract struct {
 	ShareProcessNamespace *bool                      `json:"shareProcessNamespace,omitempty"`
 	SecurityContext       *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	RuntimeClassName      *string                    `json:"runtimeClassName,omitempty"`
-	NodeName              string                     `json:"nodeName,omitempty"`
-	NodeSelector          map[string]string          `json:"nodeSelector,omitempty"`
-	NodeAffinity          *corev1.NodeAffinity       `json:"nodeAffinity,omitempty"`
-	SchedulerName         string                     `json:"schedulerName,omitempty"`
-	ResourceClaims        []corev1.PodResourceClaim  `json:"resourceClaims,omitempty"`
+	// NodeName records only an explicit pod-template pin. The scheduler-assigned
+	// node is not present in a PodTemplateSpec and therefore is never hashed.
+	NodeName       string                    `json:"nodeName,omitempty"`
+	NodeSelector   map[string]string         `json:"nodeSelector,omitempty"`
+	NodeAffinity   *corev1.NodeAffinity      `json:"nodeAffinity,omitempty"`
+	SchedulerName  string                    `json:"schedulerName,omitempty"`
+	ResourceClaims []corev1.PodResourceClaim `json:"resourceClaims,omitempty"`
 }
 
-// ComputeSnapshotCompatibilityHash returns the portable v1 compatibility
+// ComputeSnapshotCompatibilityHash returns the portable v2 compatibility
 // identity for one captured process. It deliberately excludes rollout and
 // graph-incarnation identity, along with restore-time environment that Dynamo
 // refreshes in the destination Pod.
@@ -220,6 +222,12 @@ func canonicalSnapshotContainer(container corev1.Container, keepName bool) corev
 			return container.VolumeDevices[i].DevicePath < container.VolumeDevices[j].DevicePath
 		}
 		return container.VolumeDevices[i].Name < container.VolumeDevices[j].Name
+	})
+	sort.SliceStable(container.Resources.Claims, func(i, j int) bool {
+		if container.Resources.Claims[i].Name != container.Resources.Claims[j].Name {
+			return container.Resources.Claims[i].Name < container.Resources.Claims[j].Name
+		}
+		return container.Resources.Claims[i].Request < container.Resources.Claims[j].Request
 	})
 
 	// Health and termination policy affect Kubernetes lifecycle, not whether a

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateCheckpointCompatibility(t *testing.T) {
@@ -71,6 +73,119 @@ func TestValidateCheckpointCompatibility(t *testing.T) {
 			assert.Equal(t, test.wantErrs, gotErrs)
 		})
 	}
+}
+
+func TestComputeSnapshotCompatibilityHashV2KnownAnswer(t *testing.T) {
+	t.Log("Build a representative v2 contract fixture")
+	claimName := "gpu-claim"
+	template := corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:            "main",
+			Image:           "registry.example/worker@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"python3", "-m", "dynamo.vllm"},
+			Args:            []string{"--model", "/models/model", "--tensor-parallel-size", "1"},
+			WorkingDir:      "/workspace",
+			Env: []corev1.EnvVar{
+				{Name: "MODEL_ROOT", Value: "/models"},
+				{Name: "MODEL_PATH", Value: "$(MODEL_ROOT)/model"},
+				{Name: "DYN_NAMESPACE", Value: "capture-runtime"},
+			},
+			EnvFrom: []corev1.EnvFromSource{{
+				Prefix: "WORKER_",
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "worker-config"},
+				},
+			}},
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					corev1.ResourceMemory:                 resource.MustParse("64Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					corev1.ResourceMemory:                 resource.MustParse("32Gi"),
+				},
+				Claims: []corev1.ResourceClaim{{Name: "accelerator", Request: "gpu"}},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "models", MountPath: "/models", ReadOnly: true},
+				{Name: "config", MountPath: "/etc/worker", ReadOnly: true},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsNonRoot:             ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+			},
+		}},
+		InitContainers: []corev1.Container{{
+			Name:            "prepare",
+			Image:           "registry.example/prepare@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/bin/sh", "-c"},
+			Args:            []string{"cp /input/config.yaml /output/config.yaml"},
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "config", MountPath: "/input", ReadOnly: true},
+				{Name: "models", MountPath: "/output"},
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "models",
+				VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "model-cache",
+					ReadOnly:  true,
+				}},
+			},
+			{
+				Name: "config",
+				VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "worker-config"},
+				}},
+			},
+		},
+		HostNetwork:           true,
+		HostPID:               true,
+		ShareProcessNamespace: ptr.To(true),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsNonRoot: ptr.To(true),
+			FSGroup:      ptr.To[int64](1000),
+		},
+		RuntimeClassName: ptr.To("nvidia"),
+		NodeName:         "gpu-node-07",
+		NodeSelector: map[string]string{
+			"kubernetes.io/arch":     "amd64",
+			"nvidia.com/gpu.product": "H100",
+		},
+		Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key:      "nvidia.com/gpu.memory",
+						Operator: corev1.NodeSelectorOpGt,
+						Values:   []string{"70000"},
+					}},
+				}},
+			},
+		}},
+		SchedulerName: "gpu-scheduler",
+		ResourceClaims: []corev1.PodResourceClaim{{
+			Name:              "accelerator",
+			ResourceClaimName: &claimName,
+		}},
+	}}
+
+	t.Log("Hash the fixture with the persisted protocol inputs")
+	got, err := ComputeSnapshotCompatibilityHash(
+		&template,
+		"main",
+		"vllm",
+		"IntraPod",
+		"gpu.nvidia.com/h100",
+	)
+	require.NoError(t, err)
+
+	t.Log("Require an explicit fixture update when the v2 wire contract changes")
+	assert.Equal(t, "bdd84a0ec0b3c59217f168356fd65f64507e30de28e7d4fe2eda7290dd9f80f1", got)
 }
 
 func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -117,6 +117,14 @@ func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testin
 			gmsMode: "disabled",
 		},
 		{
+			name: "image pull policy",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
 			name: "engine arguments",
 			mutate: func(template *corev1.PodTemplateSpec) {
 				template.Spec.Containers[0].Args = append(template.Spec.Containers[0].Args, "--tensor-parallel-size=2")

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -10,6 +10,8 @@ import (
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestValidateCheckpointCompatibility(t *testing.T) {
@@ -55,14 +57,117 @@ func TestValidateCheckpointCompatibility(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			violations := ValidateCheckpointCompatibility(tt.experimental)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			violations := ValidateCheckpointCompatibility(test.experimental)
 			var gotErrs []string
 			for _, violation := range violations {
 				gotErrs = append(gotErrs, violation.Error())
 			}
-			assert.Equal(t, tt.wantErrs, gotErrs)
+			assert.Equal(t, test.wantErrs, gotErrs)
 		})
+	}
+}
+
+func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testing.T) {
+	t.Log("Given equivalent capture targets rendered for two different DGD identities")
+	first := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
+	second := snapshotCompatibilityTestPodTemplate("restore-dgd", "restore-ns", "worker-b")
+	first.Spec.Volumes = append(first.Spec.Volumes, corev1.Volume{Name: "helper-only"})
+	first.Spec.Containers = append(first.Spec.Containers, corev1.Container{
+		Name:         "checkpoint-helper",
+		Image:        "helper:latest",
+		VolumeMounts: []corev1.VolumeMount{{Name: "helper-only", MountPath: "/helper"}},
+	})
+
+	t.Log("When their snapshot compatibility hashes are computed")
+	firstHash, err := ComputeSnapshotCompatibilityHash(&first, "main", "vllm", "disabled")
+	require.NoError(t, err)
+	secondHash, err := ComputeSnapshotCompatibilityHash(&second, "main", "vllm", "disabled")
+	require.NoError(t, err)
+
+	t.Log("Then graph, Pod, worker-generation, and helper-sidecar identity do not make the artifact incompatible")
+	assert.Equal(t, firstHash, secondHash)
+	assert.Len(t, firstHash, 64)
+}
+
+func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testing.T) {
+	base := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
+	baseHash, err := ComputeSnapshotCompatibilityHash(&base, "main", "vllm", "disabled")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		mutate  func(*corev1.PodTemplateSpec)
+		backend string
+		gmsMode string
+	}{
+		{
+			name: "image",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.Containers[0].Image = "worker:2.0"
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
+			name: "engine arguments",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.Containers[0].Args = append(template.Spec.Containers[0].Args, "--tensor-parallel-size=2")
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
+			name: "model environment",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.Containers[0].Env = append(template.Spec.Containers[0].Env, corev1.EnvVar{Name: "MODEL_PATH", Value: "/models/other"})
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
+			name:    "backend",
+			mutate:  func(*corev1.PodTemplateSpec) {},
+			backend: "sglang",
+			gmsMode: "disabled",
+		},
+		{
+			name:    "GMS topology",
+			mutate:  func(*corev1.PodTemplateSpec) {},
+			backend: "vllm",
+			gmsMode: "IntraPod",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := base.DeepCopy()
+			test.mutate(changed)
+			changedHash, err := ComputeSnapshotCompatibilityHash(changed, "main", test.backend, test.gmsMode)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseHash, changedHash)
+		})
+	}
+}
+
+func snapshotCompatibilityTestPodTemplate(dgdName, namespace, workerSuffix string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "main",
+				Image:   "worker:1.0",
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args:    []string{"--model", "/models/model"},
+				Env: []corev1.EnvVar{
+					{Name: "MODEL_PATH", Value: "/models/model"},
+					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: dgdName},
+					{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: namespace},
+					{Name: "DYN_NAMESPACE", Value: namespace + "-runtime"},
+					{Name: "DYN_NAMESPACE_WORKER_SUFFIX", Value: workerSuffix},
+					{Name: "POD_NAME", Value: dgdName + "-pod"},
+				},
+			}},
+		},
 	}
 }

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -79,6 +79,14 @@ func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testin
 	second := snapshotCompatibilityTestPodTemplate("restore-dgd", "restore-ns", "worker-b")
 	first.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "network"}, {Name: "accelerator"}}
 	second.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "accelerator"}, {Name: "network"}}
+	first.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+		{Name: "network", Request: "interface"},
+		{Name: "accelerator", Request: "gpu"},
+	}
+	second.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+		{Name: "accelerator", Request: "gpu"},
+		{Name: "network", Request: "interface"},
+	}
 	first.Spec.Volumes = append(first.Spec.Volumes, corev1.Volume{Name: "helper-only"})
 	first.Spec.Containers = append(first.Spec.Containers, corev1.Container{
 		Name:         "checkpoint-helper",

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -218,6 +218,9 @@ func TestSnapshotRestoreEnvironmentNamesMatchPythonRuntime(t *testing.T) {
 		"../../../../components/src/dynamo/common/snapshot/constants.py",
 	)
 	contents, err := os.ReadFile(constantsPath)
+	if os.IsNotExist(err) && os.Getenv("DYNAMO_REQUIRE_SNAPSHOT_ENV_PARITY") == "" {
+		t.Skip("Python snapshot constants are not present in the operator-only build context")
+	}
 	require.NoError(t, err)
 
 	pythonNames := map[string]struct{}{}

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -87,9 +87,9 @@ func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testin
 	})
 
 	t.Log("When their snapshot compatibility hashes are computed")
-	firstHash, err := ComputeSnapshotCompatibilityHash(&first, "main", "vllm", "disabled")
+	firstHash, err := ComputeSnapshotCompatibilityHash(&first, "main", "vllm", "disabled", "")
 	require.NoError(t, err)
-	secondHash, err := ComputeSnapshotCompatibilityHash(&second, "main", "vllm", "disabled")
+	secondHash, err := ComputeSnapshotCompatibilityHash(&second, "main", "vllm", "disabled", "")
 	require.NoError(t, err)
 
 	t.Log("Then graph, Pod, worker-generation, and helper-sidecar identity do not make the artifact incompatible")
@@ -99,7 +99,7 @@ func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testin
 
 func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testing.T) {
 	base := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
-	baseHash, err := ComputeSnapshotCompatibilityHash(&base, "main", "vllm", "disabled")
+	baseHash, err := ComputeSnapshotCompatibilityHash(&base, "main", "vllm", "disabled", "")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -183,11 +183,33 @@ func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testin
 		t.Run(test.name, func(t *testing.T) {
 			changed := base.DeepCopy()
 			test.mutate(changed)
-			changedHash, err := ComputeSnapshotCompatibilityHash(changed, "main", test.backend, test.gmsMode)
+			changedHash, err := ComputeSnapshotCompatibilityHash(changed, "main", test.backend, test.gmsMode, "")
 			require.NoError(t, err)
 			assert.NotEqual(t, baseHash, changedHash)
 		})
 	}
+}
+
+func TestComputeSnapshotCompatibilityHashRejectsGMSDeviceClassChanges(t *testing.T) {
+	template := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
+	defaultClassHash, err := ComputeSnapshotCompatibilityHash(
+		&template,
+		"main",
+		"vllm",
+		"IntraPod",
+		"gpu.nvidia.com",
+	)
+	require.NoError(t, err)
+	h100ClassHash, err := ComputeSnapshotCompatibilityHash(
+		&template,
+		"main",
+		"vllm",
+		"IntraPod",
+		"gpu.nvidia.com/h100",
+	)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, defaultClassHash, h100ClassHash)
 }
 
 func TestComputeSnapshotCompatibilityHashPreservesEnvironmentOrder(t *testing.T) {
@@ -201,9 +223,9 @@ func TestComputeSnapshotCompatibilityHashPreservesEnvironmentOrder(t *testing.T)
 	reordered.Spec.Containers[0].Env[0], reordered.Spec.Containers[0].Env[1] =
 		reordered.Spec.Containers[0].Env[1], reordered.Spec.Containers[0].Env[0]
 
-	orderedHash, err := ComputeSnapshotCompatibilityHash(&ordered, "main", "vllm", "disabled")
+	orderedHash, err := ComputeSnapshotCompatibilityHash(&ordered, "main", "vllm", "disabled", "")
 	require.NoError(t, err)
-	reorderedHash, err := ComputeSnapshotCompatibilityHash(reordered, "main", "vllm", "disabled")
+	reorderedHash, err := ComputeSnapshotCompatibilityHash(reordered, "main", "vllm", "disabled", "")
 	require.NoError(t, err)
 
 	assert.NotEqual(t, orderedHash, reorderedHash,

--- a/deploy/operator/internal/checkpoint/compatibility_test.go
+++ b/deploy/operator/internal/checkpoint/compatibility_test.go
@@ -6,6 +6,10 @@
 package checkpoint
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"testing"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
@@ -73,6 +77,8 @@ func TestComputeSnapshotCompatibilityHashIsPortableAcrossGraphIdentity(t *testin
 	t.Log("Given equivalent capture targets rendered for two different DGD identities")
 	first := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
 	second := snapshotCompatibilityTestPodTemplate("restore-dgd", "restore-ns", "worker-b")
+	first.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "network"}, {Name: "accelerator"}}
+	second.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "accelerator"}, {Name: "network"}}
 	first.Spec.Volumes = append(first.Spec.Volumes, corev1.Volume{Name: "helper-only"})
 	first.Spec.Containers = append(first.Spec.Containers, corev1.Container{
 		Name:         "checkpoint-helper",
@@ -127,6 +133,39 @@ func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testin
 			gmsMode: "disabled",
 		},
 		{
+			name: "GPU node selector",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.NodeSelector = map[string]string{"nvidia.com/gpu.product": "H100"}
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
+			name: "DRA resource claim",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.ResourceClaims = []corev1.PodResourceClaim{{Name: "accelerator"}}
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
+			name: "PVC claim identity",
+			mutate: func(template *corev1.PodTemplateSpec) {
+				template.Spec.Containers[0].VolumeMounts = append(
+					template.Spec.Containers[0].VolumeMounts,
+					corev1.VolumeMount{Name: "model-cache", MountPath: "/models"},
+				)
+				template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
+					Name: "model-cache",
+					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "capture-dgd-model-cache",
+					}},
+				})
+			},
+			backend: "vllm",
+			gmsMode: "disabled",
+		},
+		{
 			name:    "backend",
 			mutate:  func(*corev1.PodTemplateSpec) {},
 			backend: "sglang",
@@ -149,6 +188,55 @@ func TestComputeSnapshotCompatibilityHashRejectsProcessContractChanges(t *testin
 			assert.NotEqual(t, baseHash, changedHash)
 		})
 	}
+}
+
+func TestComputeSnapshotCompatibilityHashPreservesEnvironmentOrder(t *testing.T) {
+	ordered := snapshotCompatibilityTestPodTemplate("capture-dgd", "capture-ns", "worker-a")
+	ordered.Spec.Containers[0].Env = []corev1.EnvVar{
+		{Name: "MODEL_ROOT", Value: "/models"},
+		{Name: "MODEL_PATH", Value: "$(MODEL_ROOT)/model"},
+		{Name: "DYN_NAMESPACE", Value: "capture-runtime"},
+	}
+	reordered := ordered.DeepCopy()
+	reordered.Spec.Containers[0].Env[0], reordered.Spec.Containers[0].Env[1] =
+		reordered.Spec.Containers[0].Env[1], reordered.Spec.Containers[0].Env[0]
+
+	orderedHash, err := ComputeSnapshotCompatibilityHash(&ordered, "main", "vllm", "disabled")
+	require.NoError(t, err)
+	reorderedHash, err := ComputeSnapshotCompatibilityHash(reordered, "main", "vllm", "disabled")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, orderedHash, reorderedHash,
+		"Kubernetes expands $(VAR_NAME) from earlier entries, so environment order is part of the process contract")
+}
+
+func TestSnapshotRestoreEnvironmentNamesMatchPythonRuntime(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	constantsPath := filepath.Join(
+		filepath.Dir(thisFile),
+		"../../../../components/src/dynamo/common/snapshot/constants.py",
+	)
+	contents, err := os.ReadFile(constantsPath)
+	require.NoError(t, err)
+
+	pythonNames := map[string]struct{}{}
+	quotedName := regexp.MustCompile(`"([A-Z][A-Z0-9_]*)"`)
+	for _, variable := range []string{
+		"KUBERNETES_REQUIRED_ENV_NAMES",
+		"KUBERNETES_OPTIONAL_ENV_NAMES",
+		"RESTORE_RUNTIME_ENV_NAMES",
+	} {
+		assignment := regexp.MustCompile(`(?ms)^` + regexp.QuoteMeta(variable) + `\s*=\s*\{(.*?)\}`)
+		match := assignment.FindSubmatch(contents)
+		require.Len(t, match, 2, "find Python assignment for %s", variable)
+		for _, name := range quotedName.FindAllSubmatch(match[1], -1) {
+			pythonNames[string(name[1])] = struct{}{}
+		}
+	}
+
+	assert.Equal(t, pythonNames, snapshotRestoreEnvironmentNames,
+		"Go compatibility filtering must track the Python restore-context allowlist")
 }
 
 func snapshotCompatibilityTestPodTemplate(dgdName, namespace, workerSuffix string) corev1.PodTemplateSpec {

--- a/deploy/operator/internal/checkpoint/hash.go
+++ b/deploy/operator/internal/checkpoint/hash.go
@@ -26,15 +26,17 @@ import (
 // DGDCheckpointID returns the snapshot artifact ID for an automatic DGD-owned
 // checkpoint. The DGD UID prevents cross-DGD reuse; the component name and
 // worker hash/generation prevent reuse across incompatible worker generations
-// inside the same DGD. The compatibility version forces a fresh immutable
-// SnapshotJob when the persisted snapshot contract changes.
-func DGDCheckpointID(namespace, dgdName, dgdUID, componentName, workerHash, compatibilityVersion string) string {
+// inside the same DGD. The compatibility hash prevents reuse when rendered
+// capture inputs outside the worker hash change, while the version forces a
+// fresh immutable SnapshotJob when the persisted contract format changes.
+func DGDCheckpointID(namespace, dgdName, dgdUID, componentName, workerHash, compatibilityHash, compatibilityVersion string) string {
 	data, _ := json.Marshal(struct {
 		Namespace            string `json:"namespace,omitempty"`
 		DGDName              string `json:"dgdName"`
 		DGDUID               string `json:"dgdUID,omitempty"`
 		ComponentName        string `json:"componentName"`
 		WorkerHash           string `json:"workerHash,omitempty"`
+		CompatibilityHash    string `json:"compatibilityHash,omitempty"`
 		CompatibilityVersion string `json:"compatibilityVersion,omitempty"`
 	}{
 		Namespace:            namespace,
@@ -42,6 +44,7 @@ func DGDCheckpointID(namespace, dgdName, dgdUID, componentName, workerHash, comp
 		DGDUID:               dgdUID,
 		ComponentName:        componentName,
 		WorkerHash:           workerHash,
+		CompatibilityHash:    compatibilityHash,
 		CompatibilityVersion: compatibilityVersion,
 	})
 	hash := sha256.Sum256(data)

--- a/deploy/operator/internal/checkpoint/hash.go
+++ b/deploy/operator/internal/checkpoint/hash.go
@@ -26,20 +26,23 @@ import (
 // DGDCheckpointID returns the snapshot artifact ID for an automatic DGD-owned
 // checkpoint. The DGD UID prevents cross-DGD reuse; the component name and
 // worker hash/generation prevent reuse across incompatible worker generations
-// inside the same DGD.
-func DGDCheckpointID(namespace, dgdName, dgdUID, componentName, workerHash string) string {
+// inside the same DGD. The compatibility version forces a fresh immutable
+// SnapshotJob when the persisted snapshot contract changes.
+func DGDCheckpointID(namespace, dgdName, dgdUID, componentName, workerHash, compatibilityVersion string) string {
 	data, _ := json.Marshal(struct {
-		Namespace     string `json:"namespace,omitempty"`
-		DGDName       string `json:"dgdName"`
-		DGDUID        string `json:"dgdUID,omitempty"`
-		ComponentName string `json:"componentName"`
-		WorkerHash    string `json:"workerHash,omitempty"`
+		Namespace            string `json:"namespace,omitempty"`
+		DGDName              string `json:"dgdName"`
+		DGDUID               string `json:"dgdUID,omitempty"`
+		ComponentName        string `json:"componentName"`
+		WorkerHash           string `json:"workerHash,omitempty"`
+		CompatibilityVersion string `json:"compatibilityVersion,omitempty"`
 	}{
-		Namespace:     namespace,
-		DGDName:       dgdName,
-		DGDUID:        dgdUID,
-		ComponentName: componentName,
-		WorkerHash:    workerHash,
+		Namespace:            namespace,
+		DGDName:              dgdName,
+		DGDUID:               dgdUID,
+		ComponentName:        componentName,
+		WorkerHash:           workerHash,
+		CompatibilityVersion: compatibilityVersion,
 	})
 	hash := sha256.Sum256(data)
 	return hex.EncodeToString(hash[:])[:32]

--- a/deploy/operator/internal/checkpoint/hash_test.go
+++ b/deploy/operator/internal/checkpoint/hash_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func TestDGDCheckpointID(t *testing.T) {
-	id := DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v2")
+	id := DGDCheckpointID("ns", "dgd", "uid-1", "worker", "worker-hash-1", "compatibility-hash-1", "v2")
 	assert.Regexp(t, "^[0-9a-f]{32}$", id)
-	assert.Equal(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v2"))
+	assert.Equal(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "worker-hash-1", "compatibility-hash-1", "v2"))
 
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-2", "worker", "hash-1", "v2"), "DGD UID must prevent cross-DGD reuse")
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-2", "v2"), "worker hash must isolate worker generations")
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "prefill", "hash-1", "v2"), "component name must isolate components")
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v1"), "compatibility version must isolate contract generations")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-2", "worker", "worker-hash-1", "compatibility-hash-1", "v2"), "DGD UID must prevent cross-DGD reuse")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "worker-hash-2", "compatibility-hash-1", "v2"), "worker hash must isolate worker generations")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "worker-hash-1", "compatibility-hash-2", "v2"), "compatibility hash must isolate rendered capture contracts")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "prefill", "worker-hash-1", "compatibility-hash-1", "v2"), "component name must isolate components")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "worker-hash-1", "compatibility-hash-1", "v1"), "compatibility version must isolate contract generations")
 }

--- a/deploy/operator/internal/checkpoint/hash_test.go
+++ b/deploy/operator/internal/checkpoint/hash_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 func TestDGDCheckpointID(t *testing.T) {
-	id := DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1")
+	id := DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v2")
 	assert.Regexp(t, "^[0-9a-f]{32}$", id)
-	assert.Equal(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1"))
+	assert.Equal(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v2"))
 
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-2", "worker", "hash-1"), "DGD UID must prevent cross-DGD reuse")
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-2"), "worker hash must isolate worker generations")
-	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "prefill", "hash-1"), "component name must isolate components")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-2", "worker", "hash-1", "v2"), "DGD UID must prevent cross-DGD reuse")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-2", "v2"), "worker hash must isolate worker generations")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "prefill", "hash-1", "v2"), "component name must isolate components")
+	assert.NotEqual(t, id, DGDCheckpointID("ns", "dgd", "uid-1", "worker", "hash-1", "v1"), "compatibility version must isolate contract generations")
 }

--- a/deploy/operator/internal/checkpoint/native.go
+++ b/deploy/operator/internal/checkpoint/native.go
@@ -157,7 +157,7 @@ func ResolvePodSnapshotForService(
 	compatibilityHash := annotations[consts.SnapshotCompatibilityHashAnnotation]
 	if compatibilityHash != expectedCompatibilityHash {
 		return nil, fmt.Errorf(
-			"referenced PodSnapshot %s/%s compatibility hash %q does not match expected hash %q",
+			"referenced PodSnapshot %s/%s compatibility hash %q does not match expected hash %q; compare the target image, command and args, non-restored environment, init containers, mounted volumes (including PVC claim names), accelerator placement and claims, Pod security/runtime settings, backend, and GMS mode",
 			namespace,
 			snapshotName,
 			compatibilityHash,

--- a/deploy/operator/internal/checkpoint/native.go
+++ b/deploy/operator/internal/checkpoint/native.go
@@ -157,7 +157,7 @@ func ResolvePodSnapshotForService(
 	compatibilityHash := annotations[consts.SnapshotCompatibilityHashAnnotation]
 	if compatibilityHash != expectedCompatibilityHash {
 		return nil, fmt.Errorf(
-			"referenced PodSnapshot %s/%s compatibility hash %q does not match expected hash %q; compare the target image, command and args, non-restored environment, init containers, mounted volumes (including PVC claim names), accelerator placement and claims, Pod security/runtime settings, backend, and GMS mode",
+			"referenced PodSnapshot %s/%s compatibility hash %q does not match expected hash %q; compare the target image, command and args, non-restored environment, init containers, mounted volumes (including PVC claim names), accelerator placement and claims, Pod security/runtime settings, backend, and GMS mode/device class",
 			namespace,
 			snapshotName,
 			compatibilityHash,

--- a/deploy/operator/internal/checkpoint/native.go
+++ b/deploy/operator/internal/checkpoint/native.go
@@ -24,7 +24,6 @@ type ResolvedPodSnapshot struct {
 	BoundContentName     string
 	SourceContainer      string
 	CompatibilityVersion string
-	CompatibilityHash    string
 	GMSMode              string
 }
 
@@ -198,7 +197,6 @@ func ResolvePodSnapshotForService(
 			BoundContentName:     contentName,
 			SourceContainer:      containers[0],
 			CompatibilityVersion: version,
-			CompatibilityHash:    compatibilityHash,
 			GMSMode:              gmsMode,
 		},
 	}

--- a/deploy/operator/internal/checkpoint/native.go
+++ b/deploy/operator/internal/checkpoint/native.go
@@ -24,6 +24,7 @@ type ResolvedPodSnapshot struct {
 	BoundContentName     string
 	SourceContainer      string
 	CompatibilityVersion string
+	CompatibilityHash    string
 	GMSMode              string
 }
 
@@ -62,14 +63,14 @@ func ManagedPodSnapshotUse(ownerUID types.UID) PodSnapshotUse {
 // but not-yet-ready snapshot is returned with Ready=false so callers can gate
 // workloads while retaining an admission-time reference to the same object.
 // A nil config means checkpointing is disabled. Reader must be non-nil when
-// checkpointing is enabled. A nil expectedWorkerHash means the target is not a
-// worker-class component; a non-nil value must contain its generation hash.
+// checkpointing is enabled. expectedCompatibilityHash must contain the
+// independently rendered compatibility identity for the restore target.
 func ResolvePodSnapshotForService(
 	ctx context.Context,
 	reader client.Reader,
 	namespace string,
 	config *nvidiacomv1alpha1.ServiceCheckpointConfig,
-	expectedWorkerHash *string,
+	expectedCompatibilityHash string,
 	use PodSnapshotUse,
 ) (*CheckpointInfo, error) {
 	if config == nil || !config.Enabled {
@@ -81,8 +82,8 @@ func ResolvePodSnapshotForService(
 	if config.CheckpointRef == nil || strings.TrimSpace(*config.CheckpointRef) == "" {
 		return nil, fmt.Errorf("checkpointRef is required for native PodSnapshot restore")
 	}
-	if expectedWorkerHash != nil && *expectedWorkerHash == "" {
-		return nil, fmt.Errorf("worker compatibility hash is required for native PodSnapshot restore")
+	if expectedCompatibilityHash == "" {
+		return nil, fmt.Errorf("snapshot compatibility hash is required for native PodSnapshot restore")
 	}
 
 	// Read the referenced standalone Snapshot object directly.
@@ -153,14 +154,14 @@ func ResolvePodSnapshotForService(
 			version,
 		)
 	}
-	workerHash := annotations[consts.SnapshotWorkerHashAnnotation]
-	if expectedWorkerHash != nil && workerHash != *expectedWorkerHash {
+	compatibilityHash := annotations[consts.SnapshotCompatibilityHashAnnotation]
+	if compatibilityHash != expectedCompatibilityHash {
 		return nil, fmt.Errorf(
-			"referenced PodSnapshot %s/%s worker hash %q does not match expected hash %q",
+			"referenced PodSnapshot %s/%s compatibility hash %q does not match expected hash %q",
 			namespace,
 			snapshotName,
-			workerHash,
-			*expectedWorkerHash,
+			compatibilityHash,
+			expectedCompatibilityHash,
 		)
 	}
 	gmsMode := annotations[consts.SnapshotGMSModeAnnotation]
@@ -185,17 +186,19 @@ func ResolvePodSnapshotForService(
 		startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
 	}
 	info := &CheckpointInfo{
-		Enabled:          true,
-		Exists:           true,
-		GPUMemoryService: gmsSpec,
-		CheckpointName:   snapshot.Name,
-		Ready:            ready,
-		StartupPolicy:    startupPolicy,
+		Enabled:                   true,
+		Exists:                    true,
+		GPUMemoryService:          gmsSpec,
+		CheckpointName:            snapshot.Name,
+		Ready:                     ready,
+		StartupPolicy:             startupPolicy,
+		SnapshotCompatibilityHash: compatibilityHash,
 		NativeSnapshot: &ResolvedPodSnapshot{
 			UID:                  snapshot.UID,
 			BoundContentName:     contentName,
 			SourceContainer:      containers[0],
 			CompatibilityVersion: version,
+			CompatibilityHash:    compatibilityHash,
 			GMSMode:              gmsMode,
 		},
 	}

--- a/deploy/operator/internal/checkpoint/native_test.go
+++ b/deploy/operator/internal/checkpoint/native_test.go
@@ -176,7 +176,7 @@ func TestResolvePodSnapshotForServiceRejectsIncompatibleReferences(t *testing.T)
 			mutate: func(snapshot *snapshotv1alpha1.PodSnapshot) {
 				snapshot.Annotations[consts.SnapshotCompatibilityHashAnnotation] = "compatibility-v2"
 			},
-			wantErr: "does not match expected hash",
+			wantErr: "including PVC claim names",
 		},
 		{
 			name: "unsupported GMS mode",

--- a/deploy/operator/internal/checkpoint/native_test.go
+++ b/deploy/operator/internal/checkpoint/native_test.go
@@ -48,7 +48,7 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 		assert.Equal(t, snapshot.UID, info.NativeSnapshot.UID)
 		assert.Equal(t, "content-a", info.NativeSnapshot.BoundContentName)
 		assert.Equal(t, "main", info.NativeSnapshot.SourceContainer)
-		assert.Equal(t, "compatibility-v1", info.NativeSnapshot.CompatibilityHash)
+		assert.Equal(t, "compatibility-v1", info.SnapshotCompatibilityHash)
 		assert.Nil(t, info.GPUMemoryService)
 		assert.Equal(t, []string{"engine-0"}, info.RestoreTargetContainers)
 		assert.Equal(t, nvidiacomv1alpha1.CheckpointStartupPolicyImmediate, info.StartupPolicy)
@@ -165,9 +165,9 @@ func TestResolvePodSnapshotForServiceRejectsIncompatibleReferences(t *testing.T)
 			wantErr: "exactly one source container",
 		},
 		{
-			name: "unsupported compatibility version",
+			name: "legacy compatibility version",
 			mutate: func(snapshot *snapshotv1alpha1.PodSnapshot) {
-				snapshot.Annotations[consts.SnapshotCompatibilityVersionAnnotation] = "v2"
+				snapshot.Annotations[consts.SnapshotCompatibilityVersionAnnotation] = "v1"
 			},
 			wantErr: "unsupported Dynamo compatibility version",
 		},

--- a/deploy/operator/internal/checkpoint/native_test.go
+++ b/deploy/operator/internal/checkpoint/native_test.go
@@ -28,13 +28,13 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 		reader := fake.NewClientBuilder().WithScheme(nativeTestScheme(t)).WithObjects(snapshot).Build()
 		config := nativeTestCheckpointConfig(snapshot.Name)
 
-		t.Log("When the explicit reference is resolved for the same worker generation")
+		t.Log("When the explicit reference is resolved for a compatible target")
 		info, err := ResolvePodSnapshotForService(
 			context.Background(),
 			reader,
 			snapshot.Namespace,
 			config,
-			ptr.To("worker-v1"),
+			"compatibility-v1",
 			ExplicitPodSnapshotUse(),
 		)
 
@@ -48,6 +48,7 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 		assert.Equal(t, snapshot.UID, info.NativeSnapshot.UID)
 		assert.Equal(t, "content-a", info.NativeSnapshot.BoundContentName)
 		assert.Equal(t, "main", info.NativeSnapshot.SourceContainer)
+		assert.Equal(t, "compatibility-v1", info.NativeSnapshot.CompatibilityHash)
 		assert.Nil(t, info.GPUMemoryService)
 		assert.Equal(t, []string{"engine-0"}, info.RestoreTargetContainers)
 		assert.Equal(t, nvidiacomv1alpha1.CheckpointStartupPolicyImmediate, info.StartupPolicy)
@@ -65,7 +66,7 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 			reader,
 			snapshot.Namespace,
 			nativeTestCheckpointConfig(snapshot.Name),
-			ptr.To("worker-v1"),
+			"compatibility-v1",
 			ExplicitPodSnapshotUse(),
 		)
 
@@ -100,7 +101,7 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 					reader,
 					snapshot.Namespace,
 					nativeTestCheckpointConfig(snapshot.Name),
-					ptr.To("worker-v1"),
+					"compatibility-v1",
 					ExplicitPodSnapshotUse(),
 				)
 
@@ -113,46 +114,23 @@ func TestResolvePodSnapshotForService(t *testing.T) {
 		}
 	})
 
-	t.Run("resolves a non-worker snapshot without a worker hash", func(t *testing.T) {
-		t.Log("Given a compatible non-worker PodSnapshot with no worker generation")
-		snapshot := nativeTestPodSnapshot()
-		delete(snapshot.Annotations, consts.SnapshotWorkerHashAnnotation)
-		reader := fake.NewClientBuilder().WithScheme(nativeTestScheme(t)).WithObjects(snapshot).Build()
-
-		t.Log("When the reference is resolved without a worker hash contract")
-		info, err := ResolvePodSnapshotForService(
-			context.Background(),
-			reader,
-			snapshot.Namespace,
-			nativeTestCheckpointConfig(snapshot.Name),
-			nil,
-			ExplicitPodSnapshotUse(),
-		)
-
-		t.Log("Then the remaining native compatibility contract is still enforced")
-		require.NoError(t, err)
-		assert.True(t, info.Ready)
-		require.NotNil(t, info.NativeSnapshot)
-		assert.Equal(t, snapshot.UID, info.NativeSnapshot.UID)
-	})
-
-	t.Run("rejects a worker restore before its hash is available", func(t *testing.T) {
-		t.Log("Given a worker restore whose generation identity is not initialized")
+	t.Run("rejects a restore without an expected compatibility hash", func(t *testing.T) {
+		t.Log("Given a restore whose compatibility identity was not rendered")
 		snapshot := nativeTestPodSnapshot()
 		reader := fake.NewClientBuilder().WithScheme(nativeTestScheme(t)).WithObjects(snapshot).Build()
 
-		t.Log("When resolution requires an empty worker hash")
+		t.Log("When the reference is resolved without a compatibility hash")
 		_, err := ResolvePodSnapshotForService(
 			context.Background(),
 			reader,
 			snapshot.Namespace,
 			nativeTestCheckpointConfig(snapshot.Name),
-			ptr.To(""),
+			"",
 			ExplicitPodSnapshotUse(),
 		)
 
-		t.Log("Then resolution fails closed until the worker generation is known")
-		require.ErrorContains(t, err, "worker compatibility hash is required")
+		t.Log("Then resolution fails closed")
+		require.ErrorContains(t, err, "snapshot compatibility hash is required")
 	})
 }
 
@@ -194,9 +172,9 @@ func TestResolvePodSnapshotForServiceRejectsIncompatibleReferences(t *testing.T)
 			wantErr: "unsupported Dynamo compatibility version",
 		},
 		{
-			name: "worker generation mismatch",
+			name: "snapshot compatibility mismatch",
 			mutate: func(snapshot *snapshotv1alpha1.PodSnapshot) {
-				snapshot.Annotations[consts.SnapshotWorkerHashAnnotation] = "worker-v2"
+				snapshot.Annotations[consts.SnapshotCompatibilityHashAnnotation] = "compatibility-v2"
 			},
 			wantErr: "does not match expected hash",
 		},
@@ -229,7 +207,7 @@ func TestResolvePodSnapshotForServiceRejectsIncompatibleReferences(t *testing.T)
 				reader,
 				snapshot.Namespace,
 				nativeTestCheckpointConfig(snapshot.Name),
-				ptr.To("worker-v1"),
+				"compatibility-v1",
 				ExplicitPodSnapshotUse(),
 			)
 
@@ -256,7 +234,7 @@ func TestResolvePodSnapshotForServiceRetainedAutomaticCheckpoint(t *testing.T) {
 			reader,
 			snapshot.Namespace,
 			config,
-			ptr.To("worker-v1"),
+			"compatibility-v1",
 			ExplicitPodSnapshotUse(),
 		)
 
@@ -271,7 +249,7 @@ func TestResolvePodSnapshotForServiceRetainedAutomaticCheckpoint(t *testing.T) {
 			reader,
 			snapshot.Namespace,
 			config,
-			ptr.To("worker-v1"),
+			"compatibility-v1",
 			ManagedPodSnapshotUse(ownerUID),
 		)
 
@@ -287,7 +265,7 @@ func TestResolvePodSnapshotForServiceRetainedAutomaticCheckpoint(t *testing.T) {
 			reader,
 			snapshot.Namespace,
 			config,
-			ptr.To("worker-v1"),
+			"compatibility-v1",
 			ManagedPodSnapshotUse("different-dgd-uid"),
 		)
 
@@ -304,7 +282,7 @@ func nativeTestPodSnapshot() *snapshotv1alpha1.PodSnapshot {
 			UID:       types.UID("snapshot-uid"),
 			Annotations: map[string]string{
 				consts.SnapshotCompatibilityVersionAnnotation: consts.SnapshotCompatibilityVersion,
-				consts.SnapshotWorkerHashAnnotation:           "worker-v1",
+				consts.SnapshotCompatibilityHashAnnotation:    "compatibility-v1",
 				consts.SnapshotGMSModeAnnotation:              consts.SnapshotGMSModeDisabled,
 			},
 		},

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -41,6 +41,11 @@ func ApplyRestoreCandidateMetadata(annotations map[string]string, checkpointInfo
 	if startupPolicy == "" {
 		startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
 	}
+	if checkpointInfo.SnapshotCompatibilityHash != "" {
+		// Keep the expected identity on pending explicit references so the DCD
+		// renderer can repeat resolution without relying on the rollout hash.
+		annotations[commonconsts.SnapshotCandidateCompatibilityHashAnnotation] = checkpointInfo.SnapshotCompatibilityHash
+	}
 
 	if checkpointInfo.AutomaticSnapshotJob != nil {
 		if !checkpointInfo.AutomaticCapture {
@@ -48,6 +53,9 @@ func ApplyRestoreCandidateMetadata(annotations map[string]string, checkpointInfo
 		}
 		if strings.TrimSpace(checkpointInfo.AutomaticSnapshotJob.Name) == "" || checkpointInfo.AutomaticSnapshotJob.UID == "" {
 			return fmt.Errorf("SnapshotJob restore candidate requires a name and UID")
+		}
+		if checkpointInfo.SnapshotCompatibilityHash == "" {
+			return fmt.Errorf("SnapshotJob restore candidate requires a compatibility hash")
 		}
 		annotations[commonconsts.CheckpointRestoreCandidateAnnotation] = commonconsts.KubeLabelValueTrue
 		annotations[commonconsts.CheckpointNameAnnotation] = checkpointInfo.AutomaticSnapshotJob.Name
@@ -65,6 +73,9 @@ func ApplyRestoreCandidateMetadata(annotations map[string]string, checkpointInfo
 	}
 	if checkpointInfo.NativeSnapshot == nil {
 		return fmt.Errorf("restore candidate requires a resolved PodSnapshot")
+	}
+	if checkpointInfo.SnapshotCompatibilityHash == "" {
+		return fmt.Errorf("PodSnapshot restore candidate requires a compatibility hash")
 	}
 
 	annotations[commonconsts.CheckpointRestoreCandidateAnnotation] = commonconsts.KubeLabelValueTrue
@@ -89,6 +100,7 @@ func removeRestoreCandidateMetadata(annotations map[string]string) {
 	delete(annotations, commonconsts.SnapshotCandidateContentAnnotation)
 	delete(annotations, commonconsts.SnapshotCandidateGMSModeAnnotation)
 	delete(annotations, commonconsts.SnapshotCandidateVersionAnnotation)
+	delete(annotations, commonconsts.SnapshotCandidateCompatibilityHashAnnotation)
 	delete(annotations, commonconsts.RestoreCandidateTargetContainersAnnotation)
 }
 

--- a/deploy/operator/internal/checkpoint/podspec_test.go
+++ b/deploy/operator/internal/checkpoint/podspec_test.go
@@ -20,19 +20,21 @@ func TestApplyRestoreCandidateMetadataAutomaticCaptureIsStable(t *testing.T) {
 	t.Log("Given pending and Ready states for the same automatic SnapshotJob candidate")
 	job := &SnapshotJobReference{Name: "checkpoint-worker", UID: types.UID("job-uid")}
 	pending := &CheckpointInfo{
-		Enabled:              true,
-		AutomaticCapture:     true,
-		StartupPolicy:        nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
-		AutomaticSnapshotJob: job,
+		Enabled:                   true,
+		AutomaticCapture:          true,
+		StartupPolicy:             nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+		SnapshotCompatibilityHash: "compatibility-v1",
+		AutomaticSnapshotJob:      job,
 	}
 	ready := &CheckpointInfo{
-		Enabled:              true,
-		Exists:               true,
-		Ready:                true,
-		AutomaticCapture:     true,
-		CheckpointName:       "worker-snapshot",
-		StartupPolicy:        nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
-		AutomaticSnapshotJob: job,
+		Enabled:                   true,
+		Exists:                    true,
+		Ready:                     true,
+		AutomaticCapture:          true,
+		CheckpointName:            "worker-snapshot",
+		StartupPolicy:             nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+		SnapshotCompatibilityHash: "compatibility-v1",
+		AutomaticSnapshotJob:      job,
 		NativeSnapshot: &ResolvedPodSnapshot{
 			UID:                  types.UID("snapshot-uid"),
 			BoundContentName:     "content-a",
@@ -55,6 +57,7 @@ func TestApplyRestoreCandidateMetadataAutomaticCaptureIsStable(t *testing.T) {
 		pendingAnnotations[consts.RestoreCandidateSourceKindAnnotation])
 	assert.Equal(t, job.Name, pendingAnnotations[consts.CheckpointNameAnnotation])
 	assert.Equal(t, string(job.UID), pendingAnnotations[consts.SnapshotJobCandidateUIDAnnotation])
+	assert.Equal(t, "compatibility-v1", pendingAnnotations[consts.SnapshotCandidateCompatibilityHashAnnotation])
 	assert.NotContains(t, pendingAnnotations, consts.SnapshotCandidateUIDAnnotation)
 }
 

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -27,6 +27,9 @@ type CheckpointInfo struct {
 	CheckpointName   string
 	Ready            bool
 	StartupPolicy    nvidiacomv1alpha1.CheckpointStartupPolicy
+	// SnapshotCompatibilityHash is the independently rendered identity expected
+	// by both pending automatic captures and resolved explicit references.
+	SnapshotCompatibilityHash string
 	// Empty means the restore pod targets the default main container.
 	RestoreTargetContainers []string
 	// NativeSnapshot is non-nil once CheckpointName resolves to a standalone

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -123,7 +123,7 @@ const (
 	SnapshotCompatibilityVersionAnnotation = "nvidia.com/dynamo-snapshot-compatibility-version"
 	SnapshotCompatibilityHashAnnotation    = "nvidia.com/dynamo-snapshot-compatibility-hash"
 	SnapshotGMSModeAnnotation              = "nvidia.com/dynamo-snapshot-gms-mode"
-	SnapshotCompatibilityVersion           = "v1"
+	SnapshotCompatibilityVersion           = "v2"
 	SnapshotGMSModeDisabled                = "disabled"
 
 	// Native restore candidate metadata pins the PodSnapshot observation used

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -121,17 +121,18 @@ const (
 	// Snapshot compatibility metadata is written by Dynamo capture producers
 	// and validated before a PodSnapshot may restore a Dynamo worker.
 	SnapshotCompatibilityVersionAnnotation = "nvidia.com/dynamo-snapshot-compatibility-version"
-	SnapshotWorkerHashAnnotation           = "nvidia.com/dynamo-snapshot-worker-hash"
+	SnapshotCompatibilityHashAnnotation    = "nvidia.com/dynamo-snapshot-compatibility-hash"
 	SnapshotGMSModeAnnotation              = "nvidia.com/dynamo-snapshot-gms-mode"
 	SnapshotCompatibilityVersion           = "v1"
 	SnapshotGMSModeDisabled                = "disabled"
 
 	// Native restore candidate metadata pins the PodSnapshot observation used
 	// by workload reconciliation so admission can detect intervening changes.
-	SnapshotCandidateUIDAnnotation     = "nvidia.com/dynamo-restore-snapshot-uid"
-	SnapshotCandidateContentAnnotation = "nvidia.com/dynamo-restore-snapshot-content"
-	SnapshotCandidateGMSModeAnnotation = "nvidia.com/dynamo-restore-snapshot-gms-mode"
-	SnapshotCandidateVersionAnnotation = "nvidia.com/dynamo-restore-snapshot-version"
+	SnapshotCandidateUIDAnnotation               = "nvidia.com/dynamo-restore-snapshot-uid"
+	SnapshotCandidateContentAnnotation           = "nvidia.com/dynamo-restore-snapshot-content"
+	SnapshotCandidateGMSModeAnnotation           = "nvidia.com/dynamo-restore-snapshot-gms-mode"
+	SnapshotCandidateVersionAnnotation           = "nvidia.com/dynamo-restore-snapshot-version"
+	SnapshotCandidateCompatibilityHashAnnotation = "nvidia.com/dynamo-restore-snapshot-compatibility-hash"
 	// RestoreCandidateTargetContainersAnnotation carries Dynamo's rendered
 	// restore destinations from workload reconciliation to Pod admission.
 	RestoreCandidateTargetContainersAnnotation = "nvidia.com/dynamo-restore-target-containers"

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -256,15 +256,6 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		return nil, fmt.Errorf("checkpoint config is required")
 	}
 
-	checkpointID := checkpoint.DGDCheckpointID(
-		dynamoDeployment.Namespace,
-		dynamoDeployment.Name,
-		string(dynamoDeployment.UID),
-		componentName,
-		workerHash,
-		consts.SnapshotCompatibilityVersion,
-	)
-
 	backendFramework, err := dynamo.BackendFrameworkForComponent(component, dynamoDeployment)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine backend framework for component %s: %w", componentName, err)
@@ -325,6 +316,15 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 	if err != nil {
 		return nil, err
 	}
+	checkpointID := checkpoint.DGDCheckpointID(
+		dynamoDeployment.Namespace,
+		dynamoDeployment.Name,
+		string(dynamoDeployment.UID),
+		componentName,
+		workerHash,
+		compatibilityHash,
+		consts.SnapshotCompatibilityVersion,
+	)
 	var checkpointGMSClaimTemplateName string
 	if gmsSpec != nil && gmsSpec.Enabled {
 		checkpointGMSClaimTemplateName = checkpointGMSResourceClaimTemplateName(checkpointID)
@@ -492,10 +492,9 @@ func (r *dgdCheckpointsReconciler) syncAutomaticSnapshotJob(
 		return created, nil
 	}
 
-	// A deterministic name may be reused only by this graph incarnation.
-	// Capture inputs that participate in the worker hash select a new name;
-	// inputs outside that hash intentionally preserve the existing one-shot job,
-	// matching the previous automatic-capture invalidation contract.
+	// A deterministic name may be reused only by this graph incarnation and
+	// compatibility contract. Capture inputs covered by either the worker hash
+	// or compatibility hash select a fresh immutable one-shot job.
 	if existing.Annotations[consts.CheckpointAutoAnnotation] != consts.KubeLabelValueTrue ||
 		existing.Annotations[consts.CheckpointOwnerUIDAnnotation] != string(dgd.UID) {
 		return nil, fmt.Errorf("SnapshotJob %s already exists and is not managed by DGD uid %q", key, dgd.UID)

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -224,7 +224,9 @@ func (r *dgdCheckpointsReconciler) snapshotCompatibilityHashForComponent(
 	if checkpointConfig := dynamo.GetCheckpoint(component); checkpointConfig != nil && checkpointConfig.TargetContainerName != "" {
 		targetContainerName = checkpointConfig.TargetContainerName
 	}
-	gmsMode, err := automaticSnapshotGMSMode(gms.ToAlphaSpec(dynamo.GetGPUMemoryService(component)))
+	gmsMode, gmsDeviceClassName, err := snapshotGMSCompatibility(
+		gms.ToAlphaSpec(dynamo.GetGPUMemoryService(component)),
+	)
 	if err != nil {
 		return "", err
 	}
@@ -233,6 +235,7 @@ func (r *dgdCheckpointsReconciler) snapshotCompatibilityHashForComponent(
 		targetContainerName,
 		string(backendFramework),
 		gmsMode,
+		gmsDeviceClassName,
 	)
 }
 
@@ -307,7 +310,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 			gmsSpec.ExtraClientContainers = append([]string(nil), checkpointConfig.Job.GMSClientContainers...)
 		}
 	}
-	gmsMode, err := automaticSnapshotGMSMode(gmsSpec)
+	gmsMode, gmsDeviceClassName, err := snapshotGMSCompatibility(gmsSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -316,6 +319,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		targetContainerName,
 		string(backendFramework),
 		gmsMode,
+		gmsDeviceClassName,
 	)
 	if err != nil {
 		return nil, err
@@ -327,16 +331,12 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		if err != nil {
 			return nil, fmt.Errorf("invalid GPU resource requirements for GMS checkpoint %s/%s: %w", dynamoDeployment.Name, componentName, err)
 		}
-		checkpointGMSDeviceClassName := gmsSpec.DeviceClassName
-		if checkpointGMSDeviceClassName == "" {
-			checkpointGMSDeviceClassName = dra.DefaultDeviceClassName
-		}
 		if err := r.syncCheckpointGMSResourceClaimTemplate(
 			ctx,
 			dynamoDeployment,
 			checkpointGMSClaimTemplateName,
 			checkpointGMSGPUCount,
-			checkpointGMSDeviceClassName,
+			gmsDeviceClassName,
 		); err != nil {
 			return nil, err
 		}
@@ -660,15 +660,21 @@ func (r *dgdCheckpointsReconciler) resolveAutomaticSnapshotJob(
 	return resolved, nil
 }
 
-func automaticSnapshotGMSMode(spec *nvidiacomv1alpha1.GPUMemoryServiceSpec) (string, error) {
+func snapshotGMSCompatibility(
+	spec *nvidiacomv1alpha1.GPUMemoryServiceSpec,
+) (string, string, error) {
 	if spec == nil || !spec.Enabled {
-		return consts.SnapshotGMSModeDisabled, nil
+		return consts.SnapshotGMSModeDisabled, "", nil
+	}
+	deviceClassName := spec.DeviceClassName
+	if deviceClassName == "" {
+		deviceClassName = dra.DefaultDeviceClassName
 	}
 	switch spec.Mode {
 	case "", nvidiacomv1alpha1.GMSModeIntraPod:
-		return string(nvidiacomv1alpha1.GMSModeIntraPod), nil
+		return string(nvidiacomv1alpha1.GMSModeIntraPod), deviceClassName, nil
 	default:
-		return "", fmt.Errorf("automatic SnapshotJob has unsupported gpuMemoryService mode %q", spec.Mode)
+		return "", "", fmt.Errorf("snapshot has unsupported gpuMemoryService mode %q", spec.Mode)
 	}
 }
 

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -262,6 +262,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		string(dynamoDeployment.UID),
 		componentName,
 		workerHash,
+		consts.SnapshotCompatibilityVersion,
 	)
 
 	backendFramework, err := dynamo.BackendFrameworkForComponent(component, dynamoDeployment)

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -116,52 +116,49 @@ func (r *dgdCheckpointsReconciler) Reconcile(
 			startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
 		}
 
-		// Derive the compatibility identity expected by captured and restored workers.
-		workerHash, err := checkpointWorkerHashForComponent(dgd, componentName)
-		if err != nil {
-			return dgdCheckpointsResult{}, fmt.Errorf("failed to compute checkpoint worker hash for component %s: %w", componentName, err)
-		}
-		workerComponent := dynamo.IsWorkerComponent(string(component.ComponentType))
-		var expectedWorkerHash *string
-		if workerComponent {
-			expectedWorkerHash = &workerHash
-		}
-
 		var info *checkpoint.CheckpointInfo
-		if workerComponent && workerHash == "" {
-			// Grove records the active worker generation after synchronizing its
-			// first PodCliqueSet. Do not capture or resolve a generation-less
-			// worker while that durable identity is still being initialized.
-			logger.Info("Waiting for active worker hash before checkpoint reconciliation", "component", componentName)
-			info = &checkpoint.CheckpointInfo{
-				Enabled:        true,
-				CheckpointName: checkpointName,
-				StartupPolicy:  startupPolicy,
+		var err error
+		if !hasCheckpointRef {
+			// The rollout hash remains the automatic-capture generation key. It is
+			// deliberately separate from the portable snapshot compatibility hash.
+			workerHash, hashErr := checkpointWorkerHashForComponent(dgd, componentName)
+			if hashErr != nil {
+				return dgdCheckpointsResult{}, fmt.Errorf("failed to compute checkpoint worker hash for component %s: %w", componentName, hashErr)
 			}
-			if hasCheckpointRef {
-				// Explicit restore must remain fail-closed while compatibility
-				// identity is unavailable, even when Immediate was requested.
-				info.StartupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint
+			workerComponent := dynamo.IsWorkerComponent(string(component.ComponentType))
+			if workerComponent && workerHash == "" {
+				// Grove records the active worker generation after synchronizing its
+				// first PodCliqueSet. Do not capture or resolve a generation-less
+				// worker while that durable identity is still being initialized.
+				logger.Info("Waiting for active worker hash before checkpoint reconciliation", "component", componentName)
+				info = &checkpoint.CheckpointInfo{
+					Enabled:          true,
+					CheckpointName:   checkpointName,
+					StartupPolicy:    startupPolicy,
+					AutomaticCapture: true,
+				}
 			} else {
-				info.AutomaticCapture = true
+				info, err = r.reconcileAutomaticSnapshotJob(
+					ctx,
+					dgd,
+					componentName,
+					component,
+					workerHash,
+					startupPolicy,
+				)
 			}
-		} else if !hasCheckpointRef {
-			info, err = r.reconcileAutomaticSnapshotJob(
-				ctx,
-				dgd,
-				componentName,
-				component,
-				workerHash,
-				startupPolicy,
-			)
 		} else {
+			compatibilityHash, hashErr := r.snapshotCompatibilityHashForComponent(dgd, componentName, component)
+			if hashErr != nil {
+				return dgdCheckpointsResult{}, fmt.Errorf("failed to compute snapshot compatibility hash for component %s: %w", componentName, hashErr)
+			}
 			// Resolve explicit references against the standalone PodSnapshot API.
 			info, err = checkpoint.ResolvePodSnapshotForService(
 				ctx,
 				r.Client,
 				dgd.Namespace,
 				alphaCheckpointConfig,
-				expectedWorkerHash,
+				compatibilityHash,
 				checkpoint.ExplicitPodSnapshotUse(),
 			)
 		}
@@ -200,6 +197,43 @@ func (r *dgdCheckpointsReconciler) Reconcile(
 	}
 
 	return result, nil
+}
+
+func (r *dgdCheckpointsReconciler) snapshotCompatibilityHashForComponent(
+	dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment,
+	componentName string,
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) (string, error) {
+	backendFramework, err := dynamo.BackendFrameworkForComponent(component, dynamoDeployment)
+	if err != nil {
+		return "", fmt.Errorf("determine backend framework: %w", err)
+	}
+	if backendFramework == "" || backendFramework == dynamo.BackendFrameworkNoop {
+		return "", fmt.Errorf("backend framework could not be determined; set spec.backendFramework or use a recognizable worker command")
+	}
+	podTemplate, err := r.buildCheckpointJobPodTemplate(
+		dynamoDeployment,
+		component,
+		componentName,
+		backendFramework,
+	)
+	if err != nil {
+		return "", fmt.Errorf("build compatibility pod template: %w", err)
+	}
+	targetContainerName := consts.MainContainerName
+	if checkpointConfig := dynamo.GetCheckpoint(component); checkpointConfig != nil && checkpointConfig.TargetContainerName != "" {
+		targetContainerName = checkpointConfig.TargetContainerName
+	}
+	gmsMode, err := automaticSnapshotGMSMode(gms.ToAlphaSpec(dynamo.GetGPUMemoryService(component)))
+	if err != nil {
+		return "", err
+	}
+	return checkpoint.ComputeSnapshotCompatibilityHash(
+		&podTemplate,
+		targetContainerName,
+		string(backendFramework),
+		gmsMode,
+	)
 }
 
 // reconcileAutomaticSnapshotJob converges one DGD-managed automatic capture
@@ -273,6 +307,19 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 			gmsSpec.ExtraClientContainers = append([]string(nil), checkpointConfig.Job.GMSClientContainers...)
 		}
 	}
+	gmsMode, err := automaticSnapshotGMSMode(gmsSpec)
+	if err != nil {
+		return nil, err
+	}
+	compatibilityHash, err := checkpoint.ComputeSnapshotCompatibilityHash(
+		&podTemplate,
+		targetContainerName,
+		string(backendFramework),
+		gmsMode,
+	)
+	if err != nil {
+		return nil, err
+	}
 	var checkpointGMSClaimTemplateName string
 	if gmsSpec != nil && gmsSpec.Enabled {
 		checkpointGMSClaimTemplateName = checkpointGMSResourceClaimTemplateName(checkpointID)
@@ -307,11 +354,6 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		deletionPolicy = nvidiacomv1alpha1.CheckpointDeletionPolicyDelete
 	}
 
-	gmsMode, err := automaticSnapshotGMSMode(gmsSpec)
-	if err != nil {
-		return nil, err
-	}
-
 	// SnapshotJob owns the one-shot capture state machine while Dynamo supplies
 	// the rendered workload and compatibility metadata.
 	desired := buildAutomaticSnapshotJob(
@@ -319,6 +361,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		componentName,
 		checkpointID,
 		workerHash,
+		compatibilityHash,
 		podTemplate,
 		targetContainerName,
 		deletionPolicy,
@@ -342,15 +385,11 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		return nil, err
 	}
 
-	var expectedWorkerHash *string
-	if dynamo.IsWorkerComponent(string(component.ComponentType)) {
-		expectedWorkerHash = &workerHash
-	}
 	return r.resolveAutomaticSnapshotJob(
 		ctx,
 		snapshotJob,
 		dynamo.ToAlphaCheckpointConfig(checkpointConfig),
-		expectedWorkerHash,
+		compatibilityHash,
 		startupPolicy,
 	)
 }
@@ -362,6 +401,7 @@ func buildAutomaticSnapshotJob(
 	componentName string,
 	checkpointID string,
 	workerHash string,
+	compatibilityHash string,
 	podTemplate corev1.PodTemplateSpec,
 	targetContainerName string,
 	deletionPolicy nvidiacomv1alpha1.CheckpointDeletionPolicy,
@@ -392,7 +432,7 @@ func buildAutomaticSnapshotJob(
 		consts.CheckpointDeletionPolicyAnnotation:     string(deletionPolicy),
 		consts.CheckpointOwnerUIDAnnotation:           string(dgd.UID),
 		consts.SnapshotCompatibilityVersionAnnotation: consts.SnapshotCompatibilityVersion,
-		consts.SnapshotWorkerHashAnnotation:           workerHash,
+		consts.SnapshotCompatibilityHashAnnotation:    compatibilityHash,
 		consts.SnapshotGMSModeAnnotation:              gmsMode,
 	}
 
@@ -550,14 +590,15 @@ func (r *dgdCheckpointsReconciler) resolveAutomaticSnapshotJob(
 	ctx context.Context,
 	snapshotJob *snapshotv1alpha1.SnapshotJob,
 	config *nvidiacomv1alpha1.ServiceCheckpointConfig,
-	expectedWorkerHash *string,
+	expectedCompatibilityHash string,
 	startupPolicy nvidiacomv1alpha1.CheckpointStartupPolicy,
 ) (*checkpoint.CheckpointInfo, error) {
 	info := &checkpoint.CheckpointInfo{
-		Enabled:          true,
-		AutomaticCapture: true,
-		CheckpointName:   snapshotJob.Status.PodSnapshotName,
-		StartupPolicy:    startupPolicy,
+		Enabled:                   true,
+		AutomaticCapture:          true,
+		CheckpointName:            snapshotJob.Status.PodSnapshotName,
+		StartupPolicy:             startupPolicy,
+		SnapshotCompatibilityHash: expectedCompatibilityHash,
 	}
 	if snapshotv1alpha1.IsSnapshotJobFailed(snapshotJob) {
 		failed := meta.FindStatusCondition(snapshotJob.Status.Conditions, snapshotv1alpha1.SnapshotJobConditionFailed)
@@ -592,7 +633,7 @@ func (r *dgdCheckpointsReconciler) resolveAutomaticSnapshotJob(
 		r.Client,
 		snapshotJob.Namespace,
 		refConfig,
-		expectedWorkerHash,
+		expectedCompatibilityHash,
 		checkpoint.ManagedPodSnapshotUse(types.UID(snapshotJob.Annotations[consts.CheckpointOwnerUIDAnnotation])),
 	)
 	if apierrors.IsNotFound(err) {

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -154,10 +154,10 @@ func reconcileAutomaticSnapshotJobForTest(
 	t *testing.T,
 	reconciler *DynamoGraphDeploymentReconciler,
 	dgd *v1beta1.DynamoGraphDeployment,
-	componentName string,
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 ) *snapshotv1alpha1.SnapshotJob {
 	t.Helper()
+	const componentName = "worker"
 	workerHash, err := checkpointWorkerHashForComponent(dgd, componentName)
 	require.NoError(t, err)
 	checkpointReconciler := newTestDGDCheckpointsReconciler(reconciler)
@@ -260,7 +260,7 @@ func TestDGDCheckpointsReconciler_SnapshotJobPreservesGMSSaverClient(t *testing.
 	}
 
 	t.Log("Create the GMS-backed SnapshotJob")
-	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", betaComponent(t, component))
+	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, betaComponent(t, component))
 
 	t.Log("Verify GMS clients, containers, claims, and templates are preserved")
 	saver := findContainer(job.Spec.PodTemplate.Spec.Containers, "gms-saver")
@@ -426,7 +426,7 @@ func TestDGDCheckpointsReconciler_SnapshotJobAppliesDGDDefaults(t *testing.T) {
 	}
 
 	t.Log("Create the SnapshotJob pod template")
-	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, component)
 
 	t.Log("Verify graph defaults reach the SnapshotJob")
 	main := findContainer(job.Spec.PodTemplate.Spec.Containers, commonconsts.MainContainerName)
@@ -492,12 +492,12 @@ func TestDGDCheckpointsReconciler_CompatibilityHashChangeRecaptures(t *testing.T
 	require.NotNil(t, component)
 
 	t.Log("Create the first immutable capture job")
-	first := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	first := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, component)
 	firstHash := first.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
 
 	t.Log("Change an operator-rendered process input outside the DGD worker hash")
 	reconciler.Config.Infrastructure.NATSTLSCAPath = "/etc/dynamo/tls/new-nats-ca.pem"
-	second := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	second := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, component)
 	secondHash := second.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
 
 	t.Log("Verify the new compatibility contract selects a fresh job")
@@ -560,7 +560,7 @@ func TestDGDCheckpointsReconciler_SnapshotJobUsesTargetContainer(t *testing.T) {
 	}
 
 	t.Log("Create the target-container SnapshotJob")
-	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	job := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, component)
 
 	t.Log("Verify target and GMS containers are retained")
 	assert.Equal(t, []string{"snapshot-me"}, job.Spec.PodSnapshotTemplate.TargetContainers)

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -160,7 +160,14 @@ func reconcileAutomaticSnapshotJobForTest(
 	t.Helper()
 	workerHash, err := checkpointWorkerHashForComponent(dgd, componentName)
 	require.NoError(t, err)
-	_, err = newTestDGDCheckpointsReconciler(reconciler).reconcileAutomaticSnapshotJob(
+	checkpointReconciler := newTestDGDCheckpointsReconciler(reconciler)
+	compatibilityHash, err := checkpointReconciler.snapshotCompatibilityHashForComponent(
+		dgd,
+		componentName,
+		component,
+	)
+	require.NoError(t, err)
+	_, err = checkpointReconciler.reconcileAutomaticSnapshotJob(
 		context.Background(),
 		dgd,
 		componentName,
@@ -176,6 +183,7 @@ func reconcileAutomaticSnapshotJobForTest(
 		string(dgd.UID),
 		componentName,
 		workerHash,
+		compatibilityHash,
 		commonconsts.SnapshotCompatibilityVersion,
 	)
 	job := &snapshotv1alpha1.SnapshotJob{}
@@ -183,9 +191,10 @@ func reconcileAutomaticSnapshotJobForTest(
 		Namespace: dgd.Namespace,
 		Name:      "checkpoint-" + checkpointID,
 	}, job))
-	compatibilityHash := job.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
-	assert.Regexp(t, "^[0-9a-f]{64}$", compatibilityHash)
-	assert.NotEqual(t, workerHash, compatibilityHash)
+	jobCompatibilityHash := job.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
+	assert.Equal(t, compatibilityHash, jobCompatibilityHash)
+	assert.Regexp(t, "^[0-9a-f]{64}$", jobCompatibilityHash)
+	assert.NotEqual(t, workerHash, jobCompatibilityHash)
 	return job
 }
 
@@ -283,6 +292,7 @@ func TestDGDCheckpointsReconciler_SnapshotJobPreservesGMSSaverClient(t *testing.
 		string(dgd.UID),
 		"worker",
 		workerHash,
+		job.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation],
 		commonconsts.SnapshotCompatibilityVersion,
 	)
 	claimTemplateName := checkpointGMSResourceClaimTemplateName(checkpointID)
@@ -442,6 +452,60 @@ func TestDGDCheckpointsReconciler_SnapshotJobAppliesDGDDefaults(t *testing.T) {
 		Name:      commonconsts.KubeValueNameSharedMemory,
 		MountPath: commonconsts.DefaultSharedMemoryMountPath,
 	})
+}
+
+func TestDGDCheckpointsReconciler_CompatibilityHashChangeRecaptures(t *testing.T) {
+	t.Log("Build an automatic checkpoint component with a stable worker generation")
+	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(testScheme).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+	}
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+			UID:       types.UID("dgd-uid"),
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "worker",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  commonconsts.MainContainerName,
+						Image: "checkpoint-writer:latest",
+					}},
+				}},
+				Experimental: &v1beta1.ExperimentalSpec{Checkpoint: &v1beta1.ComponentCheckpointConfig{
+					Enabled: true,
+					Mode:    v1beta1.CheckpointModeAuto,
+				}},
+			}},
+		},
+	}
+	workerHash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{commonconsts.AnnotationCurrentWorkerHashV2: workerHash}
+	component := dgd.GetComponentByName("worker")
+	require.NotNil(t, component)
+
+	t.Log("Create the first immutable capture job")
+	first := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	firstHash := first.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
+
+	t.Log("Change an operator-rendered process input outside the DGD worker hash")
+	reconciler.Config.Infrastructure.NATSTLSCAPath = "/etc/dynamo/tls/new-nats-ca.pem"
+	second := reconcileAutomaticSnapshotJobForTest(t, reconciler, dgd, "worker", component)
+	secondHash := second.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
+
+	t.Log("Verify the new compatibility contract selects a fresh job")
+	assert.NotEqual(t, firstHash, secondHash)
+	assert.NotEqual(t, first.Name, second.Name)
+	jobs := &snapshotv1alpha1.SnapshotJobList{}
+	require.NoError(t, reconciler.List(context.Background(), jobs, client.InNamespace(dgd.Namespace)))
+	assert.Len(t, jobs.Items, 2)
 }
 
 func TestDGDCheckpointsReconciler_SnapshotJobUsesTargetContainer(t *testing.T) {
@@ -675,6 +739,7 @@ func TestDGDCheckpointsReconciler_CompatibilityVersionUpgradeRecaptures(t *testi
 		"worker",
 		workerHash,
 		"",
+		"",
 	)
 	legacyJob := &snapshotv1alpha1.SnapshotJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -759,12 +824,19 @@ func TestDGDCheckpointsReconciler_CompatibilityVersionUpgradeRecaptures(t *testi
 	assert.False(t, result.Infos["worker"].Ready)
 
 	t.Log("Verify v2 selects a fresh immutable job without deleting the legacy capture")
+	currentCompatibilityHash, err := checkpointReconciler.snapshotCompatibilityHashForComponent(
+		dgd,
+		"worker",
+		dgd.GetComponentByName("worker"),
+	)
+	require.NoError(t, err)
 	currentCheckpointID := checkpoint.DGDCheckpointID(
 		dgd.Namespace,
 		dgd.Name,
 		string(dgd.UID),
 		"worker",
 		workerHash,
+		currentCompatibilityHash,
 		commonconsts.SnapshotCompatibilityVersion,
 	)
 	currentJob := &snapshotv1alpha1.SnapshotJob{}

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -99,14 +99,13 @@ func dgdTestPodSnapshot(name string, compatibilityHash string, ready bool) *snap
 func dgdTestSnapshotCompatibilityHash(
 	t *testing.T,
 	dgd *v1beta1.DynamoGraphDeployment,
-	componentName string,
 ) string {
 	t.Helper()
-	component := dgd.GetComponentByName(componentName)
+	component := dgd.GetComponentByName("worker")
 	require.NotNil(t, component)
 	hash, err := (&dgdCheckpointsReconciler{
 		config: &configv1alpha1.OperatorConfiguration{},
-	}).snapshotCompatibilityHashForComponent(dgd, componentName, component)
+	}).snapshotCompatibilityHashForComponent(dgd, "worker", component)
 	require.NoError(t, err)
 	require.NotEmpty(t, hash)
 	return hash
@@ -624,7 +623,7 @@ func TestDGDCheckpointsReconciler_ExplicitRestoreDoesNotDependOnActiveWorkerHash
 	}
 
 	t.Log("Create a referenced PodSnapshot carrying the independent compatibility hash")
-	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
 		Config:        &configv1alpha1.OperatorConfiguration{},
@@ -677,8 +676,8 @@ func TestDGDCheckpointsReconciler_ExplicitRestoreIsPortableAcrossDGDIdentity(t *
 
 	t.Log("Verify the rollout identities differ while the snapshot contract remains portable")
 	assert.NotEqual(t, betaDGDWorkersSpecHash(t, source), betaDGDWorkersSpecHash(t, target))
-	sourceCompatibilityHash := dgdTestSnapshotCompatibilityHash(t, source, "worker")
-	assert.Equal(t, sourceCompatibilityHash, dgdTestSnapshotCompatibilityHash(t, target, "worker"))
+	sourceCompatibilityHash := dgdTestSnapshotCompatibilityHash(t, source)
+	assert.Equal(t, sourceCompatibilityHash, dgdTestSnapshotCompatibilityHash(t, target))
 
 	t.Log("Resolve the source snapshot from the target DGD without initializing its rollout hash")
 	referenced := dgdTestPodSnapshot(ref, sourceCompatibilityHash, true)
@@ -964,7 +963,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefSkipsAutoCreateWhilePodSnapshotIs
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), false)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd), false)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -1037,7 +1036,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefUsesReadyPodSnapshot(t *testing.T
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -1123,7 +1122,7 @@ func TestDGDCheckpointsReconciler_OverlaysServiceGMSLoader(t *testing.T) {
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	referenced.Annotations[commonconsts.SnapshotGMSModeAnnotation] = string(v1alpha1.GMSModeIntraPod)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:   fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
@@ -1188,7 +1187,7 @@ func TestDGDCheckpointsReconciler_RejectsServiceGMSWithNonGMSCheckpoint(t *testi
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
 		Config:        &configv1alpha1.OperatorConfiguration{},
@@ -1252,7 +1251,7 @@ func TestDGDCheckpointsReconciler_AutomaticRestoreWaitsForSnapshotJobCompletion(
 	job := jobs.Items[0].DeepCopy()
 	// controller-runtime's fake client does not assign API-server UIDs.
 	job.UID = types.UID("snapshot-job-uid")
-	snapshot := dgdTestPodSnapshot(job.Name, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	snapshot := dgdTestPodSnapshot(job.Name, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	snapshot.Labels = map[string]string{
 		snapshotv1alpha1.SnapshotJobOwnerLabel:    job.Name,
 		snapshotv1alpha1.SnapshotJobOwnerUIDLabel: string(job.UID),

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -111,6 +111,45 @@ func dgdTestSnapshotCompatibilityHash(
 	return hash
 }
 
+func TestSnapshotGMSCompatibilityResolvesDeviceClass(t *testing.T) {
+	tests := []struct {
+		name            string
+		spec            *v1alpha1.GPUMemoryServiceSpec
+		wantMode        string
+		wantDeviceClass string
+	}{
+		{
+			name:     "disabled",
+			wantMode: commonconsts.SnapshotGMSModeDisabled,
+		},
+		{
+			name:            "enabled with default device class",
+			spec:            &v1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod},
+			wantMode:        string(v1alpha1.GMSModeIntraPod),
+			wantDeviceClass: dra.DefaultDeviceClassName,
+		},
+		{
+			name: "enabled with custom device class",
+			spec: &v1alpha1.GPUMemoryServiceSpec{
+				Enabled:         true,
+				Mode:            v1alpha1.GMSModeIntraPod,
+				DeviceClassName: "gpu.nvidia.com/h100",
+			},
+			wantMode:        string(v1alpha1.GMSModeIntraPod),
+			wantDeviceClass: "gpu.nvidia.com/h100",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mode, deviceClass, err := snapshotGMSCompatibility(test.spec)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantMode, mode)
+			assert.Equal(t, test.wantDeviceClass, deviceClass)
+		})
+	}
+}
+
 func reconcileAutomaticSnapshotJobForTest(
 	t *testing.T,
 	reconciler *DynamoGraphDeploymentReconciler,

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -63,7 +63,7 @@ func newTestDGDCheckpointsReconciler(
 	)
 }
 
-func dgdTestPodSnapshot(name string, workerHash string, ready bool) *snapshotv1alpha1.PodSnapshot {
+func dgdTestPodSnapshot(name string, compatibilityHash string, ready bool) *snapshotv1alpha1.PodSnapshot {
 	snapshot := &snapshotv1alpha1.PodSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -71,7 +71,7 @@ func dgdTestPodSnapshot(name string, workerHash string, ready bool) *snapshotv1a
 			UID:       types.UID("snapshot-uid"),
 			Annotations: map[string]string{
 				commonconsts.SnapshotCompatibilityVersionAnnotation: commonconsts.SnapshotCompatibilityVersion,
-				commonconsts.SnapshotWorkerHashAnnotation:           workerHash,
+				commonconsts.SnapshotCompatibilityHashAnnotation:    compatibilityHash,
 				commonconsts.SnapshotGMSModeAnnotation:              commonconsts.SnapshotGMSModeDisabled,
 			},
 		},
@@ -94,6 +94,22 @@ func dgdTestPodSnapshot(name string, workerHash string, ready bool) *snapshotv1a
 		}
 	}
 	return snapshot
+}
+
+func dgdTestSnapshotCompatibilityHash(
+	t *testing.T,
+	dgd *v1beta1.DynamoGraphDeployment,
+	componentName string,
+) string {
+	t.Helper()
+	component := dgd.GetComponentByName(componentName)
+	require.NotNil(t, component)
+	hash, err := (&dgdCheckpointsReconciler{
+		config: &configv1alpha1.OperatorConfiguration{},
+	}).snapshotCompatibilityHashForComponent(dgd, componentName, component)
+	require.NoError(t, err)
+	require.NotEmpty(t, hash)
+	return hash
 }
 
 func reconcileAutomaticSnapshotJobForTest(
@@ -128,6 +144,9 @@ func reconcileAutomaticSnapshotJobForTest(
 		Namespace: dgd.Namespace,
 		Name:      "checkpoint-" + checkpointID,
 	}, job))
+	compatibilityHash := job.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityHashAnnotation]
+	assert.Regexp(t, "^[0-9a-f]{64}$", compatibilityHash)
+	assert.NotEqual(t, workerHash, compatibilityHash)
 	return job
 }
 
@@ -580,15 +599,10 @@ func TestDGDCheckpointsReconciler_AutomaticCaptureWaitsForActiveWorkerHash(t *te
 	assert.Equal(t, workerHash, jobs.Items[0].Labels[commonconsts.KubeLabelDynamoWorkerHash])
 }
 
-func TestDGDCheckpointsReconciler_ExplicitRestoreWaitsForActiveWorkerHash(t *testing.T) {
-	t.Log("Build a first-generation worker with an explicit reference before its active hash is initialized")
+func TestDGDCheckpointsReconciler_ExplicitRestoreDoesNotDependOnActiveWorkerHash(t *testing.T) {
+	t.Log("Build a first-generation worker with an explicit reference before its rollout hash is initialized")
 	ctx := context.Background()
 	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
-	reconciler := &DynamoGraphDeploymentReconciler{
-		Client:        fake.NewClientBuilder().WithScheme(testScheme).Build(),
-		Config:        &configv1alpha1.OperatorConfiguration{},
-		RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{Checkpoint: true}},
-	}
 	ref := friendlyCheckpointName
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -609,39 +623,77 @@ func TestDGDCheckpointsReconciler_ExplicitRestoreWaitsForActiveWorkerHash(t *tes
 		},
 	}
 
-	t.Log("Reconcile while the worker generation has no durable identity")
+	t.Log("Create a referenced PodSnapshot carrying the independent compatibility hash")
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{Checkpoint: true}},
+	}
+
+	t.Log("Reconcile without an active rollout hash")
 	result, err := newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
 	require.NoError(t, err)
 
-	t.Log("Verify explicit restore remains fail-closed instead of failing reconciliation or cold-starting")
+	t.Log("Verify the explicit snapshot resolves without waiting for a worker generation")
 	info := result.Infos["worker"]
-	require.NotNil(t, info)
-	assert.Equal(t, ref, info.CheckpointName)
-	assert.False(t, info.Exists)
-	assert.False(t, info.Ready)
-	assert.Equal(t, v1alpha1.CheckpointStartupPolicyWaitForCheckpoint, info.StartupPolicy)
-
-	t.Log("Record the active hash while the referenced PodSnapshot is still missing")
-	workerHash := betaDGDWorkersSpecHash(t, dgd)
-	dgd.Annotations = map[string]string{commonconsts.AnnotationCurrentWorkerHashV2: workerHash}
-
-	t.Log("Verify a missing explicit reference fails reconciliation without synthesizing pending state")
-	_, err = newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
-	require.ErrorContains(t, err, "get referenced PodSnapshot")
-
-	t.Log("Create the compatible referenced PodSnapshot")
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
-	require.NoError(t, reconciler.Create(ctx, referenced))
-
-	t.Log("Verify the same explicit reference resolves once compatibility identity is available")
-	result, err = newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
-	require.NoError(t, err)
-	info = result.Infos["worker"]
 	require.NotNil(t, info)
 	assert.True(t, info.Exists)
 	assert.True(t, info.Ready)
 	require.NotNil(t, info.NativeSnapshot)
 	assert.Equal(t, referenced.UID, info.NativeSnapshot.UID)
+}
+
+func TestDGDCheckpointsReconciler_ExplicitRestoreIsPortableAcrossDGDIdentity(t *testing.T) {
+	t.Log("Build equivalent capture and restore workers under different DGD identities")
+	ref := friendlyCheckpointName
+	component := v1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentName: "worker",
+		ComponentType: v1beta1.ComponentTypeWorker,
+		PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:    commonconsts.MainContainerName,
+			Image:   "worker:1.5.0",
+			Command: []string{"python3", "-m", "dynamo.vllm"},
+			Args:    []string{"--model", "Qwen/Qwen3-0.6B"},
+		}}}},
+		Experimental: &v1beta1.ExperimentalSpec{Checkpoint: &v1beta1.ComponentCheckpointConfig{Enabled: true}},
+	}
+	source := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "capture-dgd", Namespace: "default", UID: types.UID("capture-uid")},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			Components:       []v1beta1.DynamoComponentDeploymentSharedSpec{*component.DeepCopy()},
+		},
+	}
+	targetComponent := component.DeepCopy()
+	targetComponent.Experimental.Checkpoint.CheckpointRef = &ref
+	target := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-dgd", Namespace: "default", UID: types.UID("restore-uid")},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			Components:       []v1beta1.DynamoComponentDeploymentSharedSpec{*targetComponent},
+		},
+	}
+
+	t.Log("Verify the rollout identities differ while the snapshot contract remains portable")
+	assert.NotEqual(t, betaDGDWorkersSpecHash(t, source), betaDGDWorkersSpecHash(t, target))
+	sourceCompatibilityHash := dgdTestSnapshotCompatibilityHash(t, source, "worker")
+	assert.Equal(t, sourceCompatibilityHash, dgdTestSnapshotCompatibilityHash(t, target, "worker"))
+
+	t.Log("Resolve the source snapshot from the target DGD without initializing its rollout hash")
+	referenced := dgdTestPodSnapshot(ref, sourceCompatibilityHash, true)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+			WithObjects(referenced).
+			Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{Checkpoint: true}},
+	}
+	result, err := newTestDGDCheckpointsReconciler(reconciler).Reconcile(context.Background(), target)
+	require.NoError(t, err)
+	require.NotNil(t, result.Infos["worker"])
+	assert.True(t, result.Infos["worker"].Ready)
 }
 
 func TestCheckpointWorkerHashForComponent_WaitsForCommittedGeneration(t *testing.T) {
@@ -841,6 +893,7 @@ func TestDGDCheckpointsReconciler_SyncsExistingAutoLifecycle(t *testing.T) {
 		"worker",
 		"capture-id",
 		"worker-hash",
+		"compatibility-hash",
 		corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
 			Name:  commonconsts.MainContainerName,
 			Image: "main:latest",
@@ -911,10 +964,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefSkipsAutoCreateWhilePodSnapshotIs
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	require.NotEmpty(t, workerHash)
-	referenced := dgdTestPodSnapshot(ref, workerHash, false)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), false)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -971,6 +1021,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefUsesReadyPodSnapshot(t *testing.T
 			UID:       types.UID("dgd-uid"),
 		},
 		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
 			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: string(commonconsts.ComponentTypeWorker),
@@ -986,10 +1037,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefUsesReadyPodSnapshot(t *testing.T
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	require.NotEmpty(t, workerHash)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -1050,6 +1098,7 @@ func TestDGDCheckpointsReconciler_OverlaysServiceGMSLoader(t *testing.T) {
 			UID:       types.UID("dgd-uid"),
 		},
 		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
 			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: string(commonconsts.ComponentTypeWorker),
@@ -1074,9 +1123,7 @@ func TestDGDCheckpointsReconciler_OverlaysServiceGMSLoader(t *testing.T) {
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
 	referenced.Annotations[commonconsts.SnapshotGMSModeAnnotation] = string(v1alpha1.GMSModeIntraPod)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:   fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
@@ -1141,9 +1188,7 @@ func TestDGDCheckpointsReconciler_RejectsServiceGMSWithNonGMSCheckpoint(t *testi
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
 		Config:        &configv1alpha1.OperatorConfiguration{},
@@ -1152,7 +1197,7 @@ func TestDGDCheckpointsReconciler_RejectsServiceGMSWithNonGMSCheckpoint(t *testi
 	}
 
 	t.Log("Reconcile the incompatible checkpoint reference")
-	_, err = newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
+	_, err := newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
 
 	t.Log("Verify the incompatibility is returned with checkpoint context")
 	require.Error(t, err)
@@ -1207,9 +1252,7 @@ func TestDGDCheckpointsReconciler_AutomaticRestoreWaitsForSnapshotJobCompletion(
 	job := jobs.Items[0].DeepCopy()
 	// controller-runtime's fake client does not assign API-server UIDs.
 	job.UID = types.UID("snapshot-job-uid")
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	snapshot := dgdTestPodSnapshot(job.Name, workerHash, true)
+	snapshot := dgdTestPodSnapshot(job.Name, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
 	snapshot.Labels = map[string]string{
 		snapshotv1alpha1.SnapshotJobOwnerLabel:    job.Name,
 		snapshotv1alpha1.SnapshotJobOwnerUIDLabel: string(job.UID),
@@ -1272,7 +1315,7 @@ func TestDGDCheckpointsReconciler_AutomaticCaptureReportsSnapshotJobFailure(t *t
 		context.Background(),
 		job,
 		&v1alpha1.ServiceCheckpointConfig{},
-		ptr.To("worker-hash"),
+		"compatibility-hash",
 		v1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
 	)
 

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -176,6 +176,7 @@ func reconcileAutomaticSnapshotJobForTest(
 		string(dgd.UID),
 		componentName,
 		workerHash,
+		commonconsts.SnapshotCompatibilityVersion,
 	)
 	job := &snapshotv1alpha1.SnapshotJob{}
 	require.NoError(t, reconciler.Get(context.Background(), client.ObjectKey{
@@ -282,6 +283,7 @@ func TestDGDCheckpointsReconciler_SnapshotJobPreservesGMSSaverClient(t *testing.
 		string(dgd.UID),
 		"worker",
 		workerHash,
+		commonconsts.SnapshotCompatibilityVersion,
 	)
 	claimTemplateName := checkpointGMSResourceClaimTemplateName(checkpointID)
 	assert.Contains(t, job.Spec.PodTemplate.Spec.ResourceClaims, corev1.PodResourceClaim{
@@ -635,6 +637,173 @@ func TestDGDCheckpointsReconciler_AutomaticCaptureWaitsForActiveWorkerHash(t *te
 	require.NoError(t, reconciler.List(ctx, jobs, client.InNamespace("default")))
 	require.Len(t, jobs.Items, 1)
 	assert.Equal(t, workerHash, jobs.Items[0].Labels[commonconsts.KubeLabelDynamoWorkerHash])
+}
+
+func TestDGDCheckpointsReconciler_CompatibilityVersionUpgradeRecaptures(t *testing.T) {
+	t.Log("Build an automatic checkpoint DGD with a completed pre-versioned SnapshotJob")
+	ctx := context.Background()
+	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
+	dgd := betaDGD(t, &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+			UID:       types.UID("dgd-uid"),
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: string(commonconsts.ComponentTypeWorker),
+					ExtraPodSpec: &v1alpha1.ExtraPodSpec{MainContainer: &corev1.Container{
+						Name:  commonconsts.MainContainerName,
+						Image: "worker:latest",
+					}},
+					Checkpoint: &v1alpha1.ServiceCheckpointConfig{
+						Enabled: true,
+						Mode:    v1alpha1.CheckpointModeAuto,
+					},
+				},
+			},
+		},
+	})
+	workerHash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{commonconsts.AnnotationCurrentWorkerHashV2: workerHash}
+	legacyCheckpointID := checkpoint.DGDCheckpointID(
+		dgd.Namespace,
+		dgd.Name,
+		string(dgd.UID),
+		"worker",
+		workerHash,
+		"",
+	)
+	legacyJob := &snapshotv1alpha1.SnapshotJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "checkpoint-" + legacyCheckpointID,
+			Namespace: dgd.Namespace,
+			UID:       types.UID("legacy-job-uid"),
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+				commonconsts.KubeLabelDynamoComponent:           "worker",
+				commonconsts.KubeLabelDynamoWorkerHash:          workerHash,
+			},
+			Annotations: map[string]string{
+				commonconsts.CheckpointAutoAnnotation:           commonconsts.KubeLabelValueTrue,
+				commonconsts.CheckpointDeletionPolicyAnnotation: string(v1alpha1.CheckpointDeletionPolicyDelete),
+				commonconsts.CheckpointOwnerUIDAnnotation:       string(dgd.UID),
+			},
+		},
+		Spec: snapshotv1alpha1.SnapshotJobSpec{
+			PodSnapshotTemplate: snapshotv1alpha1.PodSnapshotTemplate{
+				Metadata: &snapshotv1alpha1.PodSnapshotTemplateMetadata{Annotations: map[string]string{
+					commonconsts.SnapshotCompatibilityVersionAnnotation: "v1",
+					"nvidia.com/dynamo-snapshot-worker-hash":            workerHash,
+				}},
+				TargetContainers: []string{commonconsts.MainContainerName},
+			},
+		},
+		Status: snapshotv1alpha1.SnapshotJobStatus{
+			PodSnapshotName: "legacy-snapshot",
+			PodSnapshotUID:  types.UID("legacy-snapshot-uid"),
+			Conditions: []metav1.Condition{{
+				Type:   snapshotv1alpha1.SnapshotJobConditionCompleted,
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+	legacySnapshot := &snapshotv1alpha1.PodSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacyJob.Status.PodSnapshotName,
+			Namespace: dgd.Namespace,
+			UID:       legacyJob.Status.PodSnapshotUID,
+			Labels: map[string]string{
+				snapshotv1alpha1.SnapshotJobOwnerLabel:    legacyJob.Name,
+				snapshotv1alpha1.SnapshotJobOwnerUIDLabel: string(legacyJob.UID),
+			},
+			Annotations: map[string]string{
+				commonconsts.CheckpointAutoAnnotation:               commonconsts.KubeLabelValueTrue,
+				commonconsts.CheckpointOwnerUIDAnnotation:           string(dgd.UID),
+				commonconsts.SnapshotCompatibilityVersionAnnotation: "v1",
+				"nvidia.com/dynamo-snapshot-worker-hash":            workerHash,
+				commonconsts.SnapshotGMSModeAnnotation:              commonconsts.SnapshotGMSModeDisabled,
+				commonconsts.CheckpointDeletionPolicyAnnotation:     string(v1alpha1.CheckpointDeletionPolicyDelete),
+			},
+		},
+		Spec: snapshotv1alpha1.PodSnapshotSpec{Source: snapshotv1alpha1.PodSnapshotSource{
+			PodRef: snapshotv1alpha1.PodReference{
+				Name:       "legacy-capture-worker",
+				Containers: []string{commonconsts.MainContainerName},
+			},
+		}},
+		Status: snapshotv1alpha1.PodSnapshotStatus{
+			BoundPodSnapshotContentName: ptr.To("legacy-content"),
+			Conditions: []metav1.Condition{{
+				Type:   snapshotv1alpha1.PodSnapshotConditionReady,
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(legacyJob, legacySnapshot).
+			Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{Gate: features.Gates{Checkpoint: true}},
+	}
+	checkpointReconciler := newTestDGDCheckpointsReconciler(reconciler)
+
+	t.Log("Reconcile after the compatibility contract upgrade")
+	result, err := checkpointReconciler.Reconcile(ctx, dgd)
+	require.NoError(t, err)
+	require.NotNil(t, result.Infos["worker"])
+	assert.False(t, result.Infos["worker"].Ready)
+
+	t.Log("Verify v2 selects a fresh immutable job without deleting the legacy capture")
+	currentCheckpointID := checkpoint.DGDCheckpointID(
+		dgd.Namespace,
+		dgd.Name,
+		string(dgd.UID),
+		"worker",
+		workerHash,
+		commonconsts.SnapshotCompatibilityVersion,
+	)
+	currentJob := &snapshotv1alpha1.SnapshotJob{}
+	require.NoError(t, reconciler.Get(ctx, client.ObjectKey{
+		Namespace: dgd.Namespace,
+		Name:      "checkpoint-" + currentCheckpointID,
+	}, currentJob))
+	require.NotNil(t, currentJob.Spec.PodSnapshotTemplate.Metadata)
+	assert.Equal(t, commonconsts.SnapshotCompatibilityVersion,
+		currentJob.Spec.PodSnapshotTemplate.Metadata.Annotations[commonconsts.SnapshotCompatibilityVersionAnnotation])
+	require.NoError(t, reconciler.Get(ctx, client.ObjectKeyFromObject(legacyJob), &snapshotv1alpha1.SnapshotJob{}))
+	require.NoError(t, reconciler.Get(ctx, client.ObjectKeyFromObject(legacySnapshot), &snapshotv1alpha1.PodSnapshot{}))
+
+	t.Log("Complete the replacement capture and verify reconciliation converges on v2")
+	currentJob.UID = types.UID("current-job-uid")
+	currentSnapshot := dgdTestPodSnapshot("current-snapshot", dgdTestSnapshotCompatibilityHash(t, dgd), true)
+	currentSnapshot.UID = types.UID("current-snapshot-uid")
+	currentSnapshot.Labels = map[string]string{
+		snapshotv1alpha1.SnapshotJobOwnerLabel:    currentJob.Name,
+		snapshotv1alpha1.SnapshotJobOwnerUIDLabel: string(currentJob.UID),
+	}
+	currentSnapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
+	currentSnapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = string(dgd.UID)
+	currentJob.Status = snapshotv1alpha1.SnapshotJobStatus{
+		PodSnapshotName: currentSnapshot.Name,
+		PodSnapshotUID:  currentSnapshot.UID,
+		Conditions: []metav1.Condition{{
+			Type:   snapshotv1alpha1.SnapshotJobConditionCompleted,
+			Status: metav1.ConditionTrue,
+		}},
+	}
+	require.NoError(t, reconciler.Update(ctx, currentJob))
+	require.NoError(t, reconciler.Create(ctx, currentSnapshot))
+	result, err = checkpointReconciler.Reconcile(ctx, dgd)
+	require.NoError(t, err)
+	require.NotNil(t, result.Infos["worker"])
+	assert.True(t, result.Infos["worker"].Ready)
+	require.NotNil(t, result.Infos["worker"].NativeSnapshot)
+	assert.Equal(t, currentSnapshot.UID, result.Infos["worker"].NativeSnapshot.UID)
 }
 
 func TestDGDCheckpointsReconciler_ExplicitRestoreDoesNotDependOnActiveWorkerHash(t *testing.T) {

--- a/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
@@ -115,7 +115,7 @@ func TestDGDSharedResourcesReconciler_PreservesCheckpointResultOnLaterFailure(t 
 	dgd.Annotations = map[string]string{
 		consts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	referenced := dgdTestPodSnapshot(reference, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
+	referenced := dgdTestPodSnapshot(reference, dgdTestSnapshotCompatibilityHash(t, dgd), true)
 	s := newDynamoGraphDeploymentControllerTestScheme(t)
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(s).

--- a/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
@@ -91,6 +91,7 @@ func TestDGDSharedResourcesReconciler_PreservesCheckpointResultOnLaterFailure(t 
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default", UID: types.UID("dgd-uid")},
 		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
 			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
 				{
 					ComponentName: "worker",
@@ -114,9 +115,7 @@ func TestDGDSharedResourcesReconciler_PreservesCheckpointResultOnLaterFailure(t 
 	dgd.Annotations = map[string]string{
 		consts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(reference, workerHash, true)
+	referenced := dgdTestPodSnapshot(reference, dgdTestSnapshotCompatibilityHash(t, dgd, "worker"), true)
 	s := newDynamoGraphDeploymentControllerTestScheme(t)
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(s).

--- a/deploy/operator/internal/controller/dgd_workload_program_test.go
+++ b/deploy/operator/internal/controller/dgd_workload_program_test.go
@@ -819,13 +819,14 @@ func TestComponentWorkloadsReconciler_PreserveExistingDCDState(t *testing.T) {
 func TestComponentWorkloadsReconciler_ApplyCheckpointStartupPolicy(t *testing.T) {
 	workloads := &componentWorkloadsReconciler{}
 	tests := []struct {
-		name              string
-		replicas          int32
-		podTemplate       *corev1.PodTemplateSpec
-		checkpointInfo    checkpoint.CheckpointInfo
-		wantReplicas      int32
-		wantStartupPolicy nvidiacomv1beta1.CheckpointStartupPolicy
-		wantCandidate     bool
+		name                  string
+		replicas              int32
+		podTemplate           *corev1.PodTemplateSpec
+		checkpointInfo        checkpoint.CheckpointInfo
+		wantReplicas          int32
+		wantStartupPolicy     nvidiacomv1beta1.CheckpointStartupPolicy
+		wantCandidate         bool
+		wantCompatibilityHash bool
 	}{
 		{
 			name:     "unready explicit snapshot gates replicas under wait policy",
@@ -841,14 +842,30 @@ func TestComponentWorkloadsReconciler_ApplyCheckpointStartupPolicy(t *testing.T)
 			wantStartupPolicy: nvidiacomv1beta1.CheckpointStartupPolicyWaitForCheckpoint,
 		},
 		{
+			name:     "pending explicit snapshot carries compatibility without becoming a restore candidate",
+			replicas: 2,
+			checkpointInfo: checkpoint.CheckpointInfo{
+				Enabled:                   true,
+				Exists:                    true,
+				Ready:                     false,
+				CheckpointName:            "snapshot-name",
+				StartupPolicy:             nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+				SnapshotCompatibilityHash: "compatibility-v1",
+			},
+			wantReplicas:          2,
+			wantStartupPolicy:     nvidiacomv1beta1.CheckpointStartupPolicyImmediate,
+			wantCompatibilityHash: true,
+		},
+		{
 			name:     "ready snapshot stamps pinned candidate metadata",
 			replicas: 2,
 			checkpointInfo: checkpoint.CheckpointInfo{
-				Enabled:        true,
-				Exists:         true,
-				Ready:          true,
-				CheckpointName: "snapshot-name",
-				StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+				Enabled:                   true,
+				Exists:                    true,
+				Ready:                     true,
+				CheckpointName:            "snapshot-name",
+				StartupPolicy:             nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+				SnapshotCompatibilityHash: "compatibility-v1",
 				NativeSnapshot: &checkpoint.ResolvedPodSnapshot{
 					UID:                  types.UID("snapshot-uid"),
 					BoundContentName:     "content-a",
@@ -856,9 +873,10 @@ func TestComponentWorkloadsReconciler_ApplyCheckpointStartupPolicy(t *testing.T)
 					GMSMode:              commonconsts.SnapshotGMSModeDisabled,
 				},
 			},
-			wantReplicas:      2,
-			wantStartupPolicy: nvidiacomv1beta1.CheckpointStartupPolicyImmediate,
-			wantCandidate:     true,
+			wantReplicas:          2,
+			wantStartupPolicy:     nvidiacomv1beta1.CheckpointStartupPolicyImmediate,
+			wantCandidate:         true,
+			wantCompatibilityHash: true,
 		},
 	}
 
@@ -886,6 +904,10 @@ func TestComponentWorkloadsReconciler_ApplyCheckpointStartupPolicy(t *testing.T)
 			assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Job)
 			assert.Equal(t, tt.wantStartupPolicy, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
 			assert.Equal(t, tt.wantReplicas, *dcd.Spec.Replicas)
+			if tt.wantCompatibilityHash {
+				require.NotNil(t, dcd.Spec.PodTemplate)
+				assert.Equal(t, "compatibility-v1", dcd.Spec.PodTemplate.Annotations[commonconsts.SnapshotCandidateCompatibilityHashAnnotation])
+			}
 			if !tt.wantCandidate {
 				return
 			}
@@ -927,9 +949,10 @@ func TestComponentWorkloadsReconciler_ApplyPendingAutomaticSnapshotPolicy(t *tes
 				},
 			}
 			info := &checkpoint.CheckpointInfo{
-				Enabled:          true,
-				AutomaticCapture: true,
-				StartupPolicy:    tt.startupPolicy,
+				Enabled:                   true,
+				AutomaticCapture:          true,
+				StartupPolicy:             tt.startupPolicy,
+				SnapshotCompatibilityHash: "compatibility-v1",
 				AutomaticSnapshotJob: &checkpoint.SnapshotJobReference{
 					Name: "checkpoint-worker",
 					UID:  types.UID("snapshot-job-uid"),

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1822,6 +1822,10 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 				},
 			},
 		})
+		if dcd.Spec.PodTemplate.Annotations == nil {
+			dcd.Spec.PodTemplate.Annotations = map[string]string{}
+		}
+		dcd.Spec.PodTemplate.Annotations[commonconsts.SnapshotCandidateCompatibilityHashAnnotation] = "compatibility-v1"
 		return dcd
 	}
 
@@ -1848,9 +1852,10 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		require.NoError(t, checkpoint.ApplyRestoreCandidateMetadata(
 			dcd.Spec.PodTemplate.Annotations,
 			&checkpoint.CheckpointInfo{
-				Enabled:          true,
-				AutomaticCapture: true,
-				StartupPolicy:    v1alpha1.CheckpointStartupPolicyImmediate,
+				Enabled:                   true,
+				AutomaticCapture:          true,
+				StartupPolicy:             v1alpha1.CheckpointStartupPolicyImmediate,
+				SnapshotCompatibilityHash: "compatibility-v1",
 				AutomaticSnapshotJob: &checkpoint.SnapshotJobReference{
 					Name: "checkpoint-job",
 					UID:  types.UID("snapshot-job-uid"),
@@ -1875,7 +1880,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			corev1.Container{Name: "engine-0", Image: "test-image:latest"},
 		)
 		stampAutomaticCandidate(t, readyDCD)
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		snapshot.Spec.Source.PodRef.Containers = []string{"engine-0"}
 		snapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
 		snapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = testDGDUID
@@ -1901,7 +1906,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 	t.Run("DGD-managed checkpointRef resolves only a native PodSnapshot", func(t *testing.T) {
 		t.Log("Given a DGD-managed DCD reference and a Ready compatible PodSnapshot")
 		dcd := makeDCD("worker-snapshot")
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		r := makeReconciler(dcd, snapshot)
 
 		t.Log("When the DCD workload template is rendered")
@@ -1924,7 +1929,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 	t.Run("pending explicit snapshot keeps Immediate workload cold-start shaped", func(t *testing.T) {
 		t.Log("Given an Immediate DCD referencing a compatible PodSnapshot that is not Ready")
 		dcd := makeDCD("worker-snapshot")
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", false)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", false)
 		r := makeReconciler(dcd, snapshot)
 
 		t.Log("When the DCD workload template is rendered")
@@ -1945,7 +1950,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		t.Log("Given a WaitForCheckpoint DCD and a Ready compatible PodSnapshot with no legacy checkpoint")
 		dcd := makeDCD("worker-snapshot")
 		dcd.Spec.Experimental.Checkpoint.StartupPolicy = v1beta1.CheckpointStartupPolicyWaitForCheckpoint
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		r := makeReconciler(dcd, snapshot)
 
 		t.Log("When the DCD workload template is rendered after the startup gate opens")
@@ -1970,19 +1975,20 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		require.NoError(t, (&componentWorkloadsReconciler{}).applyCheckpointStartupPolicy(
 			dcd,
 			&checkpoint.CheckpointInfo{
-				Enabled:          true,
-				Exists:           true,
-				Ready:            true,
-				AutomaticCapture: true,
-				CheckpointName:   "worker-snapshot",
-				StartupPolicy:    v1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
+				Enabled:                   true,
+				Exists:                    true,
+				Ready:                     true,
+				AutomaticCapture:          true,
+				CheckpointName:            "worker-snapshot",
+				StartupPolicy:             v1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
+				SnapshotCompatibilityHash: "compatibility-v1",
 				AutomaticSnapshotJob: &checkpoint.SnapshotJobReference{
 					Name: "checkpoint-job",
 					UID:  types.UID("snapshot-job-uid"),
 				},
 			},
 		))
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		snapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
 		snapshot.Annotations[commonconsts.CheckpointDeletionPolicyAnnotation] = string(v1alpha1.CheckpointDeletionPolicyRetain)
 		snapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = testDGDUID
@@ -2007,7 +2013,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		t.Log("Given a generated DCD referencing another DGD's retained automatic PodSnapshot")
 		dcd := makeDCD("worker-snapshot")
 		stampAutomaticCandidate(t, dcd)
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		snapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
 		snapshot.Annotations[commonconsts.CheckpointDeletionPolicyAnnotation] = string(v1alpha1.CheckpointDeletionPolicyRetain)
 		snapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = "different-dgd-uid"
@@ -2028,7 +2034,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 	t.Run("DGD explicit checkpointRef cannot adopt a retained automatic checkpoint", func(t *testing.T) {
 		t.Log("Given a generated DCD with an explicit reference to a retained automatic PodSnapshot")
 		dcd := makeDCD("worker-snapshot")
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		snapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
 		snapshot.Annotations[commonconsts.CheckpointDeletionPolicyAnnotation] = string(v1alpha1.CheckpointDeletionPolicyRetain)
 		snapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = testDGDUID
@@ -2050,7 +2056,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		t.Log("Given a standalone DCD referencing a retained automatic PodSnapshot")
 		dcd := makeDCD("worker-snapshot")
 		dcd.OwnerReferences = nil
-		snapshot := dgdTestPodSnapshot("worker-snapshot", "workerhash", true)
+		snapshot := dgdTestPodSnapshot("worker-snapshot", "compatibility-v1", true)
 		snapshot.Annotations[commonconsts.CheckpointAutoAnnotation] = commonconsts.KubeLabelValueTrue
 		snapshot.Annotations[commonconsts.CheckpointDeletionPolicyAnnotation] = string(v1alpha1.CheckpointDeletionPolicyRetain)
 		snapshot.Annotations[commonconsts.CheckpointOwnerUIDAnnotation] = testDGDUID

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -271,6 +271,7 @@ func (r *dcdWorkloadRenderer) resolveCheckpointInfo(
 	}
 
 	alphaCheckpointConfig := dynamo.ToAlphaCheckpointConfig(checkpointConfig)
+	expectedCompatibilityHash := dynamo.GetPodTemplateAnnotations(component)[commonconsts.SnapshotCandidateCompatibilityHashAnnotation]
 	automaticSnapshotJob, err := automaticSnapshotJobReferenceForDCD(dcd)
 	if err != nil {
 		return nil, err
@@ -284,27 +285,23 @@ func (r *dcdWorkloadRenderer) resolveCheckpointInfo(
 			startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
 		}
 		info = &checkpoint.CheckpointInfo{
-			Enabled:              true,
-			AutomaticCapture:     automaticSnapshotJob != nil,
-			StartupPolicy:        startupPolicy,
-			AutomaticSnapshotJob: automaticSnapshotJob,
+			Enabled:                   true,
+			AutomaticCapture:          automaticSnapshotJob != nil,
+			StartupPolicy:             startupPolicy,
+			SnapshotCompatibilityHash: expectedCompatibilityHash,
+			AutomaticSnapshotJob:      automaticSnapshotJob,
 		}
 		// Preserve an explicit capture target across the pending-to-Ready handoff.
 		if alphaCheckpointConfig.TargetContainerName != "" {
 			info.RestoreTargetContainers = []string{alphaCheckpointConfig.TargetContainerName}
 		}
 	} else {
-		workerHash := dynamo.GetDCDEffectiveWorkerHash(dcd)
-		var expectedWorkerHash *string
-		if dynamo.IsWorkerComponent(string(component.ComponentType)) {
-			expectedWorkerHash = &workerHash
-		}
 		info, err = checkpoint.ResolvePodSnapshotForService(
 			ctx,
 			r.reader,
 			dcd.Namespace,
 			alphaCheckpointConfig,
-			expectedWorkerHash,
+			expectedCompatibilityHash,
 			podSnapshotUseForDCD(dcd, automaticSnapshotJob),
 		)
 		if err != nil {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8741,10 +8741,11 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 
 	infoByService := map[string]*checkpoint.CheckpointInfo{
 		"decode": {
-			Enabled:        true,
-			Exists:         true,
-			Ready:          true,
-			CheckpointName: "decode-checkpoint",
+			Enabled:                   true,
+			Exists:                    true,
+			Ready:                     true,
+			CheckpointName:            "decode-checkpoint",
+			SnapshotCompatibilityHash: "compatibility-v1",
 			NativeSnapshot: &checkpoint.ResolvedPodSnapshot{
 				UID:                  "snapshot-uid",
 				BoundContentName:     "snapshot-content",
@@ -8838,11 +8839,12 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 
 	infoByService := map[string]*checkpoint.CheckpointInfo{
 		"decode": {
-			Enabled:                 true,
-			Exists:                  true,
-			Ready:                   true,
-			CheckpointName:          "decode-checkpoint",
-			RestoreTargetContainers: IntraPodFailoverEngineContainerNames(),
+			Enabled:                   true,
+			Exists:                    true,
+			Ready:                     true,
+			CheckpointName:            "decode-checkpoint",
+			SnapshotCompatibilityHash: "compatibility-v1",
+			RestoreTargetContainers:   IntraPodFailoverEngineContainerNames(),
 			NativeSnapshot: &checkpoint.ResolvedPodSnapshot{
 				UID:                  "snapshot-uid",
 				BoundContentName:     "snapshot-content",

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 )
@@ -166,7 +165,7 @@ func (h *PodCheckpointRestoreMutator) buildPinnedPodSnapshotRestorePod(
 		h.apiReader,
 		podNamespace,
 		config,
-		expectedWorkerHashForPod(pod),
+		expectedSnapshotCompatibilityHashForPod(pod),
 		checkpoint.ExplicitPodSnapshotUse(),
 	)
 	if err != nil {
@@ -239,7 +238,7 @@ func (h *PodCheckpointRestoreMutator) buildAutomaticSnapshotJobRestorePod(
 		h.apiReader,
 		podNamespace,
 		config,
-		expectedWorkerHashForPod(pod),
+		expectedSnapshotCompatibilityHashForPod(pod),
 		checkpoint.ManagedPodSnapshotUse(ownerUID),
 	)
 	if apierrors.IsNotFound(err) {
@@ -269,12 +268,8 @@ func automaticCandidateUnavailable(
 	return nil, false, fmt.Errorf("automatic restore candidate unavailable: %s", reason)
 }
 
-func expectedWorkerHashForPod(pod *corev1.Pod) *string {
-	if !dynamo.IsWorkerComponent(pod.Labels[consts.KubeLabelDynamoComponentType]) {
-		return nil
-	}
-	workerHash := pod.Labels[consts.KubeLabelDynamoWorkerHash]
-	return &workerHash
+func expectedSnapshotCompatibilityHashForPod(pod *corev1.Pod) string {
+	return pod.Annotations[consts.SnapshotCandidateCompatibilityHashAnnotation]
 }
 
 func (h *PodCheckpointRestoreMutator) shapeNativeRestorePod(
@@ -334,6 +329,9 @@ func validateNativeSnapshotCandidate(annotations map[string]string, resolved *ch
 	}
 	if annotations[consts.SnapshotCandidateVersionAnnotation] != resolved.CompatibilityVersion {
 		return fmt.Errorf("PodSnapshot compatibility version changed after workload reconciliation")
+	}
+	if annotations[consts.SnapshotCandidateCompatibilityHashAnnotation] != resolved.CompatibilityHash {
+		return fmt.Errorf("PodSnapshot compatibility hash changed after workload reconciliation")
 	}
 	if annotations[consts.SnapshotCandidateGMSModeAnnotation] != resolved.GMSMode {
 		return fmt.Errorf("PodSnapshot GMS mode changed after workload reconciliation")
@@ -447,5 +445,6 @@ func removeRestoreCandidateAnnotations(annotations map[string]string) {
 	delete(annotations, consts.SnapshotCandidateContentAnnotation)
 	delete(annotations, consts.SnapshotCandidateGMSModeAnnotation)
 	delete(annotations, consts.SnapshotCandidateVersionAnnotation)
+	delete(annotations, consts.SnapshotCandidateCompatibilityHashAnnotation)
 	delete(annotations, consts.RestoreCandidateTargetContainersAnnotation)
 }

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
@@ -330,9 +330,6 @@ func validateNativeSnapshotCandidate(annotations map[string]string, resolved *ch
 	if annotations[consts.SnapshotCandidateVersionAnnotation] != resolved.CompatibilityVersion {
 		return fmt.Errorf("PodSnapshot compatibility version changed after workload reconciliation")
 	}
-	if annotations[consts.SnapshotCandidateCompatibilityHashAnnotation] != resolved.CompatibilityHash {
-		return fmt.Errorf("PodSnapshot compatibility hash changed after workload reconciliation")
-	}
 	if annotations[consts.SnapshotCandidateGMSModeAnnotation] != resolved.GMSMode {
 		return fmt.Errorf("PodSnapshot GMS mode changed after workload reconciliation")
 	}

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
@@ -128,9 +128,9 @@ func TestPodCheckpointRestoreMutatorNativeRestore(t *testing.T) {
 				wantErr: "UID changed",
 			},
 			{
-				name: "worker generation mismatch",
+				name: "snapshot compatibility mismatch",
 				mutate: func(pod *corev1.Pod) {
-					pod.Labels[consts.KubeLabelDynamoWorkerHash] = "worker-v2"
+					pod.Annotations[consts.SnapshotCandidateCompatibilityHashAnnotation] = "compatibility-v2"
 				},
 				wantErr: "does not match expected hash",
 			},
@@ -246,6 +246,7 @@ func TestPodCheckpointRestoreMutatorAutomaticSnapshotJob(t *testing.T) {
 		assert.Equal(t, snapshot.Name, shaped.Annotations[podcontract.RestoreFromAnnotation])
 		assert.NotContains(t, shaped.Annotations, consts.RestoreCandidateSourceKindAnnotation)
 		assert.NotContains(t, shaped.Annotations, consts.SnapshotJobCandidateUIDAnnotation)
+		assert.NotContains(t, shaped.Annotations, consts.SnapshotCandidateCompatibilityHashAnnotation)
 	})
 
 	t.Run("recreated SnapshotJob never restores through the stale candidate", func(t *testing.T) {
@@ -405,7 +406,7 @@ func nativeRestoreTestSnapshot() *snapshotv1alpha1.PodSnapshot {
 			UID:       types.UID("snapshot-uid"),
 			Annotations: map[string]string{
 				consts.SnapshotCompatibilityVersionAnnotation: consts.SnapshotCompatibilityVersion,
-				consts.SnapshotWorkerHashAnnotation:           "worker-v1",
+				consts.SnapshotCompatibilityHashAnnotation:    "compatibility-v1",
 				consts.SnapshotGMSModeAnnotation:              consts.SnapshotGMSModeDisabled,
 			},
 		},
@@ -440,14 +441,15 @@ func nativeRestoreCandidatePod(snapshot *snapshotv1alpha1.PodSnapshot) *corev1.P
 				consts.KubeLabelDynamoWorkerHash:    "worker-v1",
 			},
 			Annotations: map[string]string{
-				consts.CheckpointRestoreCandidateAnnotation:       consts.KubeLabelValueTrue,
-				consts.CheckpointNameAnnotation:                   snapshot.Name,
-				consts.RestoreCandidateSourceKindAnnotation:       consts.RestoreCandidateSourcePodSnapshot,
-				consts.SnapshotCandidateUIDAnnotation:             string(snapshot.UID),
-				consts.SnapshotCandidateContentAnnotation:         "content-a",
-				consts.SnapshotCandidateGMSModeAnnotation:         consts.SnapshotGMSModeDisabled,
-				consts.SnapshotCandidateVersionAnnotation:         consts.SnapshotCompatibilityVersion,
-				consts.RestoreCandidateTargetContainersAnnotation: "engine-0,engine-1",
+				consts.CheckpointRestoreCandidateAnnotation:         consts.KubeLabelValueTrue,
+				consts.CheckpointNameAnnotation:                     snapshot.Name,
+				consts.RestoreCandidateSourceKindAnnotation:         consts.RestoreCandidateSourcePodSnapshot,
+				consts.SnapshotCandidateUIDAnnotation:               string(snapshot.UID),
+				consts.SnapshotCandidateContentAnnotation:           "content-a",
+				consts.SnapshotCandidateGMSModeAnnotation:           consts.SnapshotGMSModeDisabled,
+				consts.SnapshotCandidateVersionAnnotation:           consts.SnapshotCompatibilityVersion,
+				consts.SnapshotCandidateCompatibilityHashAnnotation: "compatibility-v1",
+				consts.RestoreCandidateTargetContainersAnnotation:   "engine-0,engine-1",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -300,6 +300,19 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{"spec.experimental.checkpoint: Forbidden: checkpoint functionality is disabled in the operator configuration"},
 		},
 		{
+			name: "standalone non-worker checkpoint is rejected at admission",
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.ComponentType = nvidiacomv1beta1.ComponentTypeFrontend
+				dcd.Spec.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{
+						Enabled:       true,
+						CheckpointRef: k8sptr.To("frontend-snapshot"),
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.checkpoint: Forbidden: checkpoint functionality is supported only for worker, prefill, and decode components"},
+		},
+		{
 			name: "v1beta1 standalone worker checkpointRef is rejected",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.Experimental = &nvidiacomv1beta1.ExperimentalSpec{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1101,6 +1101,18 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "non-worker checkpoint is rejected at admission",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				frontend := dgd.GetComponentByName("frontend")
+				frontend.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+				}
+			}),
+			wantWebhookErrs: []string{
+				"spec.components[0].experimental.checkpoint: Forbidden: checkpoint functionality is supported only for worker, prefill, and decode components",
+			},
+		},
+		{
 			name:          "checkpoint configuration requires operator feature gate",
 			checkpointOff: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -29,6 +29,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/provideroverride"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -423,6 +424,37 @@ func TestValidateComponentCheckpointJobConfigFieldPaths(t *testing.T) {
 		nil,
 	)
 	assertFieldPaths(t, errs, nil)
+}
+
+func TestValidateComponentCheckpointConfigRejectsNonWorkers(t *testing.T) {
+	validation := &sharedValidation{
+		ctx: features.WithGate(context.Background(), features.Gates{Checkpoint: true}),
+	}
+	checkpointPath := field.NewPath("spec", "components").Index(0).Child("experimental", "checkpoint")
+
+	errList := validation.validateComponentCheckpointConfig(
+		&nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+		checkpointPath,
+		nil,
+		nvidiacomv1beta1.ComponentTypeFrontend,
+	)
+	assertFieldPaths(t, errList, []string{"spec.components[0].experimental.checkpoint"})
+
+	errList = validation.validateComponentCheckpointConfig(
+		&nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+		checkpointPath,
+		nil,
+		nvidiacomv1beta1.ComponentTypeWorker,
+	)
+	assertFieldPaths(t, errList, nil)
+
+	errList = validation.validateComponentCheckpointConfig(
+		&nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: false},
+		checkpointPath,
+		nil,
+		nvidiacomv1beta1.ComponentTypeFrontend,
+	)
+	assertFieldPaths(t, errList, nil)
 }
 
 func TestValidateDynamoComponentDeploymentSharedSpecV1alpha1FrontendSidecarFieldPaths(t *testing.T) {

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -426,7 +426,7 @@ func TestValidateComponentCheckpointJobConfigFieldPaths(t *testing.T) {
 	assertFieldPaths(t, errs, nil)
 }
 
-func TestValidateComponentCheckpointConfigRejectsNonWorkers(t *testing.T) {
+func TestValidateComponentCheckpointConfigRequiresWorkerType(t *testing.T) {
 	validation := &sharedValidation{
 		ctx: features.WithGate(context.Background(), features.Gates{Checkpoint: true}),
 	}
@@ -439,6 +439,20 @@ func TestValidateComponentCheckpointConfigRejectsNonWorkers(t *testing.T) {
 		nvidiacomv1beta1.ComponentTypeFrontend,
 	)
 	assertFieldPaths(t, errList, []string{"spec.components[0].experimental.checkpoint"})
+	if len(errList) != 1 || !strings.Contains(errList[0].Detail, "supported only for worker, prefill, and decode") {
+		t.Fatalf("expected one unsupported component type error, got %v", errList)
+	}
+
+	errList = validation.validateComponentCheckpointConfig(
+		&nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+		checkpointPath,
+		nil,
+		"",
+	)
+	assertFieldPaths(t, errList, []string{"spec.components[0].experimental.checkpoint"})
+	if len(errList) != 1 || !strings.Contains(errList[0].Detail, "requires component type to be explicitly set") {
+		t.Fatalf("expected one missing component type error, got %v", errList)
+	}
 
 	errList = validation.validateComponentCheckpointConfig(
 		&nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -665,7 +665,12 @@ func (v *sharedValidation) validateComponentCheckpointConfig(
 	if checkpointConfig.Enabled && !features.MustGateFrom(v.ctx).Enabled(features.Checkpoint) {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "checkpoint functionality is disabled in the operator configuration"))
 	}
-	if checkpointConfig.Enabled && !dynamo.IsWorkerComponent(string(componentType)) {
+	if checkpointConfig.Enabled && componentType == "" {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath,
+			"checkpoint functionality requires component type to be explicitly set to worker, prefill, or decode",
+		))
+	} else if checkpointConfig.Enabled && !dynamo.IsWorkerComponent(string(componentType)) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,
 			"checkpoint functionality is supported only for worker, prefill, and decode components",

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -515,6 +515,7 @@ func (v *sharedValidation) validateExperimentalSpec(
 			experimental.Checkpoint,
 			fldPath.Child("checkpoint"),
 			experimental.GPUMemoryService,
+			options.componentType,
 		)...)
 	}
 
@@ -658,10 +659,17 @@ func (v *sharedValidation) validateComponentCheckpointConfig(
 	checkpointConfig *nvidiacomv1beta1.ComponentCheckpointConfig,
 	fldPath *field.Path,
 	gms *nvidiacomv1beta1.GPUMemoryServiceSpec,
+	componentType nvidiacomv1beta1.ComponentType,
 ) field.ErrorList {
 	var allErrs field.ErrorList
 	if checkpointConfig.Enabled && !features.MustGateFrom(v.ctx).Enabled(features.Checkpoint) {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "checkpoint functionality is disabled in the operator configuration"))
+	}
+	if checkpointConfig.Enabled && !dynamo.IsWorkerComponent(string(componentType)) {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath,
+			"checkpoint functionality is supported only for worker, prefill, and decode components",
+		))
 	}
 	if checkpointConfig.Job == nil {
 		return allErrs


### PR DESCRIPTION
## Overview

Dynamo used the worker rollout-generation hash as a restore-compatibility identity. That hash intentionally includes graph and checkpoint lifecycle identity, so an equivalent worker in another DynamoGraphDeployment could not reuse the snapshot.

## Summary

- replace the worker rollout hash in the Snapshot compatibility contract with an independent full SHA-256 fingerprint of the rendered capture target
- version the new incompatible compatibility contract as `v2`
- carry that fingerprint through DGD/DCD reconciliation, Pod metadata pinning, and restore admission
- exclude destination identity and restore-rebound environment while retaining process-sensitive configuration, mounted-volume identity, accelerator placement, and DRA claims
- keep the rollout hash unchanged as the automatic SnapshotJob generation key, and include the compatibility version so contract upgrades create a fresh immutable job
- reject checkpointing on non-worker component types at admission instead of failing later during reconciliation
- add regression coverage for cross-DGD reuse, environment ordering, placement/claims, PVC identity, and Go/Python restore-environment drift

## Details

The compatibility contract is scoped to the captured target container and its restore-relevant Pod context. It excludes graph identity and helper-only sidecars, but includes the target image, command/args, ordered non-restored environment, resources, init containers, referenced volumes (including PVC claim names), Pod security/runtime settings, backend, GMS mode, node selection, node affinity, scheduler, and Pod resource claims. Explicit `podTemplate.spec.nodeName` pinning is retained; a scheduler-assigned node is not present in the template and is never hashed. Map-like Pod and container resource-claim lists are canonicalized before hashing.

`ComputeDGDWorkersSpecHash` and the ordinary workload-rendering path are unchanged. DGDs without an enabled checkpoint configuration do not compute or validate this fingerprint and are not rolled by this change.

Checkpointing is explicitly limited to worker, prefill, and decode components. Automatic capture already required a worker backend; admission now rejects the previously half-supported non-worker path with a clear error. An enabled checkpoint with an omitted component type is rejected with a dedicated diagnostic rather than being reported as an unsupported non-worker type.

### Snapshot compatibility reset

This change intentionally does not accept snapshot metadata created before the new compatibility contract.

- Existing `v1` PodSnapshots that contain only `nvidia.com/dynamo-snapshot-worker-hash` must be recaptured.
- Existing automatic `v1` captures are not reused: the compatibility version is part of the SnapshotJob identity, so reconciliation creates a fresh `v2` job and converges on its replacement snapshot without deleting the legacy resources.
- New and hand-authored SnapshotJob/PodSnapshot producers must emit `nvidia.com/dynamo-snapshot-compatibility-version: v2` and `nvidia.com/dynamo-snapshot-compatibility-hash` using the new contract.
- The controller and admission webhook should run the same version for checkpoint-enabled workload reconciliation.
- Non-snapshot DGDs and Pods are unaffected.

A compatibility mismatch now names the contract categories to inspect, including PVC claim names and accelerator placement, rather than presenting two hashes without guidance.

### Known limitation: mutable image tags

The `v2` operator fingerprint covers the image reference and pull policy declared in the Pod template, not the image digest resolved by the container runtime. If a mutable tag resolves to different image content between capture and restore, this operator-side hash cannot detect it. Checkpoint-enabled deployments should use digest-pinned images. Recording and validating the source container's runtime-resolved image digest is tracked by [ai-dynamo/snapshot#36](https://github.com/ai-dynamo/snapshot/issues/36).

## Where should the reviewer start?

- `deploy/operator/internal/checkpoint/compatibility.go` — compatibility contract and canonicalization
- `deploy/operator/internal/controller/dgd_checkpoints_reconciler.go` — capture and explicit-reference hash production
- `deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go` — DCD handoff
- `deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go` — admission-time revalidation
- `deploy/operator/internal/webhook/validation/shared_v1beta1.go` — worker-only checkpoint validation

## Validation

- `go test ./internal/checkpoint ./internal/webhook/mutation ./internal/webhook/validation ./internal/controller ./internal/dynamo -count=1`
- `go test ./internal/... -run '^$' -count=1`
- `go vet ./internal/checkpoint ./internal/webhook/mutation ./internal/webhook/validation ./internal/controller ./internal/dynamo`
- `golangci-lint run --timeout=5m`
- targeted admission envtests with Kubernetes 1.30 envtest assets

## Related Issues

- Closes #14287
- Supersedes #14304
- Fixes DYN-4413
