### PR TITLE
fix(frontend): propagate sglang backend errors with reason (4xx where settable)

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from collections.abc import AsyncGenerator
 from concurrent.futures import ProcessPoolExecutor
@@ -24,7 +25,7 @@ from dynamo._internal import ModelDeploymentCard
 from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.frontend.frontend_args import FrontendConfig
 from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine
-from dynamo.llm.exceptions import InvalidArgument, Unknown
+from dynamo.llm.exceptions import HttpError, InvalidArgument, Unknown
 
 from .sglang_prepost import (
     ReasoningParser,
@@ -42,6 +43,8 @@ from .sglang_prepost import (
 from .thinking import runtime_default_thinking_mode
 from .utils import (
     PreprocessError,
+    as_error_envelope,
+    backend_invalid_argument_to_http_error,
     extract_mm_urls,
     handle_engine_error,
     make_internal_error,
@@ -53,6 +56,42 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Map SGLang/backend error strings to client-facing HTTP errors so the reason
+# reaches the client instead of an opaque 500. The 400/429 status is honoured
+# only where the HTTP layer can still set it -- non-streaming requests, and
+# streaming with DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS (pre-commit error peek).
+# Default streaming commits 200 up front, so a classified backend error there
+# surfaces as 200 + SSE error event carrying the reason.
+# See GitHub issue #14354 (DEP: unified semantic error propagation).
+_SGL_OVERCONTEXT_RE = re.compile(
+    r"longer than the model's context length"
+    r"|exceeds\s+context"
+    r"|input is too long"
+    r"|context length",
+    re.IGNORECASE,
+)
+_SGL_QUEUE_OVERFLOW_RE = re.compile(
+    r"queue[^.\n]*limit reached|policy class.*queue",
+    re.IGNORECASE,
+)
+
+
+def _classify_sglang_error(message: str) -> HttpError | None:
+    """Map a backend or routed-engine error message to a client-facing HttpError.
+
+    Returns None when the message is none of the recognized shapes, so the
+    caller keeps its existing fallback (an SSE error envelope or Unknown).
+    """
+    err = backend_invalid_argument_to_http_error(RuntimeError(message))
+    if err is not None:
+        return err
+    if _SGL_OVERCONTEXT_RE.search(message):
+        return HttpError(400, message)
+    if _SGL_QUEUE_OVERFLOW_RE.search(message):
+        return HttpError(429, message)
+    return None
 
 
 def _cached_tokens_from_usage(usage: dict[str, Any] | None) -> int | None:
@@ -716,6 +755,13 @@ class SglangProcessor:
         post_proc_total_ms = 0.0
         created_ts = int(time.time())
         stream_interval = self.stream_interval
+        # True once any frame has been yielded to the client. A classified
+        # backend error arriving before the first byte `raise`s HttpError so the
+        # HTTP layer can set the status where it still can (non-streaming, or
+        # streaming with DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS); one arriving
+        # mid-stream, after the 200 is committed, is sent as an SSE error event
+        # so the client sees the reason.
+        yielded_any = False
 
         try:
             dynamo_stream = await self.routed_engine.generate(
@@ -851,7 +897,15 @@ class SglangProcessor:
                         request_id,
                         message,
                     )
-                    yield make_internal_error(request_id, message)
+                    err = _classify_sglang_error(message)
+                    if err is not None:
+                        if not yielded_any:
+                            raise err
+                        yield as_error_envelope(
+                            make_internal_error(request_id, err.message)
+                        )
+                        break
+                    yield as_error_envelope(make_internal_error(request_id, message))
                     break
                 engine_response = dynamo_response.data()
 
@@ -864,7 +918,9 @@ class SglangProcessor:
                     not isinstance(engine_response, dict)
                     or "token_ids" not in engine_response
                 ):
-                    yield handle_engine_error(engine_response, request_id, logger)
+                    yield as_error_envelope(
+                        handle_engine_error(engine_response, request_id, logger)
+                    )
                     break
 
                 new_ids = engine_response["token_ids"]
@@ -887,6 +943,7 @@ class SglangProcessor:
                             stop_terminated=False,
                             engine_data=None,
                         )
+                        yielded_any = True
                         yield envelope
                         if post.locally_finished:
                             break
@@ -924,16 +981,31 @@ class SglangProcessor:
                         stop_terminated=stop_terminated,
                         engine_data=engine_data,
                     )
+                    yielded_any = True
                     yield envelope
                     if post.locally_finished:
                         break
         except Unknown:
             raise
