### PR TITLE
fix(planner): [cherry-pick 1.5.0] stop a metrics outage leaving fewer replicas than min_endpoint (#14575)

### DIFF
--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -47,8 +47,14 @@ class ThroughputScalingMixin:
             if component == "prefill"
             else self._compute_decode_replicas(demand_rps, isl, osl)
         )
+        current = self._num_p_workers if component == "prefill" else self._num_d_workers
+        # A missing capacity estimate must not bypass the configured endpoint
+        # floor. Hold at the current count, then let the floor and GPU budget
+        # logic below decide whether recovery is required.
+        model_not_ready = desired is None
         if desired is None:
-            return None
+            desired = current
+        desired = max(desired, resolve_min_endpoint(self._config, component))
 
         if self._config.enable_load_scaling:
             if component == "prefill":
@@ -56,11 +62,16 @@ class ThroughputScalingMixin:
             else:
                 self._throughput_lower_bound_d = desired
             logger.info(f"Throughput lower bound set to {desired} for {component}")
-            self._diag_throughput_reason = "set_lower_bound"
+            self._diag_throughput_reason = (
+                "model_not_ready" if model_not_ready else "set_lower_bound"
+            )
             return None
 
         desired = self._apply_single_budget(desired, component)
-        self._diag_throughput_reason = "scale"
+        if model_not_ready and desired == current:
+            self._diag_throughput_reason = "model_not_ready"
+            return None
+        self._diag_throughput_reason = "model_not_ready" if model_not_ready else "scale"
         return (
             ScalingDecision(num_prefill=desired)
             if component == "prefill"
@@ -81,6 +92,7 @@ class ThroughputScalingMixin:
         # side's computation was still valid but its decision is blocked,
         # so we label it "partner_not_ready" to keep per-component
         # diagnostics consistent with the aggregate reason.
+        model_not_ready = num_p is None or num_d is None
         if num_p is None or num_d is None:
             self._diag_throughput_reason_prefill = (
                 "model_not_ready" if num_p is None else "partner_not_ready"
@@ -88,21 +100,36 @@ class ThroughputScalingMixin:
             self._diag_throughput_reason_decode = (
                 "model_not_ready" if num_d is None else "partner_not_ready"
             )
-            return None
+            # Do not move either side from a partial estimate. Hold both at
+            # their current counts so only endpoint-floor recovery can act.
+            num_p = self._num_p_workers
+            num_d = self._num_d_workers
 
-        reason = "set_lower_bound" if self._config.enable_load_scaling else "scale"
-        self._diag_throughput_reason_prefill = reason
-        self._diag_throughput_reason_decode = reason
+        num_p = max(num_p, resolve_min_endpoint(self._config, "prefill"))
+        num_d = max(num_d, resolve_min_endpoint(self._config, "decode"))
+
+        if not model_not_ready:
+            reason = "set_lower_bound" if self._config.enable_load_scaling else "scale"
+            self._diag_throughput_reason_prefill = reason
+            self._diag_throughput_reason_decode = reason
 
         if self._config.enable_load_scaling:
             self._throughput_lower_bound_p = num_p
             self._throughput_lower_bound_d = num_d
             logger.info(f"Throughput lower bounds set: prefill={num_p}, decode={num_d}")
-            self._diag_throughput_reason = "set_lower_bound"
+            self._diag_throughput_reason = (
+                "model_not_ready" if model_not_ready else "set_lower_bound"
+            )
             return None
 
         num_p, num_d = self._apply_global_budget(num_p, num_d)
-        self._diag_throughput_reason = "scale"
+        if model_not_ready and (
+            num_p,
+            num_d,
+        ) == (self._num_p_workers, self._num_d_workers):
+            self._diag_throughput_reason = "model_not_ready"
+            return None
+        self._diag_throughput_reason = "model_not_ready" if model_not_ready else "scale"
         return ScalingDecision(num_prefill=num_p, num_decode=num_d)
 
     def _throughput_agg(
@@ -114,56 +141,65 @@ class ThroughputScalingMixin:
     ) -> Optional[ScalingDecision]:
         d_caps = self._capabilities.decode
         max_tokens = d_caps.max_num_batched_tokens if d_caps else None
-        if not max_tokens or max_tokens <= 0:
-            logger.warning(
-                "max_num_batched_tokens not available, skipping agg throughput"
+        max_tokens_available = bool(max_tokens and max_tokens > 0)
+        if not max_tokens_available:
+            logger.warning("max_num_batched_tokens not available for agg throughput")
+        capacity = (
+            self._agg_regression.find_engine_capacity_rps(
+                isl=isl,
+                osl=osl,
+                ttft_sla_ms=self._config.ttft_ms,
+                itl_sla_ms=self._config.itl_ms,
+                kv_hit_rate=kv_hit_rate,
+                accept_length=self._current_decode_accept_length(),
             )
-            self._diag_throughput_reason = "model_not_ready"
-            return None
-
-        capacity = self._agg_regression.find_engine_capacity_rps(
-            isl=isl,
-            osl=osl,
-            ttft_sla_ms=self._config.ttft_ms,
-            itl_sla_ms=self._config.itl_ms,
-            kv_hit_rate=kv_hit_rate,
-            accept_length=self._current_decode_accept_length(),
+            if max_tokens_available
+            else None
         )
         engine_rps = capacity.rps if capacity is not None else 0.0
-        if engine_rps <= 0:
-            logger.warning("Agg perf model not ready, skipping throughput scaling")
-            self._diag_throughput_reason = "model_not_ready"
-            return None
-        actual_ttft = capacity.ttft_ms or 0.0
-        actual_itl = capacity.itl_ms or 0.0
-        if (
-            not capacity.eligible
-            or actual_ttft > self._config.ttft_ms
-            or actual_itl > self._config.itl_ms
-        ):
+        model_not_ready = capacity is None or engine_rps <= 0
+        if model_not_ready:
             logger.warning(
-                f"Agg SLA not fully met: TTFT={actual_ttft:.1f}ms, ITL={actual_itl:.1f}ms"
+                "Agg perf model not ready, holding at the current replica count "
+                "and enforcing the endpoint floor"
+            )
+            self._diag_throughput_reason = "model_not_ready"
+            desired = self._num_d_workers
+        else:
+            actual_ttft = capacity.ttft_ms or 0.0
+            actual_itl = capacity.itl_ms or 0.0
+            if (
+                not capacity.eligible
+                or actual_ttft > self._config.ttft_ms
+                or actual_itl > self._config.itl_ms
+            ):
+                logger.warning(
+                    f"Agg SLA not fully met: TTFT={actual_ttft:.1f}ms, ITL={actual_itl:.1f}ms"
+                )
+
+            self._diag_engine_rps_prefill = engine_rps
+            self._diag_engine_rps_decode = engine_rps
+
+            desired = math.ceil(demand_rps / engine_rps)
+            logger.info(
+                f"Agg: {demand_rps:.2f} rps / {engine_rps:.2f} engine_rps = {desired} replicas"
             )
 
-        self._diag_engine_rps_prefill = engine_rps
-        self._diag_engine_rps_decode = engine_rps
-
-        desired = max(
-            math.ceil(demand_rps / engine_rps),
-            resolve_min_endpoint(self._config, "decode"),
-        )
-        logger.info(
-            f"Agg: {demand_rps:.2f} rps / {engine_rps:.2f} engine_rps = {desired} replicas"
-        )
+        desired = max(desired, resolve_min_endpoint(self._config, "decode"))
 
         if self._config.enable_load_scaling:
             self._throughput_lower_bound_d = desired
             logger.info(f"Agg throughput lower bound set to {desired}")
-            self._diag_throughput_reason = "set_lower_bound"
+            self._diag_throughput_reason = (
+                "model_not_ready" if model_not_ready else "set_lower_bound"
+            )
             return None
 
         desired = self._apply_single_budget(desired, "decode")
-        self._diag_throughput_reason = "scale"
+        if model_not_ready and desired == self._num_d_workers:
+            self._diag_throughput_reason = "model_not_ready"
+            return None
+        self._diag_throughput_reason = "model_not_ready" if model_not_ready else "scale"
         return ScalingDecision(num_decode=desired)
 
     def _compute_prefill_replicas(
@@ -181,7 +217,10 @@ class ThroughputScalingMixin:
         )
         engine_rps = capacity.rps if capacity is not None else 0.0
         if engine_rps <= 0:
-            logger.warning("Prefill perf model not ready, skipping throughput scaling")
+            logger.warning(
+                "Prefill perf model not ready, holding at the current replica "
+                "count and enforcing the endpoint floor"
+            )
             self._diag_throughput_reason = "model_not_ready"
             return None
         ttft_ms = capacity.ttft_ms or 0.0
@@ -215,7 +254,10 @@ class ThroughputScalingMixin:
         )
         engine_rps = capacity.rps if capacity is not None else 0.0
         if engine_rps <= 0:
-            logger.warning("Decode perf model not ready, skipping throughput scaling")
+            logger.warning(
+                "Decode perf model not ready, holding at the current replica "
+                "count and enforcing the endpoint floor"
+            )
             self._diag_throughput_reason = "model_not_ready"
             return None
         itl_ms = capacity.itl_ms or 0.0

--- a/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
@@ -59,6 +59,97 @@ def test_prefill_throughput_uses_component_minimum_override():
     assert replicas == 3
 
 
+class _ModelNotReadyHarness(ThroughputScalingMixin):
+    def __init__(self, *, current_decode: int = 1):
+        self._config = SimpleNamespace(
+            enable_load_scaling=False,
+            min_endpoint=1,
+            prefill_min_endpoint=None,
+            decode_min_endpoint=3,
+            min_gpu_budget=-1,
+            max_gpu_budget=100,
+            ttft_ms=200.0,
+            itl_ms=10.0,
+        )
+        self._capabilities = WorkerCapabilities(
+            decode=EngineCapabilities(
+                gpu_cost_per_replica=1,
+                max_num_batched_tokens=4096,
+            )
+        )
+        self._num_p_workers = 1
+        self._num_d_workers = current_decode
+        self._throughput_lower_bound_p = 1
+        self._throughput_lower_bound_d = current_decode
+        self._diag_throughput_reason = None
+        self._diag_throughput_reason_prefill = None
+        self._diag_throughput_reason_decode = None
+        self._diag_engine_rps_prefill = None
+        self._diag_engine_rps_decode = None
+        self._agg_regression = SimpleNamespace(
+            find_engine_capacity_rps=lambda **_kwargs: SimpleNamespace(
+                rps=0.0,
+                ttft_ms=1.0,
+                itl_ms=1.0,
+                eligible=True,
+            )
+        )
+
+    def _compute_prefill_replicas(self, *_args, **_kwargs):
+        self._diag_throughput_reason = "model_not_ready"
+        return None
+
+    def _compute_decode_replicas(self, *_args, **_kwargs):
+        self._diag_throughput_reason = "model_not_ready"
+        return None
+
+    def _apply_single_budget(self, desired, _component):
+        return desired
+
+    def _apply_global_budget(self, num_p, num_d):
+        return num_p, num_d
+
+    def _current_decode_accept_length(self):
+        return 1.0
+
+
+def test_single_throughput_applies_floor_when_perf_model_not_ready():
+    scaling = _ModelNotReadyHarness()
+
+    decision = scaling._throughput_single(1.0, 1.0, 1.0, "decode")
+
+    assert decision is not None
+    assert decision.num_decode == 3
+    assert scaling._diag_throughput_reason == "model_not_ready"
+
+
+def test_disagg_throughput_applies_floor_when_perf_models_not_ready():
+    scaling = _ModelNotReadyHarness()
+
+    decision = scaling._throughput_disagg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert (decision.num_prefill, decision.num_decode) == (1, 3)
+    assert scaling._diag_throughput_reason == "model_not_ready"
+
+
+def test_disagg_throughput_holds_when_model_not_ready_and_floor_already_met():
+    scaling = _ModelNotReadyHarness(current_decode=3)
+
+    assert scaling._throughput_disagg(1.0, 1.0, 1.0) is None
+    assert scaling._diag_throughput_reason == "model_not_ready"
+
+
+def test_agg_throughput_applies_floor_when_perf_model_not_ready():
+    scaling = _ModelNotReadyHarness()
+
+    decision = scaling._throughput_agg(1.0, 1.0, 1.0)
+
+    assert decision is not None
+    assert decision.num_decode == 3
+    assert scaling._diag_throughput_reason == "model_not_ready"
+
+
 @pytest.mark.parametrize("gpu_cost_per_replica", [4, 5])
 def test_engine_rps_recommendation_is_independent_of_sidecar_cost(
     gpu_cost_per_replica: int,


### PR DESCRIPTION
Cherry-pick of #14575 to `release/1.5.0`.

This backport keeps enforcing configured endpoint floors when the Planner's throughput performance model cannot produce a capacity estimate, including Prometheus-outage ticks, while retaining the `model_not_ready` diagnostic.

Source issue: [DYN-4337](https://linear.app/nvidia/issue/DYN-4337)

Signed-off cherry-pick with `-x --signoff`.

Release adaptation:
- Both source files conflicted because `main` has newer throughput-cap and GPU-budget APIs that are not present on `release/1.5.0`.
- The source behavior was adapted to the release APIs: single, disaggregated, and aggregate paths hold current counts when the model is unavailable, then apply the endpoint floor and existing release budget helpers.
- Four focused release-compatible regression tests cover floor recovery and the already-at-floor hold case without importing unrelated main-only tests or helpers.

Validation:
- Remote Git tree matches the locally verified cherry-pick tree (`89aac766f990c6ed1cc5584eaeaf3a72cf75e397`).
- `git diff --check release/1.5.0...HEAD` passed.
- Both changed Python files compile successfully.
- Five dependency-light behavior checks passed: single, disaggregated, aggregate, already-at-floor hold, and aggregate missing-capacity cases.
- The source PR's full pytest suite, pre-commit, and mypy were not run because pytest, pre-commit, mypy, and required Python dependencies are unavailable in this environment.