### PR TITLE
fix(recipes): tolerate vLLM JIT stalls on DeepSeek-V4-Pro-0813 GB200 workers

### DIFF
--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-gb200-agentic/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/agg-gb200-agentic/deploy.yaml
@@ -155,6 +155,24 @@ spec:
                       key: speculative-config
                 - name: VLLM_ENGINE_READY_TIMEOUT_S
                   value: "21600"
+              # The operator's default worker liveness probe allows a single
+              # failed check at a 4 s timeout. vLLM JIT-compiles the large
+              # prefill kernels (mhc_pre_big_fuse_*_tilelang, and the Triton
+              # _prepare_dflash_inputs_kernel) the first time it sees a new
+              # prompt shape, which stalls the engine for 30-70 s -- long
+              # enough for kubelet to kill the container. Killing the leader
+              # then orphans the multinode worker, whose probes the operator
+              # strips, so the replacement leader waits out the full 10-minute
+              # init_process_group timeout and dies too. Tolerate the stall
+              # rather than restart into it. Upstream warmup that would remove
+              # the stall is tracked in vllm-project/vllm#49627.
+              livenessProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 30
               startupProbe:
                 httpGet:
                   path: /health

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-gb200-agentic/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-gb200-agentic/deploy.yaml
@@ -404,24 +404,6 @@ spec:
                       # and change prefill and decode together -- a mismatch breaks
                       # the NIXL compatibility hash.
                       key: speculative-config
-              # The operator's default worker liveness probe allows a single
-              # failed check at a 4 s timeout. vLLM JIT-compiles the large
-              # prefill kernels (mhc_pre_big_fuse_*_tilelang, and the Triton
-              # _prepare_dflash_inputs_kernel) the first time it sees a new
-              # prompt shape, which stalls the engine for 30-70 s -- long
-              # enough for kubelet to kill the container. Killing the leader
-              # then orphans the multinode worker, whose probes the operator
-              # strips, so the replacement leader waits out the full 10-minute
-              # init_process_group timeout and dies too. Tolerate the stall
-              # rather than restart into it. Upstream warmup that would remove
-              # the stall is tracked in vllm-project/vllm#49627.
-              livenessProbe:
-                httpGet:
-                  path: /live
-                  port: 9090
-                periodSeconds: 10
-                timeoutSeconds: 5
-                failureThreshold: 30
               startupProbe:
                 httpGet:
                   path: /health

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-gb200-agentic/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/vllm/disagg-gb200-agentic/deploy.yaml
@@ -203,6 +203,24 @@ spec:
                     configMapKeyRef:
                       name: dsv4-pro-0813-disagg-gb200-agentic-config
                       key: speculative-config
+              # The operator's default worker liveness probe allows a single
+              # failed check at a 4 s timeout. vLLM JIT-compiles the large
+              # prefill kernels (mhc_pre_big_fuse_*_tilelang, and the Triton
+              # _prepare_dflash_inputs_kernel) the first time it sees a new
+              # prompt shape, which stalls the engine for 30-70 s -- long
+              # enough for kubelet to kill the container. Killing the leader
+              # then orphans the multinode worker, whose probes the operator
+              # strips, so the replacement leader waits out the full 10-minute
+              # init_process_group timeout and dies too. Tolerate the stall
+              # rather than restart into it. Upstream warmup that would remove
+              # the stall is tracked in vllm-project/vllm#49627.
+              livenessProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 30
               startupProbe:
                 httpGet:
                   path: /health
@@ -386,6 +404,24 @@ spec:
                       # and change prefill and decode together -- a mismatch breaks
                       # the NIXL compatibility hash.
                       key: speculative-config