+        except HttpError:
+            raise
         except Exception as e:
-            logger.exception("Error generating response for request %s", request_id)
-            raise Unknown(
-                f"Error generating response for request {request_id}: {e}"
-            ) from e
+            err = _classify_sglang_error(str(e))
+            if err is not None:
+                logger.warning(
+                    "Backend rejected request %s with %d: %s",
+                    request_id,
+                    err.code,
+                    err.message,
+                )
+                if not yielded_any:
+                    raise err from e
+                yield as_error_envelope(make_internal_error(request_id, err.message))
+            else:
+                logger.exception("Error generating response for request %s", request_id)
+                raise Unknown(
+                    f"Error generating response for request {request_id}: {e}"
+                ) from e
         finally:
             if self.debug_perf and token_count > 0:
                 logger.info(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -53,6 +53,7 @@ from dynamo.frontend.sglang_processor import (
     SglangPreprocessWorkerResult,
     SglangProcessor,
     _build_dynamo_preproc,
+    _classify_sglang_error,
     _init_worker,
     _load_chat_template,
     _map_finish_reason,
@@ -68,7 +69,7 @@ from dynamo.frontend.utils import (
     random_call_id,
     random_uuid,
 )
-from dynamo.llm.exceptions import InvalidArgument
+from dynamo.llm.exceptions import HttpError, InvalidArgument
 
 # Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
@@ -3315,6 +3316,42 @@ def test_generator_honors_explicit_skip_special_tokens(
     )
 
 
+class TestClassifySglangError:
+    """Classify backend/routed-engine error strings to client-facing HTTP statuses."""
+
+    def test_over_context_message_is_400(self):
+        err = _classify_sglang_error(
+            "The input (5105302 tokens) is longer than the model's "
+            "context length (1048576 tokens)."
+        )
+        assert isinstance(err, HttpError)
+        assert err.code == 400
+        assert "longer than the model's context length" in err.message
+
+    def test_queue_overflow_message_is_429(self):
+        err = _classify_sglang_error(
+            'router policy class "default" queue raw_isl_tokens limit reached'
+            " (have=5000, limit=5000)"
+        )
+        assert err is not None
+        assert err.code == 429
+        assert "queue" in err.message
+
+    def test_backend_invalid_argument_envelope_is_honoured(self):
+        err = _classify_sglang_error(
+            'BackendInvalidArgument: {"message":"min_p unsupported","code":400}'
+        )
+        assert err is not None
+        assert err.code == 400
+        assert "BackendInvalidArgument" not in err.message
+
+    @pytest.mark.parametrize(
+        "message", ["unknown routed_engine error", "CUDA out of memory", ""]
+    )
+    def test_unclassified_messages_return_none(self, message):
+        assert _classify_sglang_error(message) is None
+
+
 class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
     """Test safe-boundary incremental detokenization."""
 
@@ -3984,16 +4021,22 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
 
         return asyncio.run(collect())
 
-    def test_routed_engine_is_error_yields_internal_error(self, tokenizer):
-        """is_error() True yields a single internal_error chunk with the comment text."""
+    def test_routed_engine_is_error_yields_error_envelope(self, tokenizer):
+        """is_error() with an unclassified message yields a tagged error frame.
+
+        An unclassified routed-engine error is wrapped in ``as_error_envelope``
+        so the binding reads it as an SSE error event (not a completion chunk);
+        an opaque 500 would otherwise drop the reason.
+        """
         items = self._run_stream(
             tokenizer,
             [FakeRoutedItem(None, is_error=True, comments=["backend disconnected"])],
         )
         assert len(items) == 1
-        err = items[0]["error"]
-        assert err["type"] == "internal_error"
-        assert "backend disconnected" in err["message"]
+        frame = items[0]
+        assert frame["_dynamo_annotated"] is True
+        assert frame["event"] == "error"
+        assert "backend disconnected" in frame["comment"][0]
 
     def test_routed_engine_none_data_is_skipped(self, tokenizer):
         """data() is None (e.g. comment-only event) is skipped, not yielded as error."""
@@ -4008,14 +4051,17 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert len(items) == 1
         assert items[0]["choices"][0]["finish_reason"] == "stop"
 
-    def test_malformed_engine_response_yields_engine_error(self, tokenizer):
-        """A response dict missing token_ids goes through handle_engine_error."""
+    def test_malformed_engine_response_yields_error_envelope(self, tokenizer):
+        """A response dict missing token_ids is tagged as an error frame."""
         items = self._run_stream(
             tokenizer,
             [{"status": "error", "message": "kv cache exhausted"}],
         )
         assert len(items) == 1
-        assert "error" in items[0]
+        frame = items[0]
+        assert frame["_dynamo_annotated"] is True
+        assert frame["event"] == "error"
+        assert "kv cache exhausted" in frame["comment"][0]
 
     def test_completed_batches_replace_decode_context(self):
         """Completed batches replace context instead of accumulating history."""


### PR DESCRIPTION
## Summary

The SGLang chat processor surfaces backend rejections as **opaque 500s** on the disaggregated SGLang path:

- an over-context `ValueError` from SGLang and a LocalRouter queue-overflow rejection were both caught by the generic `except Exception` and re-raised as `Unknown` (HTTP 500);
- the `is_error` and `handle_engine_error` yield paths emitted bare dicts the binding misread as completion chunks, so the reason never reached the client.

#14063 added equivalent handling to the **vLLM** chat processor (classification + `as_error_envelope` + `backend_invalid_argument_to_http_error`) but did not touch `sglang_processor.py`. The preflight guard from #12092 also does not gate this path: the worker's `token_budget` does not reach the frontend MDC under disaggregation, so `validate_requested_token_budget` returns early and the request still reaches the worker, which rejects it.

This mirrors #14063 onto the SGLang path and handles the streaming boundary:

- **classify** over-context messages -> `400` and LocalRouter queue-overflow rejections -> `429` (regex classifier `_classify_sglang_error`, which also reuses `backend_invalid_argument_to_http_error` for the `BackendInvalidArgument: {json}` envelope);
- a classified error arriving **before the first byte** `raise`s `HttpError` so the HTTP layer sets the status; one arriving **mid-stream**, after the `200` is committed, is `yield`ed as an `as_error_envelope` SSE `error` event so the reason reaches the client instead of truncating the stream (`yielded_any` flag, set by the two flush `yield envelope` sites);
- add `except HttpError: raise` so a raised `HttpError` propagates to the HTTP boundary instead of being re-caught by `except Exception` and re-wrapped (mirrors #14063's `except VLLMClientError: raise`);
- **unclassified** errors keep their existing behavior (`as_error_envelope` for `is_error` / missing `token_ids`; `raise Unknown` for genuine engine faults), so the common cases are unchanged.

Updates the two affected `test_sglang_processor_unit.py` tests to the tagged-envelope shape the binding now expects, and adds a `TestClassifySglangError` unit suite covering over-context / queue-overflow / `BackendInvalidArgument` / unclassified.

Related to DEP #14354 (unified semantic error propagation), which would subsume this once it lands; this is the SGLang-specific stopgap for the disagg path in the meantime.

## Validation

- `py_compile` + `ruff@0.5.2` check/format: pass (both files).
- Runtime: stub-loaded **real** `sglang_processor.py` + real `frontend/utils.py` (PyO3/CUDA deps stubbed; `HttpError` is a behaviour-matched Python stand-in), **21 assertions, all pass**:
  - pre-stream: queue-overflow -> `raise 429`; over-context -> `raise 400`; `BackendInvalidArgument` -> `raise 400` (no regression vs. the pre-patch opaque 500).
  - mid-stream: classified `is_error` (queue-overflow) after a data frame -> data frame + SSE `error` event carrying the queue reason (was: `raise` + reason lost); classified engine raise (over-context `ValueError` after a data frame) -> data frame + `error` event carrying the over-context reason.
  - unclassified: `is_error` -> envelope; missing `token_ids` -> envelope; genuine `RuntimeError` -> `raise Unknown` (unchanged).
- Cherry-picked onto the current `ai-dynamo/dynamo` `main` (the recent `resolve_skip_special_tokens` changes are preserved; no conflicts).

## Notes for reviewers

- Single commit, DCO-signed. It is **not** GPG/SSH-signed, so it does not qualify for automatic trusted-CI approval — it will need a maintainer `/ok to test <sha>` to run full CI.
- I could not run the repo's `pytest tests/` locally (needs `maturin develop` + `sglang`). The runtime verification uses stub injection (behaviour-matched), which equivalently exercises every branch of the patch but is not the repo `pytest` suite itself. Happy to reproduce within a CI-capable env if pointed at one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SGLang backend errors, including context-length and queue-overflow conditions.
  - Converts invalid backend arguments into clearer HTTP errors.
  - Provides consistent error responses before and during streaming.
  - Preserves successful streamed output while reporting mid-stream failures as structured error events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->