### PR TITLE
fix(operator): separate checkpoint compatibility hash from worker rollout hash

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -116,15 +116,25 @@ func (r *dgdCheckpointsReconciler) Reconcile(
 			startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
 		}
 
-		// Derive the compatibility identity expected by captured and restored workers.
+		// Derive the active worker generation, which names the capture and gates
+		// it until Grove has committed a generation.
 		workerHash, err := checkpointWorkerHashForComponent(dgd, componentName)
 		if err != nil {
 			return dgdCheckpointsResult{}, fmt.Errorf("failed to compute checkpoint worker hash for component %s: %w", componentName, err)
 		}
+
+		// Derive the restore compatibility identity, which is scoped to this
+		// component and independent of the owning graph and of the checkpoint
+		// selection fields.
 		workerComponent := dynamo.IsWorkerComponent(string(component.ComponentType))
 		var expectedWorkerHash *string
+		var compatHash string
 		if workerComponent {
-			expectedWorkerHash = &workerHash
+			compatHash, err = dynamo.ComputeDGDWorkerCheckpointCompatHash(dgd, componentName)
+			if err != nil {
+				return dgdCheckpointsResult{}, fmt.Errorf("failed to compute checkpoint compatibility hash for component %s: %w", componentName, err)
+			}
+			expectedWorkerHash = &compatHash
 		}
 
 		var info *checkpoint.CheckpointInfo
