### PR TITLE
fix(helm): [cherry-pick 1.5.0] use valid KAI staleness duration (#14722)

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -295,7 +295,7 @@ For **production environments**, Kai Scheduler and Grove should be installed sep
 
 Grove should be upgraded in lockstep with Dynamo while Grove APIs are not stable. Dynamo 1.3.x expects Grove's earlier `ClusterTopology` API and is incompatible with the newer `ClusterTopologyBinding` API; Dynamo 1.4.x expects `ClusterTopologyBinding`.
 
-Grove `v0.1.0-alpha.13` enables its `kai-scheduler` backend by default. When Grove's `kai-scheduler` profile is active, disable KAI's independent stale PodGroup eviction by setting `scheduler.args.default-staleness-grace-period` to `"-1"` in the KAI Scheduler chart; Grove owns PodGroup termination timing. Keep KAI's normal cleanup behavior when using KAI without Grove or when an externally managed Grove has that profile disabled. The bundled Grove subchart also enables its CRD installer so new and updated Grove CRDs are applied before its operator starts during upgrades.
+Grove `v0.1.0-alpha.13` enables its `kai-scheduler` backend by default. When Grove's `kai-scheduler` profile is active, disable KAI's independent stale PodGroup eviction by setting `scheduler.args.default-staleness-grace-period` to `"-1s"` in the KAI Scheduler chart; Grove owns PodGroup termination timing. Keep KAI's normal cleanup behavior when using KAI without Grove or when an externally managed Grove has that profile disabled. The bundled Grove subchart also enables its CRD installer so new and updated Grove CRDs are applied before its operator starts during upgrades.
 
 After installing them separately, enable Dynamo integration:
 
@@ -331,7 +331,7 @@ global:
 kai-scheduler:
   scheduler:
     args:
-      default-staleness-grace-period: "-1"  # Grove owns PodGroup cleanup
+      default-staleness-grace-period: "-1s"  # Grove owns PodGroup cleanup
 ```
 
 The chart requires this KAI override when it installs both bundled subcharts. With externally managed Grove, set the override only when its `kai-scheduler` profile is active. KAI-only installations should omit it.

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -206,7 +206,7 @@ For **production environments**, Kai Scheduler and Grove should be installed sep
 
 Grove should be upgraded in lockstep with Dynamo while Grove APIs are not stable. Dynamo 1.3.x expects Grove's earlier `ClusterTopology` API and is incompatible with the newer `ClusterTopologyBinding` API; Dynamo 1.4.x expects `ClusterTopologyBinding`.
 
-Grove `v0.1.0-alpha.13` enables its `kai-scheduler` backend by default. When Grove's `kai-scheduler` profile is active, disable KAI's independent stale PodGroup eviction by setting `scheduler.args.default-staleness-grace-period` to `"-1"` in the KAI Scheduler chart; Grove owns PodGroup termination timing. Keep KAI's normal cleanup behavior when using KAI without Grove or when an externally managed Grove has that profile disabled. The bundled Grove subchart also enables its CRD installer so new and updated Grove CRDs are applied before its operator starts during upgrades.
+Grove `v0.1.0-alpha.13` enables its `kai-scheduler` backend by default. When Grove's `kai-scheduler` profile is active, disable KAI's independent stale PodGroup eviction by setting `scheduler.args.default-staleness-grace-period` to `"-1s"` in the KAI Scheduler chart; Grove owns PodGroup termination timing. Keep KAI's normal cleanup behavior when using KAI without Grove or when an externally managed Grove has that profile disabled. The bundled Grove subchart also enables its CRD installer so new and updated Grove CRDs are applied before its operator starts during upgrades.
 
 After installing them separately, enable Dynamo integration:
 
@@ -242,7 +242,7 @@ global:
 kai-scheduler:
   scheduler:
     args:
-      default-staleness-grace-period: "-1"  # Grove owns PodGroup cleanup
+      default-staleness-grace-period: "-1s"  # Grove owns PodGroup cleanup
 ```
 
 The chart requires this KAI override when it installs both bundled subcharts. With externally managed Grove, set the override only when its `kai-scheduler` profile is active. KAI-only installations should omit it.

--- a/deploy/helm/charts/platform/templates/validate-values.yaml
+++ b/deploy/helm/charts/platform/templates/validate-values.yaml
@@ -130,7 +130,8 @@ Volcano:
   {{- $schedulerValues := default (dict) (index $kaiValues "scheduler") }}
   {{- $schedulerArgs := default (dict) (index $schedulerValues "args") }}
   {{- $stalenessGracePeriod := default "" (index $schedulerArgs "default-staleness-grace-period") | toString }}
-  {{- if ne $stalenessGracePeriod "-1" }}
+  {{- /* KAI parses this value as time.Duration, so the unit is required. */ -}}
+  {{- if ne $stalenessGracePeriod "-1s" }}
     {{- fail `
 CONFIGURATION ERROR: bundled KAI Scheduler must disable stale PodGroup eviction when Grove integration is enabled.
 Grove owns PodGroup termination timing, so KAI must not independently delete stale PodGroups.
@@ -140,7 +141,7 @@ Add this value:
 kai-scheduler:
   scheduler:
     args:
-      default-staleness-grace-period: "-1"
+      default-staleness-grace-period: "-1s"
 ` }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/charts/platform/tests/validate_removed_values_test.yaml
+++ b/deploy/helm/charts/platform/tests/validate_removed_values_test.yaml
@@ -67,11 +67,20 @@ tests:
       - failedTemplate:
           errorPattern: "bundled KAI Scheduler must disable stale PodGroup eviction"
 
-  - it: should allow bundled KAI with bundled Grove and the stale PodGroup override
+  - it: should reject the unitless stale PodGroup override
     set:
       global.kai-scheduler.install: true
       global.grove.install: true
       kai-scheduler.scheduler.args.default-staleness-grace-period: "-1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "bundled KAI Scheduler must disable stale PodGroup eviction"
+
+  - it: should allow bundled KAI with bundled Grove and the stale PodGroup override
+    set:
+      global.kai-scheduler.install: true
+      global.grove.install: true
+      kai-scheduler.scheduler.args.default-staleness-grace-period: "-1s"
     asserts:
       - notFailedTemplate: {}
 

--- a/docs/fern/pages/kubernetes/installation/install-dynamo.md
+++ b/docs/fern/pages/kubernetes/installation/install-dynamo.md
@@ -139,7 +139,7 @@ helm install dynamo-platform dynamo-platform-$RELEASE_VERSION.tgz \
   # Option A (install=true): Dynamo installs and manages Grove/KAI as bundled subcharts (dev/testing):
   # --set "global.grove.install=true" \
   # --set "global.kai-scheduler.install=true" \
-  # --set-string "kai-scheduler.scheduler.args.default-staleness-grace-period=-1" \
+  # --set-string "kai-scheduler.scheduler.args.default-staleness-grace-period=-1s" \
   # Option B (enabled=true): Grove/KAI are already installed externally (production):
   # --set "global.grove.enabled=true" \
   # --set "global.kai-scheduler.enabled=true" \

--- a/docs/fern/pages/kubernetes/installation/multinode-orchestration.md
+++ b/docs/fern/pages/kubernetes/installation/multinode-orchestration.md
@@ -21,7 +21,7 @@ Grove is the default and recommended orchestrator for multinode deployments. It 
   --create-namespace \
   --set "global.grove.install=true" \
   --set "global.kai-scheduler.install=true" \
-  --set-string "kai-scheduler.scheduler.args.default-staleness-grace-period=-1"
+  --set-string "kai-scheduler.scheduler.args.default-staleness-grace-period=-1s"
   ```
   </Tab>
   <Tab title="External Installation" value="external">


### PR DESCRIPTION
Linear: [DYN-4386](https://linear.app/nvidia/issue/DYN-4386/dynamorelease150kubernetes-grovekai-scheduler-podgroup-conflict-causes)

Cherry-pick of #14722.

## Summary

- Require the valid Go duration `-1s` when bundled Grove and KAI Scheduler are installed together.
- Reject the previously documented unitless `-1`, which causes KAI Scheduler to fail at startup.
- Update the Kubernetes installation guidance and regenerated platform chart README.

## Validation

- `make test` in `deploy/helm/charts/platform`: 13 suites, 51 tests passed.
- `make lint` in `deploy/helm/charts/platform`: passed.
- `python3 docs/fern/scripts/docs_lint.py --scan docs`: 0 errors.
- Pre-commit hooks for all changed files: passed.
- `git diff --check`: passed.

## Related Issues

- Relates to #14722
- Relates to #14553