### PR TITLE
fix(benchmarks): isolate router benchmark imports

### DIFF
--- a/benchmarks/router/common.py
+++ b/benchmarks/router/common.py
@@ -5,6 +5,7 @@
 
 """Common utilities shared across router benchmark scripts."""
 
+import copy
 import json
 import logging
 import os
@@ -234,6 +235,16 @@ def add_expected_osl(request):
     """Add the trace output length as the router's expected OSL hint."""
     osl = request.get("output_length", request.get("output_tokens", 0))
     set_trace_agent_hint(request, "osl", osl)
+
+
+def tag_requests_with_priority(requests, priority):
+    """Return request copies with extra.nvext.agent_hints.priority merged in."""
+    tagged_requests = []
+    for request in requests:
+        tagged_request = copy.deepcopy(request)
+        set_trace_agent_hint(tagged_request, "priority", priority)
+        tagged_requests.append(tagged_request)
+    return tagged_requests
 
 
 def prepare_trace_dataset(args, output_dir, logger):

--- a/benchmarks/router/real_data_priority_benchmark.py
+++ b/benchmarks/router/real_data_priority_benchmark.py
@@ -15,15 +15,27 @@ import subprocess
 
 import matplotlib.pyplot as plt
 import numpy as np
-from common import (
-    add_common_args,
-    add_synthesis_args,
-    get_aiperf_cmd_for_trace,
-    prepare_trace_dataset,
-    resolve_tokenizer,
-    set_trace_agent_hint,
-    setup_logger,
-)
+
+if __package__:
+    from .common import (
+        add_common_args,
+        add_synthesis_args,
+        get_aiperf_cmd_for_trace,
+        prepare_trace_dataset,
+        resolve_tokenizer,
+        set_trace_agent_hint,
+        setup_logger,
+    )
+else:
+    from common import (
+        add_common_args,
+        add_synthesis_args,
+        get_aiperf_cmd_for_trace,
+        prepare_trace_dataset,
+        resolve_tokenizer,
+        set_trace_agent_hint,
+        setup_logger,
+    )
 
 logger = setup_logger(__name__)
 

--- a/benchmarks/router/real_data_priority_benchmark.py
+++ b/benchmarks/router/real_data_priority_benchmark.py
@@ -15,27 +15,15 @@ import subprocess
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-if __package__:
-    from .common import (
-        add_common_args,
-        add_synthesis_args,
-        get_aiperf_cmd_for_trace,
-        prepare_trace_dataset,
-        resolve_tokenizer,
-        set_trace_agent_hint,
-        setup_logger,
-    )
-else:
-    from common import (
-        add_common_args,
-        add_synthesis_args,
-        get_aiperf_cmd_for_trace,
-        prepare_trace_dataset,
-        resolve_tokenizer,
-        set_trace_agent_hint,
-        setup_logger,
-    )
+from common import (
+    add_common_args,
+    add_synthesis_args,
+    get_aiperf_cmd_for_trace,
+    prepare_trace_dataset,
+    resolve_tokenizer,
+    setup_logger,
+    tag_requests_with_priority,
+)
 
 logger = setup_logger(__name__)
 
@@ -83,16 +71,6 @@ def offset_hash_ids(tier_requests):
             r["hash_ids"] = [h + offset for h in r["hash_ids"]]
             shifted[tier].append(r)
     return shifted
-
-
-def tag_requests_with_priority(requests, priority):
-    """Return request copies with extra.nvext.agent_hints.priority merged in."""
-    tagged_requests = []
-    for request in requests:
-        tagged_request = copy.deepcopy(request)
-        set_trace_agent_hint(tagged_request, "priority", priority)
-        tagged_requests.append(tagged_request)
-    return tagged_requests
 
 
 def write_trace_file(requests, path):

--- a/benchmarks/router/tests/conftest.py
+++ b/benchmarks/router/tests/conftest.py
@@ -1,23 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import sys
 from pathlib import Path
 
-import pytest
-
 _BENCHMARKS_DIR = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_BENCHMARKS_DIR))
-
-
-@pytest.fixture(scope="session")
-def benchmark_env(tmp_path_factory):
-    return {
-        **os.environ,
-        "MPLBACKEND": "Agg",
-        "MPLCONFIGDIR": str(tmp_path_factory.mktemp("router-matplotlib")),
-        "PYTHONPATH": os.pathsep.join(
-            (str(_BENCHMARKS_DIR), os.environ.get("PYTHONPATH", ""))
-        ),
-    }

