### PR TITLE
fix(vllm): settle kvwarm stages through a per-step round on every attention-DP rank

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -255,6 +255,24 @@ class _BenchmarkStageExchange:
     identities: dict[int, bytes]
 
 
+@dataclass
+class _BenchmarkStageVerdict:
+    """Group verdict on one warm-up stage (``_BenchmarkSynchronizer.stage_poll``).
+
+    ``start_step`` is the stage-relative engine step (``schedule()`` calls
+    since the stage build began) at which every rank leaves the exchange and
+    starts the rung's first point: two steps after the one in which rank 0
+    sent the decision. Ranks poll the decision from their idle steps and see
+    it in rank 0's lockstep iteration or up to two iterations later; a rank
+    that entered the point's blocking READY barrier while a peer still ran
+    that iteration's dummy forward (a group collective) left it waiting
+    there, and rank 0's READY tolerance aborted the sweep.
+    """
+
+    ok: bool
+    start_step: int
+
+
 @dataclass(frozen=True)
 class _BenchmarkCapacityEnvelope:
     """Rank-local limits that affect synthetic benchmark grid feasibility."""
@@ -1023,22 +1041,27 @@ class _BenchmarkSynchronizer:
                 }
             )
 
-    def stage_poll(self) -> bool | None:
+    def stage_poll(self, step: int) -> _BenchmarkStageVerdict | None:
         """Advance the pending stage exchange without blocking.
 
-        Returns the group verdict (every rank reported ok) once it is known,
-        else None so the caller yields the step and polls again. Past the
-        report deadline it raises TimeoutError; a protocol violation or a
-        peer abort raises RuntimeError, like the blocking phases.
+        ``step`` is this rank's engine step count since its stage build
+        began; builds start in the same lockstep iteration on every rank, so
+        the count is a shared frame. Returns the group verdict (every rank
+        reported ok) with the agreed start step once it is known, else None
+        so the caller yields the step and polls again. Past the report
+        deadline it raises TimeoutError; a protocol violation or a peer
+        abort raises RuntimeError, like the blocking phases.
         """
         stage = self._stage
         if stage is None:
             raise RuntimeError("attention-DP warm-up stage poll without a report")
         if self.dp_rank == 0:
-            return self._coordinate_stage(stage)
+            return self._coordinate_stage(stage, step)
         return self._follow_stage(stage)
 
-    def _coordinate_stage(self, stage: _BenchmarkStageExchange) -> bool | None:
+    def _coordinate_stage(
+        self, stage: _BenchmarkStageExchange, step: int
+    ) -> _BenchmarkStageVerdict | None:
         try:
             while len(stage.identities) < self.dp_size - 1:
                 if not self._socket.poll(0, zmq.POLLIN):
@@ -1067,6 +1090,14 @@ class _BenchmarkSynchronizer:
                 stage.identities[rank] = identity
                 stage.reports[rank] = ok
             decision = all(stage.reports.values())
+            # Followers see this decision in their poll of this lockstep
+            # iteration or of the next one, later still only if the message
+            # is slow; a rank that shed a still-building fleet at its report
+            # holds those blocks behind the deferred-free fence until the
+            # in-flight step's output lands, one iteration later. Two idle
+            # steps cover both: every rank, this one included, starts the
+            # rung's first point two steps after this one.
+            start_step = step + 2
             self._send_to_all(
                 stage.identities,
                 {
@@ -1074,6 +1105,7 @@ class _BenchmarkSynchronizer:
                     "benchmark_id": 0,
                     "batch": stage.batch,
                     "ok": decision,
+                    "start_step": start_step,
                 },
             )
         except Exception as error:
@@ -1081,9 +1113,11 @@ class _BenchmarkSynchronizer:
             self._notify_error(self._all_follower_identities(), str(error))
             raise
         self._stage = None
-        return decision
+        return _BenchmarkStageVerdict(decision, start_step)
 
-    def _follow_stage(self, stage: _BenchmarkStageExchange) -> bool | None:
+    def _follow_stage(
+        self, stage: _BenchmarkStageExchange
+    ) -> _BenchmarkStageVerdict | None:
         if not self._socket.poll(0, zmq.POLLIN):
             if time.monotonic() < stage.deadline:
                 return None