+              # The operator's default worker liveness probe allows a single
+              # failed check at a 4 s timeout. vLLM JIT-compiles the large
+              # prefill kernels (mhc_pre_big_fuse_*_tilelang, and the Triton
+              # _prepare_dflash_inputs_kernel) the first time it sees a new
+              # prompt shape, which stalls the engine for 30-70 s -- long
+              # enough for kubelet to kill the container. Killing the leader
+              # then orphans the multinode worker, whose probes the operator
+              # strips, so the replacement leader waits out the full 10-minute
+              # init_process_group timeout and dies too. Tolerate the stall
+              # rather than restart into it. Upstream warmup that would remove
+              # the stall is tracked in vllm-project/vllm#49627.
+              livenessProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 10
+                timeoutSeconds: 5
+                failureThreshold: 30
               startupProbe:
                 httpGet:
                   path: /health


### PR DESCRIPTION
## Summary

**Issue.** The GB200 prefill worker declares no `livenessProbe`, so it inherits the
operator default of `failureThreshold: 1` at `timeoutSeconds: 4`. vLLM JIT-compiles the
large prefill kernels (`mhc_pre_big_fuse_*_tilelang`, Triton
`_prepare_dflash_inputs_kernel`) the first time it sees a new prompt shape, stalling the
engine for 30-70 s. The engine cannot answer `/live`, so kubelet kills the prefill
leader. That orphans the multinode worker, whose probes the operator strips, and the
replacement leader then waits out the full 10-minute `init_process_group` timeout and
dies too. That loop is the crashloop in NVBug 6746890, and it is why the bug reports two
different errors.

Disagg GB200 only: liveness is disabled while a `startupProbe` is pending, so compiles
during startup are safe. In agg these kernels compile during CUDA-graph capture, inside
that window; in disagg the prefill role only meets them once real traffic arrives. H200
is unaffected, the kernels are Blackwell-only.

**Fix.** Declare an explicit `livenessProbe` on the prefill worker: about five minutes of
tolerance instead of four seconds. A genuinely wedged worker is still restarted, just not
mid-compile. Also added to the single `agg-gb200-agentic` worker, which shares the
kernels and the default.

Deliberately **not** added to the disagg decode worker. `conditional_disagg_enabled`
defaults to false and this recipe does not set it, so decode never runs a prefill and
cannot reach those kernels; measurement below confirms it is unaffected.

This tolerates the stall; removing it is upstream in vllm-project/vllm#49349 (tracking
issue; the DSv4 work is PR #49627, still open).

## Validation

Reproduced and verified on live `main`, 2-node GB200 MNNVL.

Before, one ~14K-token prompt against a cold prefill leader:

```
Killing - Container main failed liveness
restarts 1 -> 2 -> 3, frontend returning 503
```

After, same deployment and prompts:

```
prompt      state   stall    result
14K         cold    33.7 s   served, restarts=0
4K/12K/24K  warm    26-32 s  served, restarts=0  (new shape key each time)
75K         warm     4.4 s   served, restarts=0
900K        cold    72 s     served, restarts=0, returned to Ready on its own
```

Eight stalls survived, worst case 72 s against 300 s of tolerance. Worker logs confirm
the same kernels genuinely recompiled, so the identical path was exercised. No `Killing`
or liveness events in any run.

Decode scoping, measured at both ends of the range with counters taken before and after
each request:

```
                      14K cold        900K
prefill TileLang      44 -> 52 (+8)   52 -> 52 (+0), 68 s of prefill + KV transfer
decode  TileLang      40 -> 40 (+0)   40 -> 40 (+0)
decode  health t/o     0 ->  0 (+0)    0 ->  0 (+0)
decode  restarts       0               0
```

Decode compiled nothing and saw no health-check timeouts in either case, including while
prefill was busy for 68 s. Both runs were single requests against an idle decode;
behaviour under high concurrency was not measured.

Also tried and rejected: raising `max_cudagraph_capture_size` to 16384 to move the
compiles into startup. It OOMs during capture (`torch.OutOfMemoryError` in
`apply_block_scaled_mm`) because a 16K-token capture does not fit alongside a KV pool
sized for 1M context. Making it fit would shrink KV and cut the published 3.11x
concurrency at 1M.

Note for operators: probe changes do not apply to a running DGD. The operator reconciles,
but Grove keeps the existing PodClique template and new pods still render
`failureThreshold: 1`. Delete and recreate the DGD.
