### PR TITLE
fix(trtllm): reject unsupported sidecar token allowlists

### DIFF
--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -198,6 +198,21 @@ impl LLMEngine for TrtllmSidecarEngine {
             .client
             .get()
             .ok_or_else(|| client::engine_shutdown("TensorRT-LLM sidecar is not started"))?;
+        if request
+            .extra_args
+            .as_ref()
+            .and_then(|extra| extra.get("sampling_options"))
+            .and_then(|sampling| sampling.get("allowed_token_ids"))
+            .is_some_and(|ids| !ids.is_null())
+        {
+            // Null is unrestricted in Dynamo's API. Stream the client error
+            // so the transport preserves its type instead of treating it as a
+            // connection failure from the response prologue.
+            let error = client::invalid_argument(
+                "allowed_token_ids is not supported by the TensorRT-LLM sidecar",
+            );
+            return Ok(Box::pin(futures::stream::once(async move { Err(error) })));
+        }
         let request_id = ctx.id().to_string();
         let proto_request =
             build_generate_request(&request, &request_id, self.context_length.get().copied())?;

--- a/lib/sidecar/trtllm/src/tests.rs
+++ b/lib/sidecar/trtllm/src/tests.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use dynamo_backend_common::{
-    FinishReason, GenerateContext, LLMEngine, OutputOptions, PreprocessedRequest, SamplingOptions,
-    StopConditions, StopReason,
+    BackendError, ErrorType, FinishReason, GenerateContext, LLMEngine, OutputOptions,
+    PreprocessedRequest, SamplingOptions, StopConditions, StopReason,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -785,7 +785,50 @@ async fn unsupported_features_fail_before_rpc_submission() {
             .await;
         assert!(result.is_err());
     }
+    // Internal callers can bypass frontend array validation. Reject every
+    // non-null allowlist rather than silently generating unconstrained tokens.
+    for ids in [json!([198]), json!([]), json!("198")] {
+        let mut unsupported = request();
+        unsupported.extra_args = Some(json!({"sampling_options": {"allowed_token_ids": ids}}));
+        let context = dynamo_backend_common::testing::mock_context();
+        let mut stream = engine
+            .generate(unsupported, GenerateContext::new(context, None))
+            .await
+            .expect("unsupported allowlist must produce an error stream");
+        let error = stream
+            .next()
+            .await
+            .expect("error stream must contain an error")
+            .err()
+            .expect("unsupported allowlist must fail");
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert!(error.to_string().contains("allowed_token_ids"));
+        assert!(stream.next().await.is_none());
+    }
     assert!(server.service.requests.lock().await.is_empty());
+
+    // Omitted/null allowlists are unrestricted; other extensions retain their
+    // existing behavior and must not be rejected by this capability check.
+    for extra_args in [
+        None,
+        Some(json!({"sampling_options": {"allowed_token_ids": null}})),
+        Some(json!({"sampling_options": {"other_extension": true}})),
+    ] {
+        let mut supported = request();
+        supported.extra_args = extra_args;
+        let context = dynamo_backend_common::testing::mock_context();
+        let mut stream = engine
+            .generate(supported, GenerateContext::new(context, None))
+            .await
+            .expect("unrestricted request must be submitted");
+        while let Some(output) = stream.next().await {
+            output.expect("unrestricted generation must succeed");
+        }
+    }
+    assert_eq!(server.service.requests.lock().await.len(), 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Native TensorRT-LLM HTTP rejects `allowed_token_ids`, but the sidecar's typed gRPC sampling request has no field that can carry it. The converter currently drops the constraint and submits an unconstrained request, so the engine never gets an opportunity to reject it. Add a minimal sidecar compatibility check for a non-null canonical `extra_args.sampling_options.allowed_token_ids` before conversion or native Generate submission.

This is scoped to preserving TensorRT-LLM's rejection of a requested constraint. SGLang's native HTTP API ignores the unknown field, so it does not receive an equivalent rejection rule. The separate SGLang proposal #14742 remains closed.

Null is a deliberate shared Dynamo API distinction: omission and explicit null mean unrestricted, as selected for the frontend in #14698. Native TensorRT-LLM HTTP itself rejects even explicit null. This PR preserves the shared Dynamo null contract; it does not claim exact native HTTP parity for every input.

Return a terminal stream containing the existing typed `Backend(InvalidArgument)` error. A synchronous stream-opening error loses its classification in the request-plane prologue and can cause connection retries. The guard reads the existing JSON by reference without parsing or copying token IDs. Only the TensorRT-LLM sidecar and its existing regression test change.

## Validation

- Extended the existing `unsupported_features_fail_before_rpc_submission` test. It fails without the guard and passes with it: nonempty/empty/malformed internal values produce a typed terminal error and zero native RPCs; omitted/null/unrelated controls complete successfully. All 22 library tests pass.
- `cargo fmt --all -- --check`, `git diff --check`, and the sidecar executable build pass. Independent adversarial source review completed.
- Real Dynamo HTTP frontend, TCP request plane and this sidecar, backed by a recording native gRPC fixture: 16 cases across Chat/Completions, streaming/non-streaming and omitted/null/empty/nonempty values. All eight constrained requests cause zero native Generate calls; each unrestricted control succeeds with one call. Non-streaming constraints return HTTP 400.
- Known frontend gap: the two nonempty streaming cases return HTTP 200 followed by a generic `internal_server_error`/500 SSE event and `[DONE]`, with zero native calls. The rejection works, but the requested-parameter explanation is lost in shared frontend SSE conversion. Those two error-detail checks fail and are not claimed as passing.

The HTTP audit composes this sidecar with frontend draft #14698 (`ace8fef`), which supplies public null acceptance. Native responses are fixtures; these checks do not establish GPU inference.

## Related Issues

- [x] Confirmed — no related issue. Companion frontend PR: #14698.
