### PR TITLE
perf(sglang): isolate sidecar request shutdown waiters

### DIFF
--- a/lib/mocker/servers/sglang/tests/sidecar.rs
+++ b/lib/mocker/servers/sglang/tests/sidecar.rs
@@ -268,3 +268,54 @@ async fn sidecar_abort_releases_mocker_work() {
     .expect("Abort should release scheduler work promptly");
     consumer.abort();
 }
+
+#[tokio::test]
+async fn request_cancellation_is_isolated_and_shutdown_reaches_grpc_streams() {
+    let server = RunningServer::start(ServerMode::Aggregated, fast_engine_args()).await;
+    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
+    engine.start(0).await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let first_context = dynamo_backend_common::testing::mock_context();
+        let mut streams = Vec::new();
+        for context in [
+            first_context.clone(),
+            dynamo_backend_common::testing::mock_context(),
+            dynamo_backend_common::testing::mock_context(),
+        ] {
+            let mut stream = engine
+                .generate(request(64), GenerateContext::new(context, None))
+                .await
+                .unwrap();
+            let first = stream.next().await.unwrap().unwrap();
+            assert!(!first.token_ids.is_empty());
+            assert!(first.finish_reason.is_none());
+            streams.push(stream);
+        }
+
+        first_context.stop_generating();
+        assert_eq!(
+            streams[0].next().await.unwrap().unwrap().finish_reason,
+            Some(FinishReason::Cancelled)
+        );
+        assert!(streams[0].next().await.is_none());
+        for stream in &mut streams[1..] {
+            let next = stream.next().await.unwrap().unwrap();
+            assert!(next.finish_reason.is_none());
+        }
+
+        engine.cleanup().await.unwrap();
+        for stream in &mut streams[1..] {
+            assert_eq!(
+                stream.next().await.unwrap().unwrap().finish_reason,
+                Some(FinishReason::Cancelled)
+            );
+            assert!(stream.next().await.is_none());
+        }
+        let late = collect(&engine, request(1)).await;
+        assert_eq!(late.len(), 1);
+        assert_eq!(late[0].finish_reason, Some(FinishReason::Cancelled));
+    })
+    .await
+    .expect("request cancellation and engine shutdown must finish promptly");
+}

--- a/lib/mocker/servers/sglang/tests/sidecar.rs
+++ b/lib/mocker/servers/sglang/tests/sidecar.rs
@@ -281,7 +281,6 @@ async fn request_cancellation_is_isolated_and_shutdown_reaches_grpc_streams() {
         for context in [
             first_context.clone(),
             dynamo_backend_common::testing::mock_context(),
-            dynamo_backend_common::testing::mock_context(),
         ] {
             let mut stream = engine
                 .generate(request(64), GenerateContext::new(context, None))

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -285,7 +285,7 @@ impl LLMEngine for SglangSidecarEngine {
         } else {
             None
         };
-        let cancel = self.cancel.clone();
+        let cancel = self.cancel.child_token();
         let is_prefill = self.disaggregation_mode.is_prefill();
 
         Ok(Box::pin(async_stream::stream! {


### PR DESCRIPTION
## Summary

Give each SGLang gRPC generation request a child of the engine shutdown token. This separates cancellation waiters across concurrent streams while preserving engine-wide shutdown propagation. The native HTTP path is unchanged.

Add one regression test using the existing mock gRPC server to check that cancelling one request leaves other requests running, engine shutdown cancels the remaining streams, and requests created after shutdown finish as cancelled. Existing tests cover native HTTP cancellation and the gRPC Abort RPC, but not propagation through the gRPC generation shutdown token. The new test reuses the existing gRPC integration fixture.

## Validation

- `cargo test --locked -p dynamo-sglang-mocker --test sidecar request_cancellation_is_isolated_and_shutdown_reaches_grpc_streams`: passed.
- Existing SGLang sidecar and mock package tests passed before adding the regression test.
- `cargo fmt -p dynamo-sglang-sidecar -p dynamo-sglang-mocker -- --check` and `git diff --check` passed.
- The Tyche campaign validated this change with streaming and shutdown checks. No isolated SGLang throughput gain is claimed because the original baseline failed validation.

## Related Issues

- [x] Confirmed — no related issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for concurrent generation requests so stopping one request no longer interrupts other active streams.
  * Engine cleanup now reliably closes remaining streams and reports cancelled completion status for affected requests.
  * Added coverage to verify request isolation, cleanup behavior, stream closure, and timely completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->