### PR TITLE
fix(operator): avoid blocking DGD finalizers on snapshot cache

### DIFF
--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -69,6 +69,7 @@ type dgdCheckpointsReconciler struct {
 	config                *configv1alpha1.OperatorConfiguration
 	runtimeConfig         *commoncontroller.RuntimeConfig
 	dockerSecretRetriever DockerSecretRetriever
+	snapshotReader        client.Reader
 }
 
 func newDGDCheckpointsReconciler(
@@ -76,12 +77,14 @@ func newDGDCheckpointsReconciler(
 	config *configv1alpha1.OperatorConfiguration,
 	runtimeConfig *commoncontroller.RuntimeConfig,
 	dockerSecretRetriever DockerSecretRetriever,
+	snapshotReader client.Reader,
 ) *dgdCheckpointsReconciler {
 	return &dgdCheckpointsReconciler{
 		dgdResourceSyncer:     syncer,
 		config:                config,
 		runtimeConfig:         runtimeConfig,
 		dockerSecretRetriever: dockerSecretRetriever,
+		snapshotReader:        snapshotReader,
 	}
 }
 
@@ -507,7 +510,7 @@ func (r *dgdCheckpointsReconciler) syncAutomaticPodSnapshotLifecycle(
 	}
 	snapshot := &snapshotv1alpha1.PodSnapshot{}
 	key := client.ObjectKey{Namespace: job.Namespace, Name: job.Status.PodSnapshotName}
-	if err := r.Get(ctx, key, snapshot); err != nil {
+	if err := r.snapshotReader.Get(ctx, key, snapshot); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -782,7 +785,7 @@ func (r *dgdCheckpointsReconciler) deleteAutomaticSnapshotJobsForDGD(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) (map[types.UID]string, bool, error) {
 	jobs := &snapshotv1alpha1.SnapshotJobList{}
-	if err := r.List(
+	if err := r.snapshotReader.List(
 		ctx,
 		jobs,
 		client.InNamespace(dgd.Namespace),
@@ -840,7 +843,7 @@ func (r *dgdCheckpointsReconciler) deleteAutomaticPodSnapshotsForDGD(
 	retainedSnapshotJobs map[types.UID]string,
 ) error {
 	snapshots := &snapshotv1alpha1.PodSnapshotList{}
-	if err := r.List(
+	if err := r.snapshotReader.List(
 		ctx,
 		snapshots,
 		client.InNamespace(dgd.Namespace),

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler_test.go
@@ -60,6 +60,7 @@ func newTestDGDCheckpointsReconciler(
 		reconciler.Config,
 		reconciler.RuntimeConfig,
 		reconciler.DockerSecretRetriever,
+		reconciler.Client,
 	)
 }
 

--- a/deploy/operator/internal/controller/dgd_shared_resources_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_shared_resources_reconciler.go
@@ -61,7 +61,7 @@ func newDGDSharedResourcesReconciler(
 		pvcs:          newDGDPVCReconciler(syncer),
 		discovery:     newDGDDiscoveryReconciler(syncer, config),
 		gmsClaims:     newDGDGMSResourceClaimsReconciler(syncer, runtimeConfig.Gate),
-		checkpoints:   newDGDCheckpointsReconciler(syncer, config, runtimeConfig, dockerSecretRetriever),
+		checkpoints:   newDGDCheckpointsReconciler(syncer, config, runtimeConfig, dockerSecretRetriever, kubeClient),
 		epp:           newDGDEPPReconciler(syncer, config, runtimeConfig, restConfig),
 		waitForLeader: newDGDWaitForLeaderReconciler(syncer),
 		sshKeys:       newDGDSSHKeysReconciler(sshKeyManager),

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -72,6 +72,7 @@ type rbacManager interface {
 // DynamoGraphDeploymentReconciler reconciles a DynamoGraphDeployment object
 type DynamoGraphDeploymentReconciler struct {
 	client.Client
+	APIReader             client.Reader
 	Config                *configv1alpha1.OperatorConfiguration
 	RuntimeConfig         *commoncontroller.RuntimeConfig
 	RestConfig            *rest.Config
@@ -237,11 +238,15 @@ func (r *DynamoGraphDeploymentReconciler) persistWorkloadProgramResult(
 
 func (r *DynamoGraphDeploymentReconciler) FinalizeResource(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment) error {
 	syncer := newDGDResourceSyncer(r.Client, r.Recorder)
+
+	// Finalization uses a direct reader because checkpoint-disabled controllers do not register
+	// Snapshot informers, and a lazy cache read can block forever when Snapshot RBAC is incomplete.
 	return newDGDCheckpointsReconciler(
 		syncer,
 		r.Config,
 		r.RuntimeConfig,
 		r.DockerSecretRetriever,
+		r.APIReader,
 	).deleteAutoCheckpointsForDGD(ctx, dynamoDeployment)
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -172,6 +172,7 @@ func TestDynamoGraphDeploymentReconcileFinalizesDeletingStoredCheckpointIncompat
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		APIReader:     kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -209,6 +210,7 @@ func TestDynamoGraphDeploymentReconcileFinalizesWithoutSnapshotTypes(t *testing.
 		Build()
 	reconciler := &DynamoGraphDeploymentReconciler{
 		Client:        kubeClient,
+		APIReader:     kubeClient,
 		Recorder:      events.NewFakeRecorder(10),
 		Config:        &configv1alpha1.OperatorConfiguration{},
 		RuntimeConfig: &controller_common.RuntimeConfig{},
@@ -228,6 +230,72 @@ func TestDynamoGraphDeploymentReconcileFinalizesWithoutSnapshotTypes(t *testing.
 		require.NoError(t, err)
 		require.False(t, controller_common.ContainsFinalizer(&stored))
 	}
+}
+
+func TestDynamoGraphDeploymentReconcileReturnsSnapshotRBACFailureFromAPIReader(t *testing.T) {
+	t.Log("Create a deleting DGD whose cache must not lazily start a Snapshot informer")
+	now := metav1.Now()
+	dgd := &v1beta1.DynamoGraphDeployment{ObjectMeta: metav1.ObjectMeta{
+		Name:              "test-dgd",
+		Namespace:         "default",
+		DeletionTimestamp: &now,
+	}}
+	controller_common.AddFinalizer(dgd)
+	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
+	cacheReadErr := fmt.Errorf("cache-backed Snapshot list must not be used during finalization")
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(dgd).
+		WithStatusSubresource(&v1beta1.DynamoGraphDeployment{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*snapshotv1alpha1.SnapshotJobList); ok {
+					return cacheReadErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	snapshotRBACErr := apierrors.NewForbidden(
+		snapshotv1alpha1.GroupVersion.WithResource("snapshotjobs").GroupResource(),
+		"",
+		fmt.Errorf("service account cannot list SnapshotJobs"),
+	)
+	apiReaderUsed := false
+	apiReader := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*snapshotv1alpha1.SnapshotJobList); ok {
+					apiReaderUsed = true
+					return snapshotRBACErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        kubeClient,
+		APIReader:     apiReader,
+		Recorder:      events.NewFakeRecorder(10),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+	}
+
+	t.Log("Reconcile the deletion while the direct reader returns Forbidden")
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(dgd),
+	})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err))
+	assert.NotContains(t, err.Error(), cacheReadErr.Error())
+	assert.True(t, apiReaderUsed)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	t.Log("Verify the failed cleanup keeps the finalizer for a retry")
+	var stored v1beta1.DynamoGraphDeployment
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKeyFromObject(dgd), &stored))
+	assert.True(t, controller_common.ContainsFinalizer(&stored))
 }
 
 func TestDGDScalingAdaptersReconciler_Reconcile(t *testing.T) {

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -85,6 +85,7 @@ func SetupDynamoComponentDeployment(mgr ctrl.Manager, opts DynamoComponentDeploy
 func SetupDynamoGraphDeployment(mgr ctrl.Manager, opts DynamoGraphDeploymentSetupOptions) error {
 	if err := (&DynamoGraphDeploymentReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Recorder:              mgr.GetEventRecorder("dynamographdeployment"),
 		Config:                opts.Config,
 		RuntimeConfig:         opts.RuntimeConfig,


### PR DESCRIPTION
## Summary

- use the manager API reader for Snapshot reads reached from DGD finalization
- keep normal checkpoint reconciliation on the informer-backed client
- return Snapshot RBAC failures to the controller so the finalizer remains retryable without blocking the only DGD worker
- add regression coverage proving finalization bypasses the cache and returns `Forbidden`

The generated manager Role already grants the required SnapshotJob and PodSnapshot permissions, so this hardens the operator against stale or mismatched effective RBAC without changing the RBAC manifest.

Linear: https://linear.app/nvidia/issue/DYN-4336/dynamorelease150dgdr-dgd-reconcile-worker-hangs-forever-on-first

## Validation

- `go test ./internal/controller -run 'TestDynamoGraphDeploymentReconcile(FinalizesDeletingStoredCheckpointIncompatibility|FinalizesWithoutSnapshotTypes|ReturnsSnapshotRBACFailureFromAPIReader)$' -count=1`\n- `KUBEBUILDER_ASSETS=... go test ./internal/controller -count=1`\n- `go vet ./internal/controller`\n- `make manifests` (generated RBAC unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic checkpoint cleanup by reading snapshot resources directly from the Kubernetes API.
  * Cleanup now correctly handles access errors, preserves finalizers, and retries when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->