### PR TITLE
fix(sglang): reject unsupported sidecar token allowlists

### DIFF
--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -245,6 +245,19 @@ impl LLMEngine for SglangSidecarEngine {
         request: PreprocessedRequest,
         ctx: GenerateContext,
     ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        if request
+            .extra_args
+            .as_ref()
+            .and_then(|extra| extra.get("sampling_options"))
+            .and_then(|sampling| sampling.get("allowed_token_ids"))
+            .is_some_and(|ids| !ids.is_null())
+        {
+            let error =
+                client::invalid_arg("allowed_token_ids is not supported by the SGLang sidecar");
+            // A stream error preserves the client error classification across
+            // Dynamo's request plane, before either native transport can run.
+            return Ok(Box::pin(futures::stream::once(async move { Err(error) })));
+        }
         let state = self
             .state
             .get()
@@ -956,14 +969,103 @@ fn build_engine_config(
 
 #[cfg(test)]
 mod tests {
+    use dynamo_backend_common::{
+        BackendError, ErrorType, GenerateContext, LLMEngine, OutputOptions, PreprocessedRequest,
+        SamplingOptions, StopConditions, testing::mock_context,
+    };
     use dynamo_sidecar_common::GrpcEndpoint;
+    use futures::StreamExt;
     use serde_json::json;
+    use tokio::sync::OnceCell;
+    use tokio_util::sync::CancellationToken;
 
     use super::{
-        DisaggregationMode, DiscoveredKvEventSource, Discovery, build_engine_config,
-        discover_kv_event_sources, hicache_native_offloading_capacity,
+        DisaggregationMode, DiscoveredKvEventSource, Discovery, SglangSidecarEngine,
+        build_engine_config, discover_kv_event_sources, hicache_native_offloading_capacity,
         resolve_bootstrap_host_with_local, sglang_eagle_enabled,
     };
+
+    #[tokio::test]
+    async fn unsupported_allowlists_are_typed_stream_errors_before_native_dispatch() {
+        for mode in [
+            DisaggregationMode::Aggregated,
+            DisaggregationMode::Prefill,
+            DisaggregationMode::Decode,
+        ] {
+            // Leave the engine unstarted: validation must not depend on native
+            // connectivity, and unrestricted controls retain the lifecycle error.
+            let engine = SglangSidecarEngine {
+                endpoint: GrpcEndpoint::parse("127.0.0.1:30001", "test").unwrap(),
+                transport: Default::default(),
+                disaggregation_mode: mode,
+                bootstrap_host: None,
+                bootstrap_port: None,
+                state: OnceCell::new(),
+                cancel: CancellationToken::new(),
+            };
+            for native_http in [false, true] {
+                for (extra, unrestricted) in [
+                    (None, true),
+                    (
+                        Some(json!({"sampling_options": {"allowed_token_ids": null}})),
+                        true,
+                    ),
+                    (
+                        Some(json!({"sampling_options": {"unrelated": [198]}})),
+                        true,
+                    ),
+                    (
+                        Some(json!({"sampling_options": {"allowed_token_ids": [198]}})),
+                        false,
+                    ),
+                    (
+                        Some(json!({"sampling_options": {"allowed_token_ids": []}})),
+                        false,
+                    ),
+                    (
+                        Some(json!({"sampling_options": {"allowed_token_ids": 198}})),
+                        false,
+                    ),
+                ] {
+                    let mut request = PreprocessedRequest::builder()
+                        .model("model".to_string())
+                        .token_ids(vec![1, 2, 3])
+                        .sampling_options(SamplingOptions::default())
+                        .output_options(OutputOptions::default())
+                        .stop_conditions(StopConditions::default())
+                        .build()
+                        .unwrap();
+                    request.extra_args = extra;
+                    if native_http {
+                        request.extra_args.get_or_insert_with(|| json!({}))["sglang_tito"] =
+                            json!({});
+                    }
+                    let result = engine
+                        .generate(request, GenerateContext::new(mock_context(), None))
+                        .await;
+                    if unrestricted {
+                        assert_eq!(
+                            result
+                                .err()
+                                .expect("unstarted engine must fail")
+                                .error_type(),
+                            ErrorType::Backend(BackendError::EngineShutdown)
+                        );
+                    } else {
+                        let mut stream =
+                            result.expect("client errors must survive the response stream");
+                        let error = stream.next().await.unwrap().unwrap_err();
+                        assert_eq!(
+                            error.error_type(),
+                            ErrorType::Backend(BackendError::InvalidArgument)
+                        );
+                        assert!(error.to_string().contains("allowed_token_ids"));
+                        assert!(stream.next().await.is_none());
+                    }
+                }
+            }
+        }
+    }
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
         Discovery {


### PR DESCRIPTION
**Withdrawn:** The sidecar should follow the engine's behavior with minimal translation, without adding an independent rejection policy for unsupported `allowed_token_ids`. vLLM passthrough/parity fixes remain separate. Transport or engine-API differences should be documented rather than replaced with custom sidecar rejection logic. The implementation and validation below are retained as historical evidence; this change is not proposed for merging.

## Summary

The SGLang sidecar silently drops `allowed_token_ids` from canonical `extra_args.sampling_options`. A request restricting output to `[198]` can consequently generate arbitrary tokens. Reject a non-null allowlist at engine entry, before native gRPC/HTTP dispatch or a prefill handoff. Omitted/null values remain unrestricted at the sidecar boundary.

Return a terminal stream containing the existing typed `Backend(InvalidArgument)` error. Returning the error synchronously while opening the stream loses its classification in the request-plane prologue and can cause connection retries. The guard reads the existing JSON by reference and does not parse or copy token IDs.

This PR changes only the SGLang sidecar. The canonical guard also applies when an opaque SGLang HTTP payload is present; it does not reinterpret that payload. The frontend's common null/empty validation is handled separately in #14698.

## Validation

- Engine-entry regression fails without the guard and passes with it; all 37 library tests pass. The regression checks typed terminal rejection across worker modes and presence of the native HTTP marker, plus omitted/null/unrelated controls retaining their previous lifecycle behavior.
- `cargo fmt --all -- --check`, `git diff --check`, and the sidecar executable build pass. Independent adversarial source review completed.
- Real Dynamo HTTP frontend, TCP request plane and this sidecar, backed by a recording native gRPC fixture: 16 cases across Chat/Completions, streaming/non-streaming and omitted/null/empty/nonempty values. All eight constrained requests cause zero native Generate calls; each unrestricted control succeeds with one call. Non-streaming constraints return HTTP 400.
- Known frontend gap: the two nonempty streaming cases return HTTP 200 followed by a generic `internal_server_error`/500 SSE event and `[DONE]`, with zero native calls. The rejection works, but the requested-parameter explanation is lost in shared frontend SSE conversion. Those two error-detail checks fail and are not claimed as passing.

The HTTP audit composes this sidecar with frontend draft #14698 (`ace8fef`), which supplies public null acceptance. Native responses are fixtures; these checks do not establish GPU inference or full disaggregated serving.

## Related Issues

- [x] Confirmed — no related issue. Companion frontend PR: #14698.
