### PR TITLE
fix(profiler): [cherry-pick 1.5.0] stop THOROUGH profiling crashing on its first candidate deployment (#14591)

### DIFF
--- a/deploy/utils/dynamo_deployment.py
+++ b/deploy/utils/dynamo_deployment.py
@@ -141,6 +141,10 @@ class DynamoDeploymentClient:
         self.model_name = model_name
         self.service_name = service_name or f"{self.deployment_name}-frontend"
         self.components: List[str] = []  # Will store component names from CR
+        self._original_components: List[str] = []
+        # Version segment of the DynamoGraphDeployment apiVersion, reset from the
+        # manifest in create_deployment: the request path must match the body.
+        self.api_version: str = "v1beta1"
         self.deployment_spec: Optional[
             Dict[str, Any]
         ] = None  # Will store the full deployment spec
@@ -261,10 +265,19 @@ class DynamoDeploymentClient:
             self.deployment_spec is not None
         ), "Failed to load deployment specification"
 
+        self.api_version = (
+            self.deployment_spec.get("apiVersion") or "nvidia.com/v1beta1"
+        ).split("/")[-1]
+
         # Extract component names (original case for label queries, lowercase for directories)
-        self._original_components = list(
-            self.deployment_spec["spec"]["services"].keys()
-        )
+        # v1beta1 spells this `spec.components`, a list of objects each with a
+        # `name`; v1alpha1 spelled it `spec.services`, a mapping keyed by name.
+        spec = self.deployment_spec["spec"]
+        components = spec.get("components")
+        if isinstance(components, list):
+            self._original_components = [component["name"] for component in components]
+        else:
+            self._original_components = list(spec["services"].keys())
         self.components = [svc.lower() for svc in self._original_components]
 
         # Ensure name and namespace are set correctly