@@ -152,6 +162,7 @@ func (r *dgdCheckpointsReconciler) Reconcile(
 				componentName,
 				component,
 				workerHash,
+				compatHash,
 				startupPolicy,
 			)
 		} else {
@@ -212,6 +223,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 	componentName string,
 	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	workerHash string,
+	compatHash string,
 	startupPolicy nvidiacomv1alpha1.CheckpointStartupPolicy,
 ) (*checkpoint.CheckpointInfo, error) {
 	checkpointConfig := dynamo.GetCheckpoint(component)
@@ -319,6 +331,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 		componentName,
 		checkpointID,
 		workerHash,
+		compatHash,
 		podTemplate,
 		targetContainerName,
 		deletionPolicy,
@@ -344,7 +357,7 @@ func (r *dgdCheckpointsReconciler) reconcileAutomaticSnapshotJob(
 
 	var expectedWorkerHash *string
 	if dynamo.IsWorkerComponent(string(component.ComponentType)) {
-		expectedWorkerHash = &workerHash
+		expectedWorkerHash = &compatHash
 	}
 	return r.resolveAutomaticSnapshotJob(
 		ctx,
@@ -362,6 +375,7 @@ func buildAutomaticSnapshotJob(
 	componentName string,
 	checkpointID string,
 	workerHash string,
+	compatHash string,
 	podTemplate corev1.PodTemplateSpec,
 	targetContainerName string,
 	deletionPolicy nvidiacomv1alpha1.CheckpointDeletionPolicy,
@@ -392,7 +406,7 @@ func buildAutomaticSnapshotJob(
 		consts.CheckpointDeletionPolicyAnnotation:     string(deletionPolicy),
 		consts.CheckpointOwnerUIDAnnotation:           string(dgd.UID),
 		consts.SnapshotCompatibilityVersionAnnotation: consts.SnapshotCompatibilityVersion,
-		consts.SnapshotWorkerHashAnnotation:           workerHash,
+		consts.SnapshotWorkerHashAnnotation:           compatHash,
 		consts.SnapshotGMSModeAnnotation:              gmsMode,
 	}
 

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -106,12 +106,24 @@ func reconcileAutomaticSnapshotJobForTest(
 	t.Helper()
 	workerHash, err := checkpointWorkerHashForComponent(dgd, componentName)
 	require.NoError(t, err)
+
+	// Reconcile always derives the compatibility identity from a component
+	// declared on the DGD. These fixtures supply it alongside, so mirror it in.
+	compatSource := dgd.DeepCopy()
+	if compatSource.GetComponentByName(componentName) == nil {
+		declared := *component.DeepCopy()
+		declared.ComponentName = componentName
+		compatSource.Spec.Components = append(compatSource.Spec.Components, declared)
+	}
+	compatHash, err := dynamo.ComputeDGDWorkerCheckpointCompatHash(compatSource, componentName)
+	require.NoError(t, err)
 	_, err = newTestDGDCheckpointsReconciler(reconciler).reconcileAutomaticSnapshotJob(
 		context.Background(),
 		dgd,
 		componentName,
 		component,
 		workerHash,
+		compatHash,
 		v1alpha1.CheckpointStartupPolicyImmediate,
 	)
 	require.NoError(t, err)
@@ -629,8 +641,8 @@ func TestDGDCheckpointsReconciler_ExplicitRestoreWaitsForActiveWorkerHash(t *tes
 	_, err = newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
 	require.ErrorContains(t, err, "get referenced PodSnapshot")
 
-	t.Log("Create the compatible referenced PodSnapshot")
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	t.Log("Create the referenced PodSnapshot carrying the restore compatibility identity")
+	referenced := dgdTestPodSnapshot(ref, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	require.NoError(t, reconciler.Create(ctx, referenced))
 
 	t.Log("Verify the same explicit reference resolves once compatibility identity is available")
@@ -841,6 +853,7 @@ func TestDGDCheckpointsReconciler_SyncsExistingAutoLifecycle(t *testing.T) {
 		"worker",
 		"capture-id",
 		"worker-hash",
+		"compat-hash",
 		corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
 			Name:  commonconsts.MainContainerName,
 			Image: "main:latest",
@@ -911,10 +924,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefSkipsAutoCreateWhilePodSnapshotIs
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	require.NotEmpty(t, workerHash)
-	referenced := dgdTestPodSnapshot(ref, workerHash, false)
+	referenced := dgdTestPodSnapshot(ref, betaDGDCheckpointCompatHash(t, dgd, "worker"), false)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -986,10 +996,7 @@ func TestDGDCheckpointsReconciler_CheckpointRefUsesReadyPodSnapshot(t *testing.T
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	require.NotEmpty(t, workerHash)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(testScheme).
@@ -1074,9 +1081,7 @@ func TestDGDCheckpointsReconciler_OverlaysServiceGMSLoader(t *testing.T) {
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	referenced.Annotations[commonconsts.SnapshotGMSModeAnnotation] = string(v1alpha1.GMSModeIntraPod)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:   fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
@@ -1141,9 +1146,7 @@ func TestDGDCheckpointsReconciler_RejectsServiceGMSWithNonGMSCheckpoint(t *testi
 	dgd.Annotations = map[string]string{
 		commonconsts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(ref, workerHash, true)
+	referenced := dgdTestPodSnapshot(ref, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        fake.NewClientBuilder().WithScheme(testScheme).WithObjects(referenced).Build(),
 		Config:        &configv1alpha1.OperatorConfiguration{},
@@ -1152,7 +1155,7 @@ func TestDGDCheckpointsReconciler_RejectsServiceGMSWithNonGMSCheckpoint(t *testi
 	}
 
 	t.Log("Reconcile the incompatible checkpoint reference")
-	_, err = newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
+	_, err := newTestDGDCheckpointsReconciler(reconciler).Reconcile(ctx, dgd)
 
 	t.Log("Verify the incompatibility is returned with checkpoint context")
 	require.Error(t, err)
@@ -1207,9 +1210,7 @@ func TestDGDCheckpointsReconciler_AutomaticRestoreWaitsForSnapshotJobCompletion(
 	job := jobs.Items[0].DeepCopy()
 	// controller-runtime's fake client does not assign API-server UIDs.
 	job.UID = types.UID("snapshot-job-uid")
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	snapshot := dgdTestPodSnapshot(job.Name, workerHash, true)
+	snapshot := dgdTestPodSnapshot(job.Name, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	snapshot.Labels = map[string]string{
 		snapshotv1alpha1.SnapshotJobOwnerLabel:    job.Name,
 		snapshotv1alpha1.SnapshotJobOwnerUIDLabel: string(job.UID),

--- a/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_shared_resources_reconciler_test.go
@@ -114,9 +114,7 @@ func TestDGDSharedResourcesReconciler_PreservesCheckpointResultOnLaterFailure(t 
 	dgd.Annotations = map[string]string{
 		consts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
 	}
-	workerHash, err := checkpointWorkerHashForComponent(dgd, "worker")
-	require.NoError(t, err)
-	referenced := dgdTestPodSnapshot(reference, workerHash, true)
+	referenced := dgdTestPodSnapshot(reference, betaDGDCheckpointCompatHash(t, dgd, "worker"), true)
 	s := newDynamoGraphDeploymentControllerTestScheme(t)
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(s).

--- a/deploy/operator/internal/controller/test_beta_helpers_test.go
+++ b/deploy/operator/internal/controller/test_beta_helpers_test.go
@@ -86,6 +86,15 @@ func betaDGDWorkersSpecHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment) st
 	return hash
 }
 
+func betaDGDCheckpointCompatHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment, componentName string) string {
+	t.Helper()
+	hash, err := dynamo.ComputeDGDWorkerCheckpointCompatHash(dgd, componentName)
+	if err != nil {
+		t.Fatalf("compute v1beta1 DGD checkpoint compatibility hash: %v", err)
+	}
+	return hash
+}
+
 func legacyDGDWorkersSpecHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment) string {
 	t.Helper()
 	alpha := &v1alpha1.DynamoGraphDeployment{}

--- a/deploy/operator/internal/dynamo/checkpoint_hash.go
+++ b/deploy/operator/internal/dynamo/checkpoint_hash.go
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+)
+
+// ComputeDGDWorkerCheckpointCompatHash computes the checkpoint compatibility
+// hash for one worker component of dgd, which must be non-nil and must declare
+// componentName as a worker.
+//
+// This answers a different question from ComputeDGDWorkersSpecHash. That hash
+// identifies a worker *generation* within one DGD and drives managed rollout.
+// This one identifies a worker *shape*: whether a PodSnapshot captured from one
+// worker can be restored into another. The two differ on three points, each of
+// which makes the rollout hash unusable as a restore-compatibility token:
+//
+//   - Scope. The rollout hash covers every worker component at once, so editing
+//     a prefill worker would invalidate a decode worker's checkpoint. This hash
+//     covers the one component being restored.
+//   - Graph identity. The rollout hash carries the owning DGD's name, so a
+//     checkpoint captured by one DGD could never be restored into another,
+//     however identically configured.
+//   - Checkpoint selection. The rollout hash carries checkpointRef, which is
+//     necessarily empty at capture time and set at restore time, so an explicit
+//     reference could never match the value recorded at capture.
+//
+// Keeping this separate leaves ComputeDGDWorkersSpecHash byte-identical, so
+// deployments that do not use checkpointing are not rolled by an operator
+// upgrade.
+func ComputeDGDWorkerCheckpointCompatHash(dgd *v1beta1.DynamoGraphDeployment, componentName string) (string, error) {
+	dcds, err := GenerateDynamoComponentsDeployments(
+		dgd,
+		nil,
+		nil,
+		RollingUpdateContext{NewWorkerHash: dgdWorkerHashPlaceholderValue},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	for _, dcd := range dcds {
+		if dcd == nil || GetDCDComponentName(dcd) != componentName {
+			continue
+		}
+		if !IsWorkerComponent(string(dcd.Spec.ComponentType)) {
+			return "", fmt.Errorf("component %q is not a worker component", componentName)
+		}
+
+		spec := workerHashSpec(dcd)
+		canonicalizeCheckpointForCompatHash(spec.Experimental)
+		data, err := json.Marshal(struct {
+			Labels         map[string]string                     `json:"labels,omitempty"`
+			Annotations    map[string]string                     `json:"annotations,omitempty"`
+			RuntimeVersion string                                `json:"runtimeVersion,omitempty"`
+			Spec           v1beta1.DynamoComponentDeploymentSpec `json:"spec"`
+		}{
+			Labels:         canonicalizeGraphIdentityForCompatHash(dcd, GetDCDKubeLabels(dcd)),
+			Annotations:    GetDCDKubeAnnotations(dcd),
+			RuntimeVersion: resolvedRuntimeVersionForHash(&dcd.Spec.DynamoComponentDeploymentSharedSpec),
+			Spec:           spec,
+		})
+		if err != nil {
+			return "", fmt.Errorf("marshal generated worker DCD %q: %w", componentName, err)
+		}
+
+		hash := sha256.Sum256(data)
+		return hex.EncodeToString(hash[:])[:8], nil
+	}
+
+	return "", fmt.Errorf("no generated DCD for component %q", componentName)
+}
+
+// canonicalizeCheckpointForCompatHash removes the checkpoint fields that select
+// a PodSnapshot or govern its lifecycle from the spec copy returned by
+// workerHashSpec.
+//
+// checkpointRef is the field that makes explicit reuse impossible: the worker
+// that captured a checkpoint could not have referenced its own not-yet-existing
+// PodSnapshot. deletionPolicy has the same defect — retaining a checkpoint past
+// its producing DGD is exactly what a later consumer needs, yet the consumer
+// has no reason to repeat the producer's Retain. startupPolicy only gates the
+// replica count, which workerHashSpec already excludes.
+//
+// enabled, targetContainerName, and job all stay: they describe how the worker
+// Pod is rendered, which container is captured, and what the capture Pod ran.
+func canonicalizeCheckpointForCompatHash(experimental *v1beta1.ExperimentalSpec) {
+	if experimental == nil || experimental.Checkpoint == nil {
+		return
+	}
+	checkpoint := experimental.Checkpoint
+
+	checkpoint.CheckpointRef = nil
+	checkpoint.Identity = nil
+	checkpoint.Mode = ""
+	checkpoint.StartupPolicy = ""
+	checkpoint.DeletionPolicy = ""
+}
+
+// canonicalizeGraphIdentityForCompatHash removes the owning DGD's name from the
+// labels rendered for dcd, where it otherwise appears twice: directly, and as
+// the second segment of the Dynamo namespace.
+//
+// The Kubernetes namespace stays. A checkpointRef resolves a PodSnapshot in the
+// consumer's own namespace, so dropping it would widen compatibility without
+// enabling any supported reuse. globalDynamoNamespace remains part of the hash
+// through its effect on this label.
+//
+// Removing the name narrows what the hash covers: getCommonContainer injects
+// DYN_NAMESPACE and DYN_PARENT_DGD_K8S_NAME downstream of the DCD spec, so two
+// workers that share this hash still render Pods differing in those values.
+func canonicalizeGraphIdentityForCompatHash(dcd *v1beta1.DynamoComponentDeployment, labels map[string]string) map[string]string {
+	delete(labels, commonconsts.KubeLabelDynamoGraphDeploymentName)
+	if _, ok := labels[commonconsts.KubeLabelDynamoNamespace]; ok {
+		labels[commonconsts.KubeLabelDynamoNamespace] = v1beta1.ComputeDynamoNamespace(
+			dcd.Spec.GlobalDynamoNamespace,
+			dcd.GetNamespace(),
+			"",
+		)
+	}
+	return labels
+}

--- a/deploy/operator/internal/dynamo/checkpoint_hash_test.go
+++ b/deploy/operator/internal/dynamo/checkpoint_hash_test.go
@@ -1,0 +1,222 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamo
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// checkpointDGD builds a single-worker DGD named name whose worker carries an
+// enabled checkpoint block, mutated by mutate when supplied.
+func checkpointDGD(t testing.TB, name string, mutate func(*v1beta1.ComponentCheckpointConfig)) *v1beta1.DynamoGraphDeployment {
+	t.Helper()
+	src := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+		"decode": {ComponentType: commonconsts.ComponentTypeDecode},
+	})
+	src.Name = name
+	dgd := betaDGD(t, src)
+
+	checkpoint := &v1beta1.ComponentCheckpointConfig{
+		Enabled:             true,
+		TargetContainerName: commonconsts.MainContainerName,
+		StartupPolicy:       v1beta1.CheckpointStartupPolicyImmediate,
+		DeletionPolicy:      v1beta1.CheckpointDeletionPolicyDelete,
+	}
+	if mutate != nil {
+		mutate(checkpoint)
+	}
+	dgd.Spec.Components[0].Experimental = &v1beta1.ExperimentalSpec{Checkpoint: checkpoint}
+
+	return dgd
+}
+
+func mustComputeCheckpointCompatHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment, componentName string) string {
+	t.Helper()
+	hash, err := ComputeDGDWorkerCheckpointCompatHash(dgd, componentName)
+	require.NoError(t, err)
+	return hash
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_ReportedScenario(t *testing.T) {
+	t.Log("Build the probe DGD that captures an automatic checkpoint and retains it")
+	probe := mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", func(c *v1beta1.ComponentCheckpointConfig) {
+		c.DeletionPolicy = v1beta1.CheckpointDeletionPolicyRetain
+	}), "decode")
+
+	t.Log("Build a separately named consumer DGD with a byte-identical worker restoring that PodSnapshot")
+	consumer := mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-consumer", func(c *v1beta1.ComponentCheckpointConfig) {
+		c.CheckpointRef = ptr.To("tc-standalone-snapjob")
+	}), "decode")
+
+	t.Log("Verify the consumer matches the compatibility identity recorded at capture")
+	assert.Equal(t, probe, consumer)
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_IgnoresNonRestoreFields(t *testing.T) {
+	baseline := mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", nil), "decode")
+
+	tests := map[string]func(*v1beta1.ComponentCheckpointConfig){
+		"checkpointRef":  func(c *v1beta1.ComponentCheckpointConfig) { c.CheckpointRef = ptr.To("other-snapjob") },
+		"deletionPolicy": func(c *v1beta1.ComponentCheckpointConfig) { c.DeletionPolicy = v1beta1.CheckpointDeletionPolicyRetain },
+		"startupPolicy": func(c *v1beta1.ComponentCheckpointConfig) {
+			c.StartupPolicy = v1beta1.CheckpointStartupPolicyWaitForCheckpoint
+		},
+		"mode": func(c *v1beta1.ComponentCheckpointConfig) { c.Mode = v1beta1.CheckpointModeManual },
+		"identity": func(c *v1beta1.ComponentCheckpointConfig) {
+			c.Identity = &v1beta1.DynamoCheckpointIdentity{Model: "Qwen/Qwen3-0.6B", BackendFramework: "vllm"}
+		},
+	}
+	for name, mutate := range tests {
+		assert.Equal(t, baseline, mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", mutate), "decode"), name)
+	}
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_TracksRestoreShape(t *testing.T) {
+	baseline := mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", nil), "decode")
+
+	tests := map[string]func(*v1beta1.ComponentCheckpointConfig){
+		"disabled":               func(c *v1beta1.ComponentCheckpointConfig) { c.Enabled = false },
+		"other target container": func(c *v1beta1.ComponentCheckpointConfig) { c.TargetContainerName = "sidecar" },
+		// The capture Pod determines what the produced PodSnapshot contains, so
+		// a snapshot taken under a different capture template is a different
+		// artifact even when the worker Pod is unchanged.
+		"capture job template": func(c *v1beta1.ComponentCheckpointConfig) {
+			c.Job = &v1beta1.ComponentCheckpointJobConfig{GMSClientContainers: []string{"gms-saver"}}
+		},
+	}
+	for name, mutate := range tests {
+		assert.NotEqual(t, baseline, mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", mutate), "decode"), name)
+	}
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_TracksWorkerPodShape(t *testing.T) {
+	baseline := mustComputeCheckpointCompatHash(t, checkpointDGD(t, "tc-probe", nil), "decode")
+
+	t.Log("Verify a different worker image is not a compatible restore target")
+	image := checkpointDGD(t, "tc-probe", nil)
+	image.Spec.Components[0].PodTemplate = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: commonconsts.MainContainerName, Image: "other:1.0"}},
+		},
+	}
+	assert.NotEqual(t, baseline, mustComputeCheckpointCompatHash(t, image, "decode"))
+
+	t.Log("Verify the Kubernetes namespace stays part of the identity, since a checkpointRef never crosses one")
+	namespace := checkpointDGD(t, "tc-probe", nil)
+	namespace.Namespace = "other"
+	assert.NotEqual(t, baseline, mustComputeCheckpointCompatHash(t, namespace, "decode"))
+
+	t.Log("Verify the user-settable Dynamo namespace input stays part of the identity")
+	global := checkpointDGD(t, "tc-probe", nil)
+	global.Spec.Components[0].GlobalDynamoNamespace = true
+	assert.NotEqual(t, baseline, mustComputeCheckpointCompatHash(t, global, "decode"))
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_IsScopedToOneComponent(t *testing.T) {
+	t.Log("Build a disaggregated DGD whose decode worker is checkpointed")
+	disagg := func() *v1beta1.DynamoGraphDeployment {
+		src := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+			"decode":  {ComponentType: commonconsts.ComponentTypeDecode},
+			"prefill": {ComponentType: commonconsts.ComponentTypePrefill},
+		})
+		src.Name = "tc-probe"
+		dgd := betaDGD(t, src)
+		for i := range dgd.Spec.Components {
+			if dgd.Spec.Components[i].ComponentName == "decode" {
+				dgd.Spec.Components[i].Experimental = &v1beta1.ExperimentalSpec{
+					Checkpoint: &v1beta1.ComponentCheckpointConfig{Enabled: true},
+				}
+			}
+		}
+		return dgd
+	}
+	baseline := mustComputeCheckpointCompatHash(t, disagg(), "decode")
+
+	t.Log("Verify editing the prefill worker does not invalidate the decode checkpoint")
+	changed := disagg()
+	for i := range changed.Spec.Components {
+		if changed.Spec.Components[i].ComponentName == "prefill" {
+			changed.Spec.Components[i].PodTemplate = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: commonconsts.MainContainerName, Image: "other:1.0"}},
+				},
+			}
+		}
+	}
+	assert.Equal(t, baseline, mustComputeCheckpointCompatHash(t, changed, "decode"))
+	assert.NotEqual(t, baseline, mustComputeCheckpointCompatHash(t, changed, "prefill"))
+}
+
+func TestComputeDGDWorkerCheckpointCompatHash_RejectsNonWorkerComponents(t *testing.T) {
+	dgd := betaDGD(t, baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+		"decode":   {ComponentType: commonconsts.ComponentTypeDecode},
+		"frontend": {ComponentType: commonconsts.ComponentTypeFrontend},
+	}))
+
+	_, err := ComputeDGDWorkerCheckpointCompatHash(dgd, "frontend")
+	assert.ErrorContains(t, err, "not a worker component")
+
+	_, err = ComputeDGDWorkerCheckpointCompatHash(dgd, "absent")
+	assert.ErrorContains(t, err, "no generated DCD")
+}
+
+// TestCheckpointCompatHashFieldsReviewed fails when ComponentCheckpointConfig
+// gains a field, forcing an explicit decision about whether it identifies a
+// restorable worker. Add it to canonicalizeCheckpointForCompatHash when it only
+// selects a PodSnapshot or governs checkpoint CR lifecycle; otherwise leave it
+// hashed.
+func TestCheckpointCompatHashFieldsReviewed(t *testing.T) {
+	reviewed := []string{
+		"Enabled", "Mode", "StartupPolicy", "DeletionPolicy",
+		"CheckpointRef", "Identity", "TargetContainerName", "Job",
+	}
+
+	configType := reflect.TypeOf(v1beta1.ComponentCheckpointConfig{})
+	actual := make([]string, 0, configType.NumField())
+	for i := range configType.NumField() {
+		actual = append(actual, configType.Field(i).Name)
+	}
+
+	assert.ElementsMatch(t, reviewed, actual,
+		"ComponentCheckpointConfig changed: decide whether each new field belongs in the checkpoint compatibility hash")
+}
+
+// TestComputeDGDWorkersSpecHash_UnaffectedByCheckpointCompatHash pins the
+// rollout hash against the compatibility hash's canonicalization. An
+// operator-only upgrade must not roll unchanged workloads, so these two must
+// stay independent.
+func TestComputeDGDWorkersSpecHash_UnaffectedByCheckpointCompatHash(t *testing.T) {
+	t.Log("Verify checkpoint selection still creates a worker generation in the rollout hash")
+	baseline := mustComputeBetaDGDWorkersSpecHash(t, checkpointDGD(t, "tc-probe", nil))
+	withRef := mustComputeBetaDGDWorkersSpecHash(t, checkpointDGD(t, "tc-probe", func(c *v1beta1.ComponentCheckpointConfig) {
+		c.CheckpointRef = ptr.To("tc-standalone-snapjob")
+	}))
+	assert.NotEqual(t, baseline, withRef)
+
+	t.Log("Verify graph identity still creates a worker generation in the rollout hash")
+	assert.NotEqual(t, baseline, mustComputeBetaDGDWorkersSpecHash(t, checkpointDGD(t, "tc-consumer", nil)))
+}