@@ -1095,9 +1129,14 @@ class _BenchmarkSynchronizer:
         self._stage = None
         reply = self._read_follower(0, "stage_decision")
         ok = reply.get("ok")
-        if reply.get("batch") != stage.batch or not isinstance(ok, bool):
+        start_step = reply.get("start_step")
+        if (
+            reply.get("batch") != stage.batch
+            or not isinstance(ok, bool)
+            or not isinstance(start_step, int)
+        ):
             raise RuntimeError(f"invalid attention-DP warm-up stage decision: {reply}")
-        return ok
+        return _BenchmarkStageVerdict(ok, start_step)
 
     @staticmethod
     def _deadline_elapsed(deadline: float | None) -> bool:
@@ -4669,6 +4708,11 @@ class InstrumentedScheduler(AsyncScheduler):
     # Local outcome ``(batch, ok, detail)`` of the active stage while the
     # attention-DP group verdict is pending (``_kvwarm_stage_await``).
     _kvwarm_stage_reported: tuple[int | None, bool, dict] | None = None
+    # Engine steps (``schedule()`` calls) since the active stage build began,
+    # and the step at which the group agreed to start the rung's first point
+    # (``_BenchmarkStageVerdict``).
+    _kvwarm_stage_steps: int = 0
+    _kvwarm_stage_start_step: int = 0
     # Real-KV prefill seeding state: per-batch-size seed chains, the parked
     # point with its per-request KV and new-token lengths, which shot
     # ("warm" | "measure") comes next, and whether this point staged.
@@ -5132,6 +5176,8 @@ class InstrumentedScheduler(AsyncScheduler):
         self._kvwarm_stage_batch = None
         self._kvwarm_building = False
         self._kvwarm_stage_reported = None