@@ -281,7 +294,7 @@ class DynamoDeploymentClient:
             if self.namespace == dgdr_namespace:
                 self.deployment_spec["metadata"]["ownerReferences"] = [
                     {
-                        "apiVersion": "nvidia.com/v1alpha1",
+                        "apiVersion": "nvidia.com/v1beta1",
                         "kind": "DynamoGraphDeploymentRequest",
                         "name": dgdr_name,
                         "uid": dgdr_uid,
@@ -294,7 +307,7 @@ class DynamoDeploymentClient:
         try:
             await self.custom_api.create_namespaced_custom_object(
                 group="nvidia.com",
-                version="v1alpha1",
+                version=self.api_version,
                 namespace=self.namespace,
                 plural="dynamographdeployments",
                 body=self.deployment_spec,
@@ -404,7 +417,7 @@ class DynamoDeploymentClient:
             try:
                 status = await self.custom_api.get_namespaced_custom_object(
                     group="nvidia.com",
-                    version="v1alpha1",
+                    version=self.api_version,
                     namespace=self.namespace,
                     plural="dynamographdeployments",
                     name=self.deployment_name,
@@ -622,7 +635,7 @@ class DynamoDeploymentClient:
         try:
             await self.custom_api.delete_namespaced_custom_object(
                 group="nvidia.com",
-                version="v1alpha1",
+                version=self.api_version,
                 namespace=self.namespace,
                 plural="dynamographdeployments",
                 name=self.deployment_name,

--- a/deploy/utils/tests/test_dynamo_deployment.py
+++ b/deploy/utils/tests/test_dynamo_deployment.py
@@ -62,3 +62,78 @@ async def test_wait_for_deployment_ready_raises_deployment_failed_on_crashloop(
     # Confirm we didn't run out the timeout — there should have been at
     # most one DGD status check before the raise.
     assert client.custom_api.get_namespaced_custom_object.await_count == 1
+
+
+def _mocked_client() -> DynamoDeploymentClient:
+    client = DynamoDeploymentClient(namespace="ns", deployment_name="dgd-test")
+    client._init_kubernetes = AsyncMock()  # type: ignore[method-assign]
+    client.custom_api = MagicMock()
+    client.custom_api.create_namespaced_custom_object = AsyncMock()
+    client.custom_api.delete_namespaced_custom_object = AsyncMock()
+    return client
+
+
+async def test_create_deployment_reads_v1beta1_components():
+    """A v1beta1 candidate must deploy without a KeyError.
+
+    ``materialize_dgd`` has produced ``spec.components`` — a list of objects
+    each carrying a ``name`` — since DGD generation moved to v1beta1, while
+    this client still read the v1alpha1 ``spec.services`` mapping.
+    """
+    client = _mocked_client()
+
+    await client.create_deployment(
+        {
+            "apiVersion": "nvidia.com/v1beta1",
+            "kind": "DynamoGraphDeployment",
+            "metadata": {"name": "candidate", "namespace": "ns"},
+            "spec": {
+                "components": [
+                    {"name": "Frontend"},
+                    {"name": "VllmPrefillWorker"},
+                ]
+            },
+        }
+    )
+
+    # Original case drives the nvidia.com/dynamo-component label selector;
+    # the lowercase projection names the per-component log directory.
+    assert client._original_components == ["Frontend", "VllmPrefillWorker"]
+    assert client.components == ["frontend", "vllmprefillworker"]
+
+    create_kwargs = client.custom_api.create_namespaced_custom_object.await_args.kwargs
+    assert create_kwargs["version"] == "v1beta1"
+
+    await client.delete_deployment()
+    delete_kwargs = client.custom_api.delete_namespaced_custom_object.await_args.kwargs
+    assert delete_kwargs["version"] == "v1beta1"
+
+
+async def test_create_deployment_owner_reference_targets_v1beta1_dgdr(monkeypatch):
+    """The owner reference must name a DGDR version the API server serves.
+
+    Profiling DGDs are garbage-collected through this reference when the
+    owning DynamoGraphDeploymentRequest is deleted. The DGDR CRD stores
+    v1beta1, so a reference declaring v1alpha1 would leak every profiling
+    deployment once v1alpha1 stops being served.
+    """
+    monkeypatch.setenv("DGDR_NAME", "dgdr-test")
+    monkeypatch.setenv("DGDR_NAMESPACE", "ns")
+    monkeypatch.setenv("DGDR_UID", "8f0b0f4e-0000-4000-8000-000000000000")
+
+    client = _mocked_client()
+
+    await client.create_deployment(
+        {
+            "apiVersion": "nvidia.com/v1beta1",
+            "kind": "DynamoGraphDeployment",
+            "metadata": {"name": "candidate", "namespace": "ns"},
+            "spec": {"components": [{"name": "Frontend"}]},
+        }
+    )
+
+    create_kwargs = client.custom_api.create_namespaced_custom_object.await_args.kwargs
+    owner_references = create_kwargs["body"]["metadata"]["ownerReferences"]
+    assert owner_references[0]["apiVersion"] == "nvidia.com/v1beta1"
+    assert owner_references[0]["kind"] == "DynamoGraphDeploymentRequest"
+    assert owner_references[0]["name"] == "dgdr-test"


### PR DESCRIPTION
Cherry-pick of #14591 to `release/1.5.0`.

This backport lets the profiling deployment client handle both v1beta1 `spec.components` and legacy v1alpha1 `spec.services`, and derives Kubernetes API request versions from each manifest so THOROUGH profiling can deploy its first candidate.

Source issue: [DYN-4332](https://linear.app/nvidia/issue/DYN-4332)

Signed-off cherry-pick with `-x --signoff`.

Validation:
- Applied cleanly with no conflicts.
- Remote Git tree matches the locally verified cherry-pick tree (`f2d08f057a0926f821bd854c77ce1e5f49cfa73f`).
- `git diff --check release/1.5.0...HEAD` passed.
- The source PR's focused pytest was not rerun because `pytest` is unavailable in this environment.
- Focused `pre-commit` checks were not run because `pre-commit` is unavailable in this environment.
- The 16-GPU end-to-end THOROUGH run was not run, matching the source PR's disclosed limitation.