### PR DESCRIPTION
## Summary

A `PodSnapshot` produced by one DGD cannot be restored by another via an explicit `checkpointRef`, even when the consumer's worker pod spec is byte-identical to the producer's. The operator rejects it with `worker hash mismatch`, and the hashes genuinely differ.

The compatibility check reused `ComputeDGDWorkersSpecHash`, which identifies a *worker generation* for managed rollout. That value cannot express *restore compatibility*, for three independent reasons:

- It carries `experimental.checkpoint.checkpointRef`, which is necessarily empty when a checkpoint is captured and set when it is referenced — so an explicit reference can never match the value recorded at capture. `deletionPolicy` has the same defect: retaining a checkpoint past its producing DGD is exactly what a later consumer needs, yet the consumer has no reason to repeat the producer's `Retain`.
- It carries the owning DGD's name, both directly and as a segment of the Dynamo namespace, so a checkpoint captured by one DGD could never be restored into another however identically configured.
- It covers every worker component at once, so editing a prefill worker invalidated a decode worker's checkpoint.

This adds `ComputeDGDWorkerCheckpointCompatHash`, a per-component identity that omits graph identity and the checkpoint selection and lifecycle fields, while keeping everything that shapes the worker pod and the capture: `enabled`, `targetContainerName`, `job`, image, command, args, env, and resources. The Kubernetes namespace stays, since a `checkpointRef` only resolves a `PodSnapshot` in the consumer's own namespace.

