### PR TITLE
perf(vllm): isolate sidecar request shutdown waiters

### DIFF
--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -220,7 +220,7 @@ impl LLMEngine for VllmSidecarEngine {
         proto_request.model.clone_from(&self.model.served_name);
         let defer_request_cancellation = self.mode.is_decode();
         let stopped_ctx = ctx.inner_arc();
-        let shutdown = self.cancel.clone();
+        let shutdown = self.cancel.child_token();
         let mut request_cancellation = Box::pin(async move { stopped_ctx.stopped().await });
         let mut shutdown_cancellation = Box::pin(async move { shutdown.cancelled().await });
         let stream = if defer_request_cancellation {


### PR DESCRIPTION
## Summary

Give each vLLM gRPC generation request a child of the engine shutdown token. Concurrent streams then wait on separate cancellation state, reducing contention on the shared shutdown token while preserving shutdown propagation and request cancellation behavior.

In the Tyche AgentX comparison at 1,024 concurrent traces, sidecar CPU per output token fell 9.64%, and cancellation stacks fell from 26.2% to 1.66% of samples. Throughput stayed approximately unchanged because the mock/gRPC path limited the run. This measurement used the campaign base `58f1e01f76cbcf46a08963ffcab85c774da32a43`; this PR applies the same one-line change to current main.

## Validation

- `cargo test --locked -p dynamo-vllm-sidecar --lib`: 31 passed, including the existing request cancellation tests.
- `cargo fmt -p dynamo-vllm-sidecar -- --check` and `git diff --check` passed.
- No new tests or client-visible streaming changes.

## Related Issues

- [x] Confirmed — no related issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request cancellation handling so canceling one generation request does not affect other ongoing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->