+        self._kvwarm_stage_steps = 0
+        self._kvwarm_stage_start_step = 0
         self._kvwarm_seq = 0
         logger.info(
             "KVWARM: prepared %d stage plans over %d decode points",
@@ -5178,8 +5224,10 @@ class InstrumentedScheduler(AsyncScheduler):
         step back to the real scheduler.
 
         Under attention-DP a finished build first waits for the group's
-        verdict on the rung (``_kvwarm_stage_await``); those steps are idle
-        too, so the collective forward keeps running on every rank.
+        verdict on the rung (``_kvwarm_stage_await``) and then for the agreed
+        start step; those steps are idle too, so the collective forward keeps
+        running on every rank, and every rank enters the point's blocking
+        READY barrier in the same lockstep iteration.
 
         Chains shed while their last step is still in flight leave their
         blocks behind the deferred-free fence; every shed branch then yields
@@ -5196,11 +5244,21 @@ class InstrumentedScheduler(AsyncScheduler):
         code does not make."""
         if not getattr(self, "_kvwarm_plan", None):
             return False
+        self._kvwarm_stage_steps += 1
         if self._bench_active_req_ids or self._bench_current_point is not None:
             return False
         if self._kvwarm_stage_reported is not None:
             # The rung's verdict is with the group: idle until it arrives.
-            return self._kvwarm_stage_await()
+            if self._kvwarm_stage_await():
+                return True
+        if self._kvwarm_stage_steps < self._kvwarm_stage_start_step:
+            # Verdict in, but the group leaves the exchange together: idle
+            # until the agreed step. Ranks see the decision up to two
+            # lockstep iterations apart, and a rank that reached the point's
+            # READY barrier while a peer still ran that iteration's dummy
+            # forward (a group collective) deadlocked it; a rank that saw
+            # the decision at the agreed step starts in this very step.
+            return True
         grid = self._bench_grid
         nxt = grid[0] if grid and grid[0].point_type == "decode" else None
         if nxt is None:
@@ -5258,6 +5316,10 @@ class InstrumentedScheduler(AsyncScheduler):
         self._kvwarm_stage_batch = batch
         self._kvwarm_building = True
         self._kvwarm_stage_t0 = t0
+        # Stage-relative step frame for the group's start step: builds start
+        # in the same lockstep iteration on every rank.
+        self._kvwarm_stage_steps = 0
+        self._kvwarm_stage_start_step = 0
         logger.info("KVWARM: stage build batch=%d depth=%d", batch, depth)
 
     def _kvwarm_monitor_build(self) -> bool:
@@ -5335,7 +5397,8 @@ class InstrumentedScheduler(AsyncScheduler):
         fleet only pins KV). Without a synchronizer the outcome is final and
         settles here; under attention-DP it is reported to the group and the
         stage waits in ``_kvwarm_stage_reported`` for the verdict, which
-        ``_kvwarm_stage_await`` applies. True either way: the step is idle.
+        ``_kvwarm_stage_await`` applies before ``_kvwarm_step_busy`` idles to
+        the agreed start step. True either way: the step is idle.
         """
         batch = self._kvwarm_stage_batch
         self._kvwarm_building = False
@@ -5353,7 +5416,9 @@ class InstrumentedScheduler(AsyncScheduler):
 
     def _kvwarm_stage_await(self) -> bool:
         """Poll the group verdict for the reported stage; True (idle) while it
-        is pending. A group fallback zeroes the rung's plan on every rank, so
+        is pending. Once in, the verdict is applied here and the step is
+        handed back to ``_kvwarm_step_busy``, which idles until the agreed
+        start step. A group fallback zeroes the rung's plan on every rank, so
         a rank whose own build succeeded sheds its chains too and the rung's
         points take fake injection everywhere."""
         synchronizer = self._bench_synchronizer
@@ -5361,16 +5426,36 @@ class InstrumentedScheduler(AsyncScheduler):
         if synchronizer is None or reported is None:
             # Nothing is awaiting a verdict (dp=1 settles locally).
             return False
-        decision = synchronizer.stage_poll()
-        if decision is None:
+        verdict = synchronizer.stage_poll(self._kvwarm_stage_steps)
+        if verdict is None:
             return True
         batch, _, detail = reported
         self._kvwarm_stage_reported = None
-        if not decision:
+        self._kvwarm_stage_start_step = verdict.start_step
+        logger.info(
+            "KVWARM: stage decision batch=%s ok=%s seen at step %d, start step %d",
+            batch,
+            verdict.ok,
+            self._kvwarm_stage_steps,
+            verdict.start_step,
+        )
+        if not verdict.start_step - 2 <= self._kvwarm_stage_steps <= verdict.start_step:
+            # In lockstep a decision is seen within two iterations of being
+            # sent; anything else means the ranks' stage-relative step counts
+            # disagree (engines paused, or a build that did not start in the
+            # same iteration everywhere).
+            logger.warning(
+                "KVWARM: stage decision for batch=%s seen at step %d, agreed "
+                "start step %d; ranks are not in lockstep",
+                batch,
+                self._kvwarm_stage_steps,
+                verdict.start_step,
+            )
+        if not verdict.ok:
             detail = {**detail, "group_fallback": True}
             self._kvwarm_shed_chains()
-        self._kvwarm_stage_settle(batch, decision, detail)
-        return True
+        self._kvwarm_stage_settle(batch, verdict.ok, detail)
+        return False
 
     def _kvwarm_stage_settle(self, batch: int | None, ok: bool, detail: dict) -> None:
         """Record the final outcome of a stage. A failed rung has its plan

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -953,14 +953,17 @@ def _stage_pair(timeout=1):
     return rank0, rank1
 
 
-def _stage_verdict(synchronizer, budget=2.0):
+def _stage_verdict(synchronizer, budget=2.0, first_step=1):
     """Drive ``stage_poll`` the way the scheduler does: one non-blocking poll
-    per idle step until the verdict arrives."""
+    per idle step, carrying this rank's stage-relative step count, until the
+    verdict arrives."""
     end = time.monotonic() + budget
+    step = first_step
     while time.monotonic() < end:
-        verdict = synchronizer.stage_poll()
+        verdict = synchronizer.stage_poll(step)
         if verdict is not None:
             return verdict
+        step += 1
         time.sleep(0.005)
     raise AssertionError("no stage verdict within budget")
 
@@ -978,14 +981,14 @@ def test_benchmark_synchronizer_stage_exchange_agrees_when_every_rank_is_ok():
     try:
         rank0.stage_report(8, True)
         # Non-blocking: rank 0 keeps polling between idle steps.
-        assert _stage_verdict(rank0) is True
+        assert _stage_verdict(rank0).ok is True
         follower.join(timeout=2)
         assert not follower.is_alive()
-        assert follower_result["verdict"] is True
+        assert follower_result["verdict"].ok is True
         # The exchange is closed on both sides once the verdict is out.
         for synchronizer in (rank0, rank1):
             with pytest.raises(RuntimeError, match="without a report"):
-                synchronizer.stage_poll()
+                synchronizer.stage_poll(1)
     finally:
         rank1.close()
         rank0.close()
@@ -1006,10 +1009,10 @@ def test_benchmark_synchronizer_stage_exchange_fails_the_group_with_one_rank(
     follower.start()
     try:
         rank0.stage_report(16, failing_rank != 0)
-        assert _stage_verdict(rank0) is False
+        assert _stage_verdict(rank0).ok is False
         follower.join(timeout=2)
         assert not follower.is_alive()
-        assert follower_result["verdict"] is False
+        assert follower_result["verdict"].ok is False
     finally:
         rank1.close()
         rank0.close()
@@ -1043,6 +1046,37 @@ def test_benchmark_synchronizer_stage_exchange_rejects_a_rung_mismatch():
             _stage_verdict(rank0)
         with pytest.raises(RuntimeError, match="synchronization failed"):
             _stage_verdict(rank1)
+    finally:
+        rank1.close()
+        rank0.close()
+
+
+def test_benchmark_synchronizer_stage_decision_carries_rank0_next_step():
+    """Every rank starts the rung's first point two steps after the one in
+    which rank 0 sent the decision, whatever step the follower's own poll is
+    at. Followers see the decision in rank 0's lockstep iteration or up to
+    two iterations later; a rank that entered the point's READY barrier one
+    iteration before its peers left them waiting in that iteration's
+    dummy-forward collective, and rank 0's READY tolerance aborted the
+    sweep."""
+    rank0, rank1 = _stage_pair()
+    try:
+        rank1.stage_report(8, True)
+        rank0.stage_report(8, True)
+        end = time.monotonic() + 2.0
+        verdict = None
+        while verdict is None and time.monotonic() < end:
+            verdict = rank0.stage_poll(41)
+            time.sleep(0.005)
+        assert verdict == instrumented_scheduler_module._BenchmarkStageVerdict(
+            ok=True, start_step=43
+        )
+        # The follower's own step count does not enter the agreed value.
+        assert _stage_verdict(
+            rank1, first_step=7
+        ) == instrumented_scheduler_module._BenchmarkStageVerdict(
+            ok=True, start_step=43
+        )
     finally:
         rank1.close()
         rank0.close()
@@ -5525,9 +5559,11 @@ def _kvwarm_group_stage_stub(*, chains=("chain-a", "chain-b"), synchronizer=None
 def test_kvwarm_stage_verdict_is_taken_from_the_group():
     stub, meta = _kvwarm_group_stage_stub()
     sync = stub._bench_synchronizer
-    sync.stage_poll.side_effect = [None, None, True]
+    verdict_cls = instrumented_scheduler_module._BenchmarkStageVerdict
+    # Rank 0 decides in its step 4 and names step 6 as the group's start.
+    sync.stage_poll.side_effect = [None, None, verdict_cls(ok=True, start_step=6)]
 
-    # Build complete: the local outcome is reported, not applied.
+    # Step 1, build complete: the local outcome is reported, not applied.
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     sync.stage_report.assert_called_once()
     (batch, ok), kwargs = sync.stage_report.call_args
@@ -5536,39 +5572,117 @@ def test_kvwarm_stage_verdict_is_taken_from_the_group():
     assert stub._kvwarm_building is False
     assert stub._kvwarm_stage_reported[:2] == (4, True)
     assert meta["stages"] == []
-    # Pending verdict: every step is an idle step for the real scheduler.
+    # Steps 2-3, pending verdict: every step is an idle step for the real
+    # scheduler, and every poll carries this rank's stage-relative step.
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     assert meta["stages"] == []
-    # Verdict in: the stage is ready and the point flow resumes.
+    # Step 4, verdict in: the stage is ready, but the point waits for the
+    # agreed step so peers that see the decision up to two steps later catch
+    # up.
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     assert stub._kvwarm_stage_reported is None
+    assert (stub._kvwarm_stage_steps, stub._kvwarm_stage_start_step) == (4, 6)
     assert [entry["batch"] for entry in meta["stages"]] == [4]
     assert meta["stages"][0]["depth"] == 8 and "failed" not in meta["stages"][0]
+    assert sync.stage_poll.call_args_list == [call(2), call(3), call(4)]
+    # Step 5: still idle, no poll.
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
+    # Step 6: the point flow resumes.
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is False
     assert stub._kvwarm_plan[4] == 128
     stub._kvwarm_shed_chains.assert_not_called()
     assert sync.stage_poll.call_count == 3
 
 
+def test_kvwarm_late_stage_verdict_starts_the_point_in_the_same_step():
+    """A follower whose poll sees the decision two lockstep iterations after
+    rank 0 sent it is already at the agreed start step: it must not idle
+    again, or rank 0 (blocked in the point's READY barrier) and this rank
+    (in the iteration's dummy-forward collective) wait for each other."""
+    stub, meta = _kvwarm_group_stage_stub()
+    sync = stub._bench_synchronizer
+    verdict_cls = instrumented_scheduler_module._BenchmarkStageVerdict
+    # Rank 0 sent the decision in step 2 (start step 4); it lands in this
+    # rank's step-4 poll.
+    sync.stage_poll.side_effect = [None, None, verdict_cls(ok=True, start_step=4)]
+
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 1: reported
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 2: pending
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 3: pending
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is False  # 4: start
+    assert stub._kvwarm_stage_reported is None
+    assert [entry["batch"] for entry in meta["stages"]] == [4]
+    assert sync.stage_poll.call_args_list == [call(2), call(3), call(4)]
+    stub._kvwarm_shed_chains.assert_not_called()
+
+
+def test_kvwarm_stage_verdict_far_from_the_agreed_step_idles_until_it():
+    """Outside lockstep (engines paused, no dummy forwards) a rank may be
+    well behind rank 0's count; it idles up to the agreed step and blocking
+    there is harmless. The skew is logged, not fatal."""
+    stub, meta = _kvwarm_group_stage_stub()
+    sync = stub._bench_synchronizer
+    verdict_cls = instrumented_scheduler_module._BenchmarkStageVerdict
+    sync.stage_poll.side_effect = [verdict_cls(ok=True, start_step=6)]
+
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 1: reported
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 2: verdict
+    assert stub._kvwarm_stage_reported is None
+    assert [entry["batch"] for entry in meta["stages"]] == [4]
+    for _ in range(3):  # steps 3-5: idle until the agreed step
+        assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is False  # 6: start
+    assert sync.stage_poll.call_count == 1
+
+
 def test_kvwarm_group_fallback_zeroes_the_plan_and_sheds_a_healthy_fleet():
     stub, meta = _kvwarm_group_stage_stub()
     sync = stub._bench_synchronizer
-    sync.stage_poll.side_effect = [None, False]
+    verdict_cls = instrumented_scheduler_module._BenchmarkStageVerdict
+    sync.stage_poll.side_effect = [None, verdict_cls(ok=False, start_step=4)]
 
-    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # reported ok
-    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # pending
-    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # verdict: no
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 1: reported ok
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 2: pending
+    # Step 3, verdict no: applied at once, but the group leaves the exchange
+    # together at step 4.
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     assert stub._kvwarm_plan[4] == 0
     stub._kvwarm_shed_chains.assert_called_once_with()
     (entry,) = meta["stages"]
     assert entry["batch"] == 4 and entry["failed"] is True
     assert entry["group_fallback"] is True
+    assert (stub._kvwarm_stage_steps, stub._kvwarm_stage_start_step) == (3, 4)
     # The rung's points now take fake injection: the shed blocks drain behind
     # the fence first, then the fake path proceeds.
-    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 4: fence
     stub.deferred_frees.clear()
-    assert InstrumentedScheduler._kvwarm_step_busy(stub) is False
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is False  # 5
+    stub._kvwarm_start_stage.assert_not_called()
+
+
+def test_kvwarm_late_group_fallback_takes_the_fake_path_in_the_same_step():
+    """The fallback path ends in the same READY barrier as the real-KV path,
+    so a rank that sees the "no" verdict at the agreed step sheds and moves
+    on to fake injection in that very step."""
+    stub, meta = _kvwarm_group_stage_stub()
+    sync = stub._bench_synchronizer
+    verdict_cls = instrumented_scheduler_module._BenchmarkStageVerdict
+
+    def shed_parked():  # parked chains: their blocks return at once
+        stub._kvwarm_chain_ids = []
+        stub._kvwarm_stage_batch = None
+
+    stub._kvwarm_shed_chains = MagicMock(side_effect=shed_parked)
+    sync.stage_poll.side_effect = [None, verdict_cls(ok=False, start_step=3)]
+
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 1: reported ok
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is True  # 2: pending
+    assert InstrumentedScheduler._kvwarm_step_busy(stub) is False  # 3: fake path
+    assert stub._kvwarm_plan[4] == 0
+    stub._kvwarm_shed_chains.assert_called_once_with()
+    (entry,) = meta["stages"]
+    assert entry["failed"] is True and entry["group_fallback"] is True
     stub._kvwarm_start_stage.assert_not_called()
 
 
@@ -5576,7 +5690,10 @@ def test_kvwarm_local_stage_failure_is_reported_before_it_is_applied():
     stub, meta = _kvwarm_group_stage_stub()
     del stub.requests["chain-a"]  # vanished during the build
     sync = stub._bench_synchronizer
-    sync.stage_poll.side_effect = [None, False]
+    sync.stage_poll.side_effect = [
+        None,
+        instrumented_scheduler_module._BenchmarkStageVerdict(ok=False, start_step=4),
+    ]
 
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     # Survivors are released at once, but the plan waits for the group.
@@ -5600,7 +5717,9 @@ def test_kvwarm_stage_pool_shortfall_fails_the_rung_for_the_group():
     stub, meta = _kvwarm_group_stage_stub()
     stub._kvwarm_stage_shadow_shortfall = lambda batch: 3
     sync = stub._bench_synchronizer
-    sync.stage_poll.side_effect = [False]
+    sync.stage_poll.side_effect = [
+        instrumented_scheduler_module._BenchmarkStageVerdict(ok=False, start_step=3)
+    ]
 
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     (batch, ok), _ = sync.stage_report.call_args
@@ -5620,7 +5739,9 @@ def test_kvwarm_soft_timeout_mid_build_abandons_the_stage_through_the_group():
     stub.requests["chain-a"].num_computed_tokens = 2  # still building
     stub._bench_deadline_monotonic = 0.0  # soft timeout elapsed
     sync = stub._bench_synchronizer
-    sync.stage_poll.side_effect = [False]
+    sync.stage_poll.side_effect = [
+        instrumented_scheduler_module._BenchmarkStageVerdict(ok=False, start_step=3)
+    ]
 
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is True
     (batch, ok), _ = sync.stage_report.call_args
@@ -5643,6 +5764,27 @@ def test_kvwarm_stage_settles_locally_without_a_synchronizer():
     assert [entry["batch"] for entry in meta["stages"]] == [4]
     stub._kvwarm_stage_shadow_shortfall.assert_not_called()
     assert InstrumentedScheduler._kvwarm_step_busy(stub) is False
+
+
+def test_kvwarm_start_stage_resets_the_stage_step_frame():
+    """The agreed start step is expressed in steps since the stage build
+    began, so each build restarts the count on every rank."""
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub.add_request = MagicMock()
+    stub._kvwarm_chain_token_ids = lambda index, depth: [index + 1] * depth
+    stub._bench_block_hasher = None
+    stub._fpm_dp_rank = 0
+    stub._kvwarm_seq = 0
+    stub._kvwarm_chain_ids = []
+    stub._kvwarm_chain_prompts = {}
+    stub._kvwarm_stage_steps = 17
+    stub._kvwarm_stage_start_step = 9
+
+    InstrumentedScheduler._kvwarm_start_stage(stub, 2, 8)
+
+    assert stub.add_request.call_count == 2
+    assert (stub._kvwarm_stage_batch, stub._kvwarm_building) == (2, True)
+    assert (stub._kvwarm_stage_steps, stub._kvwarm_stage_start_step) == (0, 0)
 
 
 def test_kvwarm_stage_shadow_shortfall_takes_the_rung_worst_case(monkeypatch):


### PR DESCRIPTION
## Summary

The FPM self-benchmark's KV warm-up settles each rung's chain-fleet stage through the non-blocking stage exchange added in #14029: every attention-DP rank reports its build outcome and polls the group verdict from its idle scheduler steps. On GB200 DEP16 (GLM-5.2-NVFP4, `--data-parallel-size 16 --enable-expert-parallel`, unpinned KV pools) every decode sweep on `main` aborts at the first point: rank 0's 10 s READY tolerance expires with 2–3 of 16 ranks at READY (`timed out waiting for attention-DP benchmark ranks for benchmark_id=1; ready_ranks=[0, 13]`; three runs, survivor sets `[0, 4, 11]`, `[0, 13]`, `[0, 5]`). The pre-merge code (all fleets settled locally in the same step) completed the same 564-point manifest 564/564.

## Root cause

Under attention-DP an idle benchmark step runs vLLM's dummy forward, a group collective, so ranks step in lockstep; the benchmark overrides `has_requests()` so `schedule()` runs once per engine-loop iteration on every rank (in `step` and in `step_with_batch_queue` alike). The stage decision is a ZMQ message from rank 0 polled inside `schedule()`, so ranks see it in different iterations: rank 0 and any follower whose poll runs in the same iteration see it one step before the rest. Every rank idled the step it saw the verdict in and started the rung's first point in the next one. The early ranks therefore injected the point and blocked in its READY barrier (a plain ZMQ wait inside `schedule()`) in iteration N+1, while the late ranks returned an idle step in N+1 and entered that iteration's dummy forward, a collective that waits for the blocked ranks. A diagnostic overlay that logged every idle gate confirmed it: all 16 ranks log the verdict within 20 ms, two ranks log `Benchmark decode: … batch_size=121` at once, the other 14 log nothing for the following 10 s (they are outside `schedule()`, in the executor), then rank 0 times out.

## Fix

Settle the stage in a blocking round that every rank runs in the same scheduler step, instead of a decision that each rank reads in its own step.

On every idle decode-sweep step under attention-DP (no benchmark point active), each rank sends rank 0 its stage status: a round sequence number, the stage batch, its phase (`none`, `building` or `done`) and, when done, whether its fleet built. Rank 0 waits for the status of every other rank, checks that all ranks report the same sequence number and the same batch (a mismatch fails the benchmark with `attention-DP warm-up ranks are not in lockstep`), and answers every rank in the same round: whether all ranks are done and, if so, the group verdict `ok = all ranks built`. A rank whose fleet is still building keeps stepping, so a slower rank's build proceeds while the faster ranks idle through rounds; the stage settles on every rank in the round in which the last rank reports `done`. Because the round is a blocking exchange inside `schedule()` that every rank enters in the same lockstep iteration, no rank can start the rung's first point before every other rank has left the round with the same verdict, and there is no delivery window to depend on: a message that arrives late only delays the round for everyone. On a failed stage all ranks shed their fleets in that step and the rung's points take fake injection from the next one. `dp_size == 1` (no synchronizer) settles locally in the step the build finishes, as before; the one visible change is that a soft timeout mid-build now records the abandoned stage as failed instead of shedding it silently.

The fallback exit still passes through the pre-existing rank-local deferred-free check one step after settlement. Under vLLM 0.28.0 a fleet shed from inside `schedule()` has its blocks fenced only when `defer_block_free` is on (a `kv_consumer`/`kv_both` connector plus `max_concurrent_batches > 1`), and with async scheduling that fence drains at the end of the same engine iteration, so the check is already clear on every rank by the next step; only pipeline-parallel configurations (`max_concurrent_batches >= 3`) could carry a deferral further. The validated setup has no KV connector, so it never defers.

An earlier revision of this PR announced a start step two iterations ahead of rank 0's decision. That works only while every rank sees the decision within two iterations, a window rather than an invariant (raised in review); the round replaces it.

Protocol change: the `stage_status`/`stage_decision` messages and the `stage_report`/`stage_poll` exchange (with `_BenchmarkStageExchange`) are gone; `_BenchmarkSynchronizer.stage_round(seq, batch, phase, ok)` returns a `_BenchmarkStageRound(all_done, ok)`; messages of the wrong shape or an out-of-lockstep status are rejected like any other malformed message, and a coordinator failure is forwarded to every follower so no rank hangs. Cost: one message exchange per idle decode-sweep step (a few hundred microseconds against ~15–150 ms steps); measured steps are unchanged. Every settlement is logged (`KVWARM: stage batch=… settled by the group (ok=…) at round …`), so a run can be audited for one settlement round per stage across all ranks.

## Validation

- Unit tests (need vLLM; run in the collection image on a GB200 node, vLLM 0.28.0): `test_vllm_instrumented_scheduler.py` + `test_benchmark_points.py` 263 passed (main 252 + 11 new or extended), 25 of them on the stage round. The new tests cover: a rank that keeps reporting `building` until every rank is `done`; one rank's failed build giving `ok=False` to all; a follower blocked until rank 0 answers; a timeout on either side without a peer; out-of-lockstep `seq`/`batch` rejected; malformed statuses and results (wrong shape, wrong rank, missing or spurious verdict) rejected with the follower notified; the status-shape check on both roles; `dp_size == 1` local settlement; the scheduler's exact round sequences for build, failure, group fallback, pool shortfall and soft timeout; and a delayed-decision regression: a real inproc pair whose broadcast is delayed 0.3 s, both ranks producing the same `[busy, idle, idle]` step sequence with neither moving ahead (a follower that polls and treats "no reply yet" as an idle step, the pre-fix behaviour, fails this test).
- GB200 DEP16 decode sweep with this change overlaid on stock `main` (GLM-5.2-NVFP4, `--data-parallel-size 16 --enable-expert-parallel --async-scheduling`, kvwarm on, KV pool unpinned, explicit 564-point manifest over 35 batch rows 1–121): **564/564 points on all 16 ranks, 35/35 stages, 0 group fallbacks, 0 skipped points, 0 READY timeouts, 0 lockstep errors** (Slurm 7201236). The same manifest on stock `main` aborted at point 1 in 3/3 runs.
- Lockstep audit from the new INFO line: each of the 35 stages settled on exactly one round on all 16 ranks (`batch=121 … at round 194` on every rank, up to `batch=1 … at round 1348`). All 35 verdicts were `ok=True`, so the group-fallback exit was not exercised on hardware in this run; it rests on the unit tests.
- Measured values are unchanged: point by point against the pre-#14029 collection of the same manifest (Slurm 7024594, same pool profile of 29,430 blocks, 559 points on real KV in both runs), the ratio has a median of 1.001 (p10–p90 0.996–1.006, min 0.94, max 1.02). One point differs by more than 5 %: batch 1 at 128 KV tokens (15.9 vs 17.0 ms, the smallest step of the grid).
- Cost: the sweep took 11.4 min from plan preparation to the results being written, against 11.3 min for the previous revision of this PR on the same manifest and hardware; the round's per-step exchange is not visible at that scale.

## Related

Linear AIC-1957 (validation of #14029 on GB200 DEP16), AIC-1944 (umbrella). Follow-up on the same surface: the fake-point repeat guard still reads the rank-local pool (`_bench_usable_blocks`) where the stage plan reads the negotiated one (AIC-1945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