It is used at the two places that mean restore compatibility: the worker-hash annotation written on a produced `PodSnapshot`, and the expected-hash comparison on the explicit and automatic paths. `DGDCheckpointID`, the `SnapshotJob` worker-hash label, and the committed-generation gate keep the rollout hash — they name a capture rather than validate one.

`ComputeDGDWorkersSpecHash` is byte-for-byte unchanged, so an operator upgrade does not roll workloads whose spec did not change.

## Validation

- `go build ./...`
- `go vet ./internal/... ./api/...`
- `go test ./internal/... ./api/...` — all pass, including the 68-spec envtest suite.

New tests in `checkpoint_hash_test.go` reproduce the reported producer/consumer scenario (`tc-probe` retains, differently named `tc-consumer` restores by `checkpointRef`, hashes match), cover the negative cases (image, k8s namespace, `globalDynamoNamespace`, `enabled`, `targetContainerName`, `job` all still change the hash), the per-component scoping, the error cases, a `ComponentCheckpointConfig` field-review guard, and a test pinning the rollout hash *against* this canonicalization so the two cannot be re-merged by accident.

The 19 golden worker-hash literals in `dynamographdeployment_controller_test.go` are untouched and still pass — that is the evidence that deployments without checkpointing are unaffected.

`pre-commit` is not installed in the environment this was developed in, so it has not been run; `gofmt` is clean.

## Behavior change

Existing `PodSnapshot`s carry the old annotation value and need recapture. Checkpointing is experimental and this lands alongside the snapshot migration, which is already breaking.

## Not addressed

`getCommonContainer` injects `DYN_NAMESPACE` and `DYN_PARENT_DGD_K8S_NAME` downstream of the DCD spec, so two workers that share this compatibility hash still render Pods differing in those values — a memory-image restore may carry the producer's Dynamo namespace into the consumer's process. This is documented on the function. The E2E for cross-DGD reuse should assert an actual completion through the consumer's frontend, not just `dgd Ready`, since that is the failure mode this change converts from a loud rejection into a silent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkpoint compatibility validation during automatic and explicit restores.
  - Snapshot validation now consistently recognizes compatible worker configurations, reducing incorrect restore failures.
  - Preserved worker-generation identity for checkpoint capture naming and labeling, preventing unrelated rollout changes from affecting restore compatibility.

- **Tests**
  - Expanded coverage for checkpoint compatibility across worker components, namespaces, restore configurations, and PodSnapshot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->