--- a/benchmarks/router/tests/conftest.py
+++ b/benchmarks/router/tests/conftest.py
@@ -1,8 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 from pathlib import Path
 
-_ROUTER_DIR = Path(__file__).resolve().parents[1]
-sys.path[:0] = [str(_ROUTER_DIR.parent), str(_ROUTER_DIR)]
+import pytest
+
+_BENCHMARKS_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BENCHMARKS_DIR))
+
+
+@pytest.fixture(scope="session")
+def benchmark_env(tmp_path_factory):
+    return {
+        **os.environ,
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": str(tmp_path_factory.mktemp("router-matplotlib")),
+        "PYTHONPATH": os.pathsep.join(
+            (str(_BENCHMARKS_DIR), os.environ.get("PYTHONPATH", ""))
+        ),
+    }

--- a/benchmarks/router/tests/test_common.py
+++ b/benchmarks/router/tests/test_common.py
@@ -1,8 +1,85 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from router.common import add_expected_osl
-from router.real_data_priority_benchmark import tag_requests_with_priority
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from benchmarks.router.common import add_expected_osl
+from benchmarks.router.real_data_priority_benchmark import tag_requests_with_priority
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.parallel,
+]
+
+
+@pytest.mark.parametrize("preload_common", [False, True])
+@pytest.mark.timeout(30)
+def test_benchmark_import_preserves_unrelated_common_package(
+    tmp_path, benchmark_env, preload_common
+):
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    for filename in ("__init__.py", "backend.py", "utils.py"):
+        (common_dir / filename).write_text("")
+
+    repo_root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib
+import runpy
+import sys
+from pathlib import Path
+
+repo_root = Path.cwd()
+sys.path.insert(0, sys.argv[1])
+if sys.argv[2] == "True":
+    importlib.import_module("common")
+runpy.run_path(str(repo_root / "benchmarks/router/tests/conftest.py"))
+importlib.import_module("benchmarks.router.real_data_priority_benchmark")
+for name in ("common.backend", "common.utils"):
+    module = importlib.import_module(name)
+    assert Path(module.__file__).parent == Path(sys.argv[1]) / "common"
+""",
+            str(tmp_path),
+            str(preload_common),
+        ],
+        cwd=repo_root,
+        env=benchmark_env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("as_module", [False, True])
+@pytest.mark.timeout(30)
+def test_priority_benchmark_cli_help(benchmark_env, as_module):
+    repo_root = Path(__file__).resolve().parents[3]
+    command = (
+        ["-m", "benchmarks.router.real_data_priority_benchmark"]
+        if as_module
+        else [str(repo_root / "benchmarks/router/real_data_priority_benchmark.py")]
+    )
+    result = subprocess.run(
+        [sys.executable, *command, "--help"],
+        cwd=repo_root if as_module else repo_root / "benchmarks/router",
+        env=benchmark_env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "--priority-distribution" in result.stdout
 
 
 def test_expected_osl_uses_mooncake_output_length_and_preserves_hints():

--- a/benchmarks/router/tests/test_common.py
+++ b/benchmarks/router/tests/test_common.py
@@ -3,8 +3,7 @@
 
 import pytest
 
-from benchmarks.router.common import add_expected_osl
-from benchmarks.router.real_data_priority_benchmark import tag_requests_with_priority
+from benchmarks.router.common import add_expected_osl, tag_requests_with_priority
 
 pytestmark = [
     pytest.mark.pre_merge,

--- a/benchmarks/router/tests/test_common.py
+++ b/benchmarks/router/tests/test_common.py
@@ -1,10 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import sys
-from pathlib import Path
-
 import pytest
 
 from benchmarks.router.common import add_expected_osl
@@ -16,70 +12,6 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.parallel,
 ]
-
-
-@pytest.mark.parametrize("preload_common", [False, True])
-@pytest.mark.timeout(30)
-def test_benchmark_import_preserves_unrelated_common_package(
-    tmp_path, benchmark_env, preload_common
-):
-    common_dir = tmp_path / "common"
-    common_dir.mkdir()
-    for filename in ("__init__.py", "backend.py", "utils.py"):
-        (common_dir / filename).write_text("")
-
-    repo_root = Path(__file__).resolve().parents[3]
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            """
-import importlib
-import runpy
-import sys
-from pathlib import Path
-
-repo_root = Path.cwd()
-sys.path.insert(0, sys.argv[1])
-if sys.argv[2] == "True":
-    importlib.import_module("common")
-runpy.run_path(str(repo_root / "benchmarks/router/tests/conftest.py"))
-importlib.import_module("benchmarks.router.real_data_priority_benchmark")
-for name in ("common.backend", "common.utils"):
-    module = importlib.import_module(name)
-    assert Path(module.__file__).parent == Path(sys.argv[1]) / "common"
-""",
-            str(tmp_path),
-            str(preload_common),
-        ],
-        cwd=repo_root,
-        env=benchmark_env,
-        capture_output=True,
-        text=True,
-        timeout=20,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-
-
-@pytest.mark.parametrize("as_module", [False, True])
-@pytest.mark.timeout(30)
-def test_priority_benchmark_cli_help(benchmark_env, as_module):
-    repo_root = Path(__file__).resolve().parents[3]
-    command = (
-        ["-m", "benchmarks.router.real_data_priority_benchmark"]
-        if as_module
-        else [str(repo_root / "benchmarks/router/real_data_priority_benchmark.py")]
-    )
-    result = subprocess.run(
-        [sys.executable, *command, "--help"],
-        cwd=repo_root if as_module else repo_root / "benchmarks/router",
-        env=benchmark_env,
-        capture_output=True,
-        text=True,
-        timeout=20,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "--priority-distribution" in result.stdout
 
 
 def test_expected_osl_uses_mooncake_output_length_and_preserves_hints():


### PR DESCRIPTION
## Summary

Fix the pytest import collision introduced by #14165. Collecting the router benchmark loaded `benchmarks/router/common.py` as the top-level `common` module, which prevented component tests from importing `common.backend` and `common.utils`.

- Remove `benchmarks/router` from the test setup's `sys.path`; retain the parent path required by `prefix_data_generator`.
- Move the priority-tagging helper into `benchmarks/router/common.py` and import both tested helpers through `benchmarks.router.common`. Pytest no longer imports the CLI script.
- Keep the priority benchmark as a directly executed script, using the same helper imports as the other router benchmarks. No `__package__` conditional is needed.
- Keep the three existing OSL/priority behavior tests with explicit CI markers. Add no new tests or fixtures.

The same `No module named 'common.backend'; 'common' is not a package` error appears in both:

- [#11219: vLLM arm64 test job](https://github.com/ai-dynamo/dynamo/actions/runs/34633841027/job/103383198902)
- [#14642: Dynamo sequential amd64 test job](https://github.com/ai-dynamo/dynamo/actions/runs/34640727456/job/103413556181)

This change is limited to benchmark import isolation. Trace-hint behavior and CI configuration are unchanged.

## Validation

Checked the revised patch in the local `dynamo:dev` container with Python 3.12.3, the worktree mounted at `/workspace`, and source paths for components, Python bindings, and benchmarks on `PYTHONPATH`.

- Ran `python3 -m pytest -c pyproject.toml benchmarks/router/tests/test_common.py components/src/dynamo/common/backend/tests components/src/dynamo/common/utils/tests -n 0 -q --tb=short --continue-on-collection-errors --junitxml=...`, then repeated with both component paths before the benchmark path. Each run completed with **3 passed, 6 skipped, 41 errors**, confirmed in JUnit. The three benchmark tests passed in both orders; neither log contained the `common` collision.
- Full component validation remains blocked by missing native bindings in this local image, including `AicPerfConfig` and `dynamo._core.backend`. These runs are not a passing component-suite result; the affected suites still require validation in the CI image.
- Standalone `python3 real_data_priority_benchmark.py --help`: passed with `PYTHONPATH=/workspace/benchmarks` and `MPLBACKEND=Agg`.
- `pre-commit run --files benchmarks/router/common.py benchmarks/router/real_data_priority_benchmark.py benchmarks/router/tests/conftest.py benchmarks/router/tests/test_common.py`: passed.
- `git diff --check`: passed.
