### PR TITLE
fix(sglang): [cherry-pick 1.5.0] stop co-located ranks crashing on a shared NIXL exporter port (#14284)

### DIFF
--- a/components/src/dynamo/common/utils/nixl_telemetry.py
+++ b/components/src/dynamo/common/utils/nixl_telemetry.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exporter ports for NIXL telemetry when several ranks share one pod.
+
+NIXL's Prometheus exporter binds one fixed TCP port, read from
+``NIXL_TELEMETRY_PROMETHEUS_PORT`` when the NIXL agent is constructed, so a
+backend that builds one agent per co-located rank needs one port per rank.
+The port is derived as ``base + local_rank`` rather than left ephemeral
+because it has to be predictable: the operator declares the whole range as
+container ports and the PodMonitor scrapes each one by name. NIXL accepts
+``0`` and binds an ephemeral port, but exposes no accessor for the port it
+actually got, so nothing could name that port as a scrape target.
+
+This module deliberately imports no inference engine: the derivation is pure
+arithmetic over a base port and a rank index, and the callers that know how to
+find a rank index live in the per-backend packages.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+MAX_PORT = 65535
+
+NIXL_TELEMETRY_ENABLE_ENV = "NIXL_TELEMETRY_ENABLE"
+NIXL_TELEMETRY_EXPORTER_ENV = "NIXL_TELEMETRY_EXPORTER"
+NIXL_TELEMETRY_PROMETHEUS_PORT_ENV = "NIXL_TELEMETRY_PROMETHEUS_PORT"
+
+DEFAULT_NIXL_PROMETHEUS_PORT = 19090
+
+# Keep in sync with DynamoMaxNixlPorts in deploy/operator/internal/consts/consts.go:
+# a rank deriving a port past the reserved range would bind a port nothing scrapes.
+MAX_COLOCATED_NIXL_EXPORTERS = 8
+
+# Listeners the container already owns, as (env var, default base). Each is
+# treated as a MAX_COLOCATED_NIXL_EXPORTERS-wide range: both are per-rank bases elsewhere.
+_COLLIDING_PORT_ENVS = ("DYN_SYSTEM_PORT", "DYN_FORWARDPASS_METRIC_PORT")
+
+
+def configured_fixed_port(
+    env_name: str,
+    *,
+    default: int | None = None,
+    env: Mapping[str, str] | None = None,
+) -> int | None:
+    """Return a configured fixed TCP port, ignoring disabled/invalid values.
+
+    Mirrors ``dynamo.vllm.backend_args._configured_fixed_port`` so that a value
+    this package accepts is exactly a value that package accepts.
+    """
+    environ = os.environ if env is None else env
+    raw = environ.get(env_name)
+    if raw is None:
+        return default
+    try:
+        port = int(raw)
+    except ValueError:
+        return None
+    return port if 0 < port <= MAX_PORT else None
+
+
+def nixl_prometheus_base_port(env: Mapping[str, str] | None = None) -> int | None:
+    """Return the base NIXL Prometheus port, or None when it is not in use."""
+    environ = os.environ if env is None else env
+    enabled = environ.get(NIXL_TELEMETRY_ENABLE_ENV, "").strip().lower()
+    exporter = environ.get(NIXL_TELEMETRY_EXPORTER_ENV, "prometheus")
+    if enabled != "y" or exporter.strip().lower() != "prometheus":
+        return None
+    return configured_fixed_port(
+        NIXL_TELEMETRY_PROMETHEUS_PORT_ENV,
+        default=DEFAULT_NIXL_PROMETHEUS_PORT,
+        env=environ,
+    )
+
+
+def reserved_port_ranges(
+    env: Mapping[str, str] | None = None,
+    *,
+    width: int = MAX_COLOCATED_NIXL_EXPORTERS,
+) -> list[tuple[str, int, int]]:
+    """Inclusive port ranges already claimed by other listeners in this container."""
+    environ = os.environ if env is None else env
+    ranges: list[tuple[str, int, int]] = []
+    for env_name in _COLLIDING_PORT_ENVS:
+        if env_name not in environ:
+            continue
+        base = configured_fixed_port(env_name, env=environ)
+        if base is None:
+            continue
+        ranges.append((env_name, base, min(base + width - 1, MAX_PORT)))
+    return ranges
+
+
+def derive_nixl_prometheus_port(
+    base_port: int,
+    local_rank: int,
+    *,
+    max_ranks: int = MAX_COLOCATED_NIXL_EXPORTERS,
+    env: Mapping[str, str] | None = None,
+) -> int:
+    """Return the exporter port for one node-local rank.
+
+    ``local_rank`` is the rank's index *within its pod*, not its global rank: a
+    port range is reserved per pod, so a multi-node deployment restarts the
+    offset on every node.
+
+    ``max_ranks`` is how wide that reservation is. A caller that knows how many
+    ranks its launch actually places on a node should pass that count rather
+    than the maximum, because every check below measures that whole span.
+
+    Raises ValueError rather than returning a port outside the reservation.
+    """
+    # A narrower reservation is the caller describing its own launch, but a
+    # wider one would hand out ports past the range the operator declares as
+    # container ports, which is the one thing no caller may narrow away.
+    if max_ranks < 1 or max_ranks > MAX_COLOCATED_NIXL_EXPORTERS:
+        raise ValueError(
+            f"a pod reserves between 1 and {MAX_COLOCATED_NIXL_EXPORTERS} NIXL "
+            f"exporter ports, so {max_ranks} co-located ranks cannot each be given "
+            f"a declared port to be scraped on."
+        )
+
+    if base_port < 1:
+        raise ValueError(
+            f"{NIXL_TELEMETRY_PROMETHEUS_PORT_ENV}={base_port} is not a usable TCP "
+            f"port. Set it between 1 and {MAX_PORT}."
+        )
+
+    # Reject the whole range up front, not just this rank's port. A base that
+    # leaves room for rank 0 alone would start one scheduler and fail the next,
+    # leaving the pod with a partially started scheduler set and never Ready.
+    last_port = base_port + max_ranks - 1
+    if last_port > MAX_PORT:
+        raise ValueError(
+            f"{NIXL_TELEMETRY_PROMETHEUS_PORT_ENV}={base_port} with {max_ranks} "
+            f"co-located ranks needs ports {base_port}-{last_port}, "
+            f"which exceeds the maximum port {MAX_PORT}. Lower "
+            f"{NIXL_TELEMETRY_PROMETHEUS_PORT_ENV}."
+        )
+
+    # Compare the whole reserved range against each listener, not just this
+    # rank's port. A base one below another listener leaves rank 0 clear and
+    # collides from rank 1 on, so checking a single port lets the pod start one
+    # scheduler and then fail every later one.
+    for env_name, start, end in reserved_port_ranges(env, width=max_ranks):
+        if base_port <= end and start <= last_port:
+            raise ValueError(
+                f"the NIXL exporter range {base_port}-{last_port} overlaps "
+                f"{env_name}, which reserves {start}-{end}. Configure "
+                f"non-overlapping ports."
+            )
+
+    if local_rank < 0 or local_rank >= max_ranks:
+        raise ValueError(
+            f"node-local rank {local_rank} is outside the reserved NIXL exporter "
+            f"range of {max_ranks} ports starting at {base_port}. The pod reserves "
+            f"one port per co-located rank; a rank beyond that range has no "
+            f"declared container port and would not be scraped."
+        )
+
+    return base_port + local_rank

--- a/components/src/dynamo/common/utils/tests/test_nixl_telemetry.py
+++ b/components/src/dynamo/common/utils/tests/test_nixl_telemetry.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dynamo.common.utils.nixl_telemetry."""
+
+import pytest
+
+from dynamo.common.utils.nixl_telemetry import (
+    MAX_COLOCATED_NIXL_EXPORTERS,
+    MAX_PORT,
+    derive_nixl_prometheus_port,
+    nixl_prometheus_base_port,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+# The ports the operator injects into a worker container today.
+OPERATOR_ENV = {
+    "NIXL_TELEMETRY_ENABLE": "y",
+    "NIXL_TELEMETRY_EXPORTER": "prometheus",
+    "NIXL_TELEMETRY_PROMETHEUS_PORT": "19090",
+    "DYN_SYSTEM_PORT": "9090",
+    "DYN_FORWARDPASS_METRIC_PORT": "20380",
+}
+
+
+class TestDeriveNixlPrometheusPort:
+    def test_colocated_ranks_never_share_an_exporter_port(self):
+        base = int(OPERATOR_ENV["NIXL_TELEMETRY_PROMETHEUS_PORT"])
+        ports = {
+            derive_nixl_prometheus_port(base, rank, env=OPERATOR_ENV)
+            for rank in range(MAX_COLOCATED_NIXL_EXPORTERS)
+        }
+        assert len(ports) == MAX_COLOCATED_NIXL_EXPORTERS
+
+    def test_derived_ports_stay_inside_the_reserved_range(self):
+        """A port past the reserved range binds where nothing scrapes it."""
+        base = int(OPERATOR_ENV["NIXL_TELEMETRY_PROMETHEUS_PORT"])
+        ports = [
+            derive_nixl_prometheus_port(base, rank, env=OPERATOR_ENV)
+            for rank in range(MAX_COLOCATED_NIXL_EXPORTERS)
+        ]
+        assert min(ports) >= base
+        assert max(ports) <= base + MAX_COLOCATED_NIXL_EXPORTERS - 1
+
+    def test_rank_beyond_the_reserved_range_is_rejected(self):
+        with pytest.raises(ValueError, match="outside the reserved"):
+            derive_nixl_prometheus_port(
+                19090, MAX_COLOCATED_NIXL_EXPORTERS, env=OPERATOR_ENV
+            )
+
+    @pytest.mark.parametrize(
+        "env_name", ["DYN_SYSTEM_PORT", "DYN_FORWARDPASS_METRIC_PORT"]
+    )
+    def test_base_that_would_overlap_another_listener_is_rejected(self, env_name):
+        # One below the listener's own base: rank 0 lands just clear of it and
+        # only later ranks collide, so rejecting rank 0 is what stops the pod
+        # from starting one scheduler and failing the rest.
+        overlapping_base = int(OPERATOR_ENV[env_name]) - 1
+        with pytest.raises(ValueError, match=env_name):
+            derive_nixl_prometheus_port(overlapping_base, 0, env=OPERATOR_ENV)
+
+    def test_base_too_high_for_the_reserved_range_is_rejected(self):
+        # Rank 0 fits at MAX_PORT on its own; rejecting it is what stops the pod
+        # from starting one scheduler and failing every rank after it.
+        with pytest.raises(ValueError, match="exceeds the maximum port"):
+            derive_nixl_prometheus_port(MAX_PORT, 0, env=OPERATOR_ENV)
+
+    def test_a_narrower_launch_is_measured_against_its_own_width(self):
+        """The pod reserves one port per rank it places, not the maximum."""
+        base = MAX_PORT - 3
+        ports = [
+            derive_nixl_prometheus_port(base, rank, max_ranks=4, env=OPERATOR_ENV)
+            for rank in range(4)
+        ]
+        assert ports == [MAX_PORT - 3, MAX_PORT - 2, MAX_PORT - 1, MAX_PORT]
+
+    def test_a_rank_outside_a_narrower_launch_is_rejected(self):
+        with pytest.raises(ValueError, match="outside the reserved"):
+            derive_nixl_prometheus_port(19090, 4, max_ranks=4, env=OPERATOR_ENV)
+
+    def test_a_launch_wider_than_the_pod_reserves_is_rejected(self):
+        """Ranks past the declared container ports would be scraped by nobody."""
+        with pytest.raises(ValueError, match="cannot each be given"):
+            derive_nixl_prometheus_port(
+                19090,
+                0,
+                max_ranks=MAX_COLOCATED_NIXL_EXPORTERS + 1,
+                env=OPERATOR_ENV,
+            )
+
+
+class TestNixlPrometheusBasePort:
+    def test_operator_defaults_are_recognized(self):
+        assert nixl_prometheus_base_port(OPERATOR_ENV) == 19090
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"NIXL_TELEMETRY_ENABLE": "n"},
+            {"NIXL_TELEMETRY_ENABLE": ""},
+            {"NIXL_TELEMETRY_EXPORTER": "file"},
+        ],
+    )
+    def test_disabled_telemetry_has_no_base_port(self, override):
+        assert nixl_prometheus_base_port({**OPERATOR_ENV, **override}) is None

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -31,6 +31,7 @@ from dynamo.sglang.init_multimodal import (
     init_multimodal_prefill_worker,
     init_multimodal_worker,
 )
+from dynamo.sglang.nixl_telemetry import install_per_rank_nixl_prometheus_ports
 from dynamo.sglang.shutdown import install_graceful_shutdown
 from dynamo.sglang.snapshot import prepare_snapshot_engine
 
@@ -43,6 +44,10 @@ async def worker(argv: list[str] | None = None):
         argv = sys.argv[1:]
     config = await parse_args(argv)
     dump_config(config.dynamo_args.dump_config_to, config)
+
+    # Must run before any sgl.Engine is constructed: it changes how the engine
+    # launches its scheduler processes, each of which needs its own exporter port.
+    install_per_rank_nixl_prometheus_ports()
 
     if (
         config.server_args.load_format == "gms"

--- a/components/src/dynamo/sglang/nixl_telemetry.py
+++ b/components/src/dynamo/sglang/nixl_telemetry.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Give each co-located SGLang scheduler its own NIXL Prometheus exporter port.
+
+SGLang runs one scheduler process per node-local rank, each building its own
+NIXL agent, so the port must be set inside the rank's own process: NIXL reads
+``NIXL_TELEMETRY_PROMETHEUS_PORT`` when the agent is constructed, ``spawn``
+carries only ``os.environ`` into a child, and under ``--enable-dp-attention``
+the schedulers are started by a data-parallel controller rather than by the
+worker process. ``Engine.run_scheduler_process_func`` is SGLang's documented
+override point for exactly this: it is forwarded through the data-parallel
+controller and invoked in the scheduler process with that scheduler's own
+arguments. The wrapper below fixes up the environment and then calls SGLang's
+real entry point. See ``dynamo.common.utils.nixl_telemetry`` for the
+derivation.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+from typing import Any
+
+from dynamo.common.utils.nixl_telemetry import (
+    NIXL_TELEMETRY_ENABLE_ENV,
+    NIXL_TELEMETRY_PROMETHEUS_PORT_ENV,
+    derive_nixl_prometheus_port,
+    nixl_prometheus_base_port,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _node_local_launch_shape(server_args: Any) -> tuple[int, int]:
+    """Return SGLang's own split of the pipeline and tensor dimensions per node."""
+    nnodes = getattr(server_args, "nnodes", 1) or 1
+    tp_size = getattr(server_args, "tp_size", 1) or 1
+    pp_size = getattr(server_args, "pp_size", 1) or 1
+
+    pp_size_per_node = max(pp_size // nnodes, 1)
+    nnodes_per_tp_group = max(nnodes // pp_size, 1)
+    tp_size_per_node = max(tp_size // nnodes_per_tp_group, 1)
+    if getattr(server_args, "is_ep_scale_joiner", False):
+        # A scale joiner enumerates its whole tensor-parallel span on one node.
+        tp_size_per_node = tp_size
+
+    return pp_size_per_node, tp_size_per_node
+
+
+def _node_local_rank_count(server_args: Any, *, dp_rank: int | None) -> int:
+    """Return how many ranks this launch places on one node.
+
+    This is the width of the port range the pod reserves, so it has to count
+    the same schedulers ``_node_local_rank`` numbers: the launch places one on
+    each node-local pipeline and tensor position, and one such group per
+    data-parallel rank whenever ``dp_rank`` names a separate launch group.
+    """
+    pp_size_per_node, tp_size_per_node = _node_local_launch_shape(server_args)
+    ranks = pp_size_per_node * tp_size_per_node
+    if dp_rank is not None and not getattr(server_args, "enable_dp_attention", False):
+        ranks *= max(getattr(server_args, "dp_size", 1) or 1, 1)
+
+    return ranks
+
+
+def _node_local_rank(
+    server_args: Any,
+    *,
+    tp_rank: int,
+    pp_rank: int,
+    dp_rank: int | None,
+) -> int:
+    """Return the scheduler's index among the ranks sharing this node.
+
+    SGLang places a scheduler on a device with ``gpu_id = base_gpu_id +
+    dp_offset + (pp_rank % pp_size_per_node) * tp_size_per_node + (tp_rank %
+    tp_size_per_node) * gpu_id_step``. That device index is not a port index:
+    ``gpu_id_step`` spaces it out, ``base_gpu_id`` and the data-parallel offset
+    shift it, and nothing bounds it by the number of ports the pod reserves.
+    The rank arguments the same launch already computes give the position
+    directly, and counting the pairs this node launches numbers them 0, 1, 2,
+    ... with no gaps.
+
+    ``dp_rank`` names a separate launch group only when SGLang's data-parallel
+    controller starts one tensor-parallel group per data-parallel rank. Under
+    ``--enable-dp-attention`` all ranks share one group and ``dp_rank`` is
+    derived from ``tp_rank``, so folding it in there would hand two schedulers
+    the same number.
+    """
+    pp_size_per_node, tp_size_per_node = _node_local_launch_shape(server_args)
+
+    rank = (pp_rank % pp_size_per_node) * tp_size_per_node + (
+        tp_rank % tp_size_per_node
+    )
+    if dp_rank is not None and not getattr(server_args, "enable_dp_attention", False):
+        rank += dp_rank * pp_size_per_node * tp_size_per_node
+
+    return rank
+
+
+def _assign_nixl_prometheus_port(target: Any, args: tuple, kwargs: dict) -> None:
+    """Rewrite this process's exporter port before the NIXL agent is built."""
+    base_port = nixl_prometheus_base_port()
+    if base_port is None:
+        return
+
+    # SGLang moves scheduler arguments between releases, and a rank this
+    # process was not given is a dimension it does not participate in, which is
+    # what the defaults below describe.
+    bound = inspect.signature(target).bind(*args, **kwargs)
+    bound.apply_defaults()
+    arguments = bound.arguments
+    tp_rank = arguments.get("tp_rank") or 0
+    pp_rank = arguments.get("pp_rank") or 0
+    dp_rank = arguments.get("dp_rank")
+
+    # Number from the resolved configuration, not from the raw ``ServerArgs``
+    # the scheduler is handed: resolution is where attention data parallelism is
+    # turned on, so the raw values would fold ``dp_rank`` in a second time and
+    # send later ranks past the reserved range. Imported here because the module
+    # is imported to reach ``install_per_rank_nixl_prometheus_ports()``, which
+    # must stay a no-op without SGLang when telemetry is off.
+    from dynamo.sglang._compat import resolved_server_args
+
+    server_args = resolved_server_args(arguments["server_args"])
+    local_rank = _node_local_rank(
+        server_args, tp_rank=tp_rank, pp_rank=pp_rank, dp_rank=dp_rank
+    )
+    # The reservation is as wide as this launch, not as wide as a pod may ever
+    # reserve: a four-rank launch that fits below the top of the port range, or
+    # beside another listener eight ports up, is one the maximum would refuse.
+    colocated_ranks = _node_local_rank_count(server_args, dp_rank=dp_rank)
+    port = derive_nixl_prometheus_port(base_port, local_rank, max_ranks=colocated_ranks)
+    os.environ[NIXL_TELEMETRY_PROMETHEUS_PORT_ENV] = str(port)
+    logger.info(
+        "NIXL Prometheus exporter for tp_rank=%s pp_rank=%s dp_rank=%s is "
+        "node-local rank %s of %s and listens on port %s (base %s)",
+        tp_rank,
+        pp_rank,
+        dp_rank,
+        local_rank,
+        colocated_ranks,
+        port,
+        base_port,
+    )
+
+
+def run_scheduler_process_with_nixl_port(*args: Any, **kwargs: Any) -> Any:
+    """SGLang scheduler entry point that first claims this rank's exporter port.
+
+    Must stay a module-level function: ``spawn`` pickles the process target by
+    module and qualified name.
+    """
+    from sglang.srt.managers.scheduler import run_scheduler_process
+
+    _assign_nixl_prometheus_port(run_scheduler_process, args, kwargs)
+    return run_scheduler_process(*args, **kwargs)
+
+
+def install_per_rank_nixl_prometheus_ports() -> None:
+    """Point SGLang's scheduler launches at the wrapper, when telemetry is on.
+
+    A no-op when NIXL Prometheus telemetry is disabled, so a deployment that
+    does not scrape NIXL keeps SGLang's own entry point. Raises ``RuntimeError``
+    when telemetry is on but this SGLang offers no override point.
+    """
+    if nixl_prometheus_base_port() is None:
+        return
+
+    # Take the class from the module that defines it: ``sglang.Engine`` is a
+    # lazy proxy, so an assignment through it would land on the proxy object and
+    # leave every scheduler on SGLang's own entry point.
+    from sglang.srt.entrypoints.engine import Engine
+
+    if not hasattr(Engine, "run_scheduler_process_func"):
+        raise RuntimeError(
+            f"this SGLang has no Engine.run_scheduler_process_func override "
+            f"point, so co-located ranks cannot be given distinct "
+            f"{NIXL_TELEMETRY_PROMETHEUS_PORT_ENV} values and all but one would "
+            f"fail to bind their NIXL Prometheus exporter. Run a supported "
+            f"SGLang version, or set {NIXL_TELEMETRY_ENABLE_ENV}=n to serve "
+            f"without NIXL telemetry."
+        )
+
+    Engine.run_scheduler_process_func = staticmethod(
+        run_scheduler_process_with_nixl_port
+    )

--- a/components/src/dynamo/sglang/tests/test_sglang_nixl_telemetry_ports.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_nixl_telemetry_ports.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-rank NIXL exporter ports for co-located SGLang schedulers.
+
+These tests replay the arguments SGLang hands each scheduler process rather
+than calling the derivation with hand-picked ranks, because what has to hold is
+that every scheduler a real launch starts gets a port of its own inside the
+range the pod reserves.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import dynamo.sglang._compat as sglang_compat
+from dynamo.common.utils.nixl_telemetry import NIXL_TELEMETRY_PROMETHEUS_PORT_ENV
+from dynamo.sglang.nixl_telemetry import (
+    _assign_nixl_prometheus_port,
+    install_per_rank_nixl_prometheus_ports,
+    run_scheduler_process_with_nixl_port,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+BASE_PORT = 19090
+
+
+def _server_args(**overrides) -> SimpleNamespace:
+    """A ServerArgs stand-in carrying only the fields the derivation reads."""
+    fields = {
+        "nnodes": 1,
+        "node_rank": 0,
+        "tp_size": 1,
+        "pp_size": 1,
+        "dp_size": 1,
+        "base_gpu_id": 0,
+        "gpu_id_step": 1,
+        "enable_dp_attention": False,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _run_scheduler_process(
+    server_args,
+    port_args,
+    gpu_id,
+    tp_rank,
+    attn_cp_rank,
+    moe_dp_rank,
+    moe_ep_rank,
+    pp_rank,
+    dp_rank,
+    pipe_writer,
+):
+    """Stands in for ``sglang.srt.managers.scheduler.run_scheduler_process``.
+
+    Mirrors that function's parameter list because the wrapper binds the call by
+    signature: it reads the rank arguments by name out of a purely positional
+    call, so the position of every other parameter matters too.
+    """
+
+
+def _scheduler_calls(server_args) -> list[tuple[int, int, int, int | None]]:
+    """The ``(gpu_id, tp_rank, pp_rank, dp_rank)`` tuples one node launches.
+
+    Mirrors ``DataParallelController.launch_dp_schedulers`` and
+    ``launch_tensor_parallel_group``, which the non-data-parallel path in
+    ``Engine._launch_subprocesses`` reproduces with ``dp_rank`` left unset.
+    Under ``--enable-dp-attention`` there is one launch group and the scheduler
+    is handed a ``dp_rank`` recomputed from its ``tp_rank``.
+    """
+    pp_size_per_node = max(server_args.pp_size // server_args.nnodes, 1)
+    nnodes_per_pp_rank = max(server_args.nnodes // server_args.pp_size, 1)
+    tp_size_per_node = server_args.tp_size // nnodes_per_pp_rank
+    pp_ranks = range(
+        pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank),
+        pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank + 1),
+    )
+    tp_ranks = range(
+        tp_size_per_node * (server_args.node_rank % nnodes_per_pp_rank),
+        tp_size_per_node * (server_args.node_rank % nnodes_per_pp_rank + 1),
+    )
+
+    attn_tp_size = max(server_args.tp_size // server_args.dp_size, 1)
+    dp_groups: list[tuple[int, int | None]] = [(0, None)]
+    if server_args.dp_size > 1 and not server_args.enable_dp_attention:
+        dp_groups = [
+            (
+                dp_rank
+                * server_args.tp_size
+                * server_args.pp_size
+                * server_args.gpu_id_step,
+                dp_rank,
+            )
+            for dp_rank in range(server_args.dp_size)
+        ]
+
+    calls = []
+    for group_gpu_offset, dp_rank in dp_groups:
+        for pp_rank in pp_ranks:
+            for tp_rank in tp_ranks:
+                gpu_id = (
+                    server_args.base_gpu_id
+                    + group_gpu_offset
+                    + (pp_rank % pp_size_per_node) * tp_size_per_node
+                    + (tp_rank % tp_size_per_node) * server_args.gpu_id_step
+                )
+                launched_dp_rank = dp_rank
+                if server_args.enable_dp_attention:
+                    launched_dp_rank = tp_rank // attn_tp_size
+                calls.append((gpu_id, tp_rank, pp_rank, launched_dp_rank))
+    return calls
+
+
+def _port_for_scheduler(
+    server_args, gpu_id, tp_rank, pp_rank, dp_rank, base_port=BASE_PORT
+) -> int:
+    """The exporter port the wrapper installs in one scheduler's process.
+
+    SGLang calls the scheduler entry point entirely positionally, so this passes
+    positionally too rather than by keyword.
+    """
+    # Every scheduler is its own process and reads the base the operator
+    # injected. Sharing one interpreter across a launch would instead let each
+    # call read the port the previous call installed.
+    os.environ[NIXL_TELEMETRY_PROMETHEUS_PORT_ENV] = str(base_port)
+
+    port_args, attn_cp_rank, moe_dp_rank, moe_ep_rank = SimpleNamespace(), 0, 0, 0
+    _assign_nixl_prometheus_port(
+        _run_scheduler_process,
+        (
+            server_args,
+            port_args,
+            gpu_id,
+            tp_rank,
+            attn_cp_rank,
+            moe_dp_rank,
+            moe_ep_rank,
+            pp_rank,
+            dp_rank,
+            None,
+        ),
+        {},
+    )
+    return int(os.environ[NIXL_TELEMETRY_PROMETHEUS_PORT_ENV])
+
+
+def _ports_for_launch(server_args, base_port=BASE_PORT) -> list[int]:
+    return [
+        _port_for_scheduler(server_args, *call, base_port=base_port)
+        for call in _scheduler_calls(server_args)
+    ]
+
+
+class _LazyProxyModule:
+    """Stands in for ``sglang``, whose ``Engine`` is a lazy import proxy.
+
+    A proxy makes the read look harmless -- it succeeds -- and then absorbs the
+    write that follows instead of passing it to the class. Raising on any
+    attribute turns that silent no-op back into a test failure.
+    """
+
+    def __getattr__(self, name: str):
+        raise AssertionError(f"install must not reach sglang.{name}")
+
+
+@pytest.fixture
+def telemetry_env(monkeypatch):
+    monkeypatch.setenv("NIXL_TELEMETRY_ENABLE", "y")
+    monkeypatch.setenv("NIXL_TELEMETRY_EXPORTER", "prometheus")
+    monkeypatch.setenv(NIXL_TELEMETRY_PROMETHEUS_PORT_ENV, str(BASE_PORT))
+    monkeypatch.setenv("DYN_SYSTEM_PORT", "9090")
+    monkeypatch.setenv("DYN_FORWARDPASS_METRIC_PORT", "20380")
+    # The stubs below carry effective values already, so pin resolution to the
+    # identity rather than let the installed SGLang project a stand-in object.
+    # The resolved-configuration case supplies its own projection.
+    monkeypatch.setattr(sglang_compat, "sglang_resolved_view", None)
+    return monkeypatch
+
+
+class TestPerRankPortAssignment:
+    @pytest.mark.parametrize(
+        "name,server_args,expected_ranks",
+        [
+            ("tensor parallel", _server_args(tp_size=8), 8),
+            ("data parallel", _server_args(tp_size=1, dp_size=8), 8),
+            (
+                "attention data parallel",
+                _server_args(tp_size=8, dp_size=8, enable_dp_attention=True),
+                8,
+            ),
+            ("offset devices", _server_args(tp_size=4, base_gpu_id=4), 4),
+            (
+                "stepped pipeline with data parallelism",
+                _server_args(tp_size=1, pp_size=2, dp_size=2, gpu_id_step=2),
+                4,
+            ),
+            (
+                "stepped pipeline with tensor parallelism",
+                _server_args(tp_size=4, pp_size=2, gpu_id_step=2),
+                8,
+            ),
+            (
+                "pipeline split across nodes",
+                _server_args(tp_size=4, pp_size=2, nnodes=2),
+                4,
+            ),
+            ("tensor group split across nodes", _server_args(tp_size=8, nnodes=2), 4),
+        ],
+    )
+    def test_every_scheduler_gets_its_own_port_in_the_reserved_range(
+        self, telemetry_env, name, server_args, expected_ranks
+    ):
+        """A pod reserves one consecutive port per node-local rank and no more.
+
+        Two schedulers on one port leave the second unable to bind, and a rank
+        past the reserved range has no declared container port to be scraped on,
+        so the ports a node hands out have to be exactly ``base .. base + n-1``.
+        """
+        ports = _ports_for_launch(server_args)
+        assert len(ports) == expected_ranks
+        assert set(ports) == set(range(BASE_PORT, BASE_PORT + expected_ranks))
+
+    def test_each_node_restarts_at_the_reserved_base(self, telemetry_env):
+        """The range is reserved per pod, so node 1 uses the same ports as node 0."""
+        first, second = (
+            _ports_for_launch(_server_args(tp_size=8, nnodes=2, node_rank=node_rank))
+            for node_rank in (0, 1)
+        )
+        assert first == second == [19090, 19091, 19092, 19093]
+
+    def test_a_narrow_launch_fits_where_a_full_range_would_not(self, telemetry_env):
+        """The pod reserves one port per rank it launches, not eight regardless.
+
+        A four-rank launch is measured against the four ports it is given, so a
+        base leaving exactly that much room is usable rather than refused for
+        ranks this launch never places.
+        """
+        base = 65535 - 3
+        assert _ports_for_launch(_server_args(tp_size=4), base_port=base) == [
+            65532,
+            65533,
+            65534,
+            65535,
+        ]
+
+    def test_a_launch_with_no_room_for_its_own_ranks_is_rejected(self, telemetry_env):
+        """Rank 0 alone fits; the ranks after it are what have nowhere to bind."""
+        with pytest.raises(ValueError, match="exceeds the maximum port"):
+            _ports_for_launch(_server_args(tp_size=8), base_port=65535 - 3)
+
+    def test_disabled_telemetry_leaves_the_environment_alone(self, telemetry_env):
+        telemetry_env.setenv("NIXL_TELEMETRY_ENABLE", "n")
+        assert _ports_for_launch(_server_args(tp_size=8)) == [BASE_PORT] * 8
+
+
+class TestResolvedLaunchConfiguration:
+    def test_ranks_are_numbered_from_the_resolved_configuration(self, telemetry_env):
+        """``--tp-size 8 --dwdp-size 8`` turns attention DP on during resolution.
+
+        The scheduler is handed the raw arguments, where ``dp_size`` still reads
+        1 and ``enable_dp_attention`` still reads False, while the launch places
+        one group of eight schedulers and derives each ``dp_rank`` from its
+        ``tp_rank``. Numbering from the raw values folds ``dp_rank`` in a second
+        time, so the scheduler at ``tp_rank=1, dp_rank=1`` claims node-local
+        rank 9 and is refused a port instead of taking 19091.
+        """
+        raw = _server_args(tp_size=8)
+        resolved = _server_args(tp_size=8, dp_size=8, enable_dp_attention=True)
+        telemetry_env.setattr(
+            sglang_compat, "sglang_resolved_view", lambda server_args: resolved
+        )
+
+        ports = [_port_for_scheduler(raw, *call) for call in _scheduler_calls(resolved)]
+        assert ports == list(range(BASE_PORT, BASE_PORT + 8))
+
+
+class TestInstall:
+    def test_install_is_a_no_op_when_telemetry_is_disabled(self, telemetry_env):
+        """No SGLang import, so a non-telemetry deployment cannot regress on it."""
+        telemetry_env.setenv("NIXL_TELEMETRY_ENABLE", "n")
+        install_per_rank_nixl_prometheus_ports()
+
+    def test_install_points_sglang_at_the_wrapper(self, telemetry_env):
+        """The override has to land on the class, not on the ``sglang`` proxy."""
+        engine = type("Engine", (), {"run_scheduler_process_func": None})
+        telemetry_env.setitem(sys.modules, "sglang", _LazyProxyModule())
+        telemetry_env.setitem(
+            sys.modules,
+            "sglang.srt.entrypoints.engine",
+            SimpleNamespace(Engine=engine),
+        )
+        install_per_rank_nixl_prometheus_ports()
+        assert engine.run_scheduler_process_func is run_scheduler_process_with_nixl_port
+
+    def test_missing_override_point_is_rejected(self, telemetry_env):
+        """Serving on would leave every rank one port and all but one rank dead."""
+        telemetry_env.setitem(
+            sys.modules,
+            "sglang.srt.entrypoints.engine",
+            SimpleNamespace(Engine=type("Engine", (), {})),
+        )
+        with pytest.raises(RuntimeError, match="run_scheduler_process_func"):
+            install_per_rank_nixl_prometheus_ports()

--- a/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
@@ -138,6 +138,18 @@ spec:
       sourceLabels:
       - __meta_kubernetes_pod_label_nvidia_com_dynamo_component_type
       targetLabel: dynamo_component_type
+  # Rank i of a co-located worker binds nixl-<i>; scraping only `nixl` would leave
+  # every rank but the first invisible. Upper bound matches DynamoMaxNixlPorts.
+  {{- range $rank := untilStep 1 8 1 }}
+  - interval: 5s
+    path: /metrics
+    port: nixl-{{ $rank }}
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_nvidia_com_dynamo_component_type
+      targetLabel: dynamo_component_type
+  {{- end }}
 {{- end }}
   selector:
     matchExpressions:

--- a/deploy/helm/charts/platform/tests/podmonitor_nixl_ports_test.yaml
+++ b/deploy/helm/charts/platform/tests/podmonitor_nixl_ports_test.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Document order in prometheus.yaml: 0 dynamo-frontend, 1 dynamo-worker,
+# 2 dynamo-planner, 3 dynamo-epp, 4 dynamo-router.
+suite: PodMonitor NIXL exporter ports
+templates:
+  - charts/dynamo-operator/templates/prometheus.yaml
+
+tests:
+  - it: scrapes every co-located rank's exporter, not just rank 0
+    set:
+      dynamo-operator.dynamo.metrics.podMonitors.enabled: true
+      dynamo-operator.dynamo.metrics.podMonitors.nixlTelemetry: true
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[4].port
+          value: nixl
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[5].port
+          value: nixl-1
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[6].port
+          value: nixl-2
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[7].port
+          value: nixl-3
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[8].port
+          value: nixl-4
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[9].port
+          value: nixl-5
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[10].port
+          value: nixl-6
+        documentIndex: 1
+      - equal:
+          path: spec.podMetricsEndpoints[11].port
+          value: nixl-7
+        documentIndex: 1
+      - lengthEqual:
+          path: spec.podMetricsEndpoints
+          count: 12
+        documentIndex: 1
+
+  - it: adds no NIXL endpoints when NIXL telemetry scraping is off
+    set:
+      dynamo-operator.dynamo.metrics.podMonitors.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.podMetricsEndpoints
+          count: 4
+        documentIndex: 1

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -27,6 +27,10 @@ const (
 	DynamoNixlPort     = 19090
 	DynamoNixlPortName = "nixl"
 
+	// DynamoMaxNixlPorts bounds the per-pod NIXL exporter ports: rank i uses
+	// DynamoNixlPort+i. Keep in sync with MAX_COLOCATED_NIXL_EXPORTERS (nixl_telemetry.py).
+	DynamoMaxNixlPorts = 8
+
 	DynamoFPMBasePort = 20380
 
 	MpiRunSshPort = 2222

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -3,14 +3,19 @@ package dynamo
 import (
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	SglangPort = "29500"
+
+	maxTCPPort = 65535
 )
 
 type SGLangBackend struct{}
@@ -26,7 +31,13 @@ func isPythonCommand(cmd string) bool {
 	return matched
 }
 
-func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, _ ContainerGPUCount) error {
+func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUCount ContainerGPUCount) error {
+	// Reserve the exporter ports before any early return: a single-node worker
+	// is exactly the case that co-locates every rank in one container.
+	if err := reserveNixlExporterPorts(container, containerGPUCount); err != nil {
+		return err
+	}
+
 	if component.CompilationCache != nil {
 		logger := log.Log.WithName("sglang-backend")
 		logger.Info("Compilation cache configured for SGLang but not yet fully supported",
@@ -57,6 +68,165 @@ func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNod
 
 	injectFlagsIntoContainerCommand(container, flags, needsShell, "sglang")
 	return nil
+}
+
+// reserveNixlExporterPorts declares one NIXL exporter port per node-local rank.
+// Skips containers without a nixl port, with NIXL_TELEMETRY_ENABLE set off, or
+// with an exporter other than Prometheus selected.
+func reserveNixlExporterPorts(container *corev1.Container, containerGPUCount ContainerGPUCount) error {
+	basePort := findContainerPort(container, commonconsts.DynamoNixlPortName)
+	if basePort == nil {
+		return nil
+	}
+
+	enabled := findEnvVar(container.Env, "NIXL_TELEMETRY_ENABLE")
+	if enabled == nil {
+		return nil
+	}
+	// The operator cannot resolve valueFrom, so reserve the range rather than
+	// assume telemetry is off: an unused declaration is harmless, a missing one
+	// leaves every rank past the base unscrapeable. Name each setting it cannot
+	// read, because the diagnostic below is the only place a deployment learns
+	// which one left telemetry undecided.
+	var sourced []string
+	prometheusOn := enabled.ValueFrom == nil
+	if !prometheusOn {
+		sourced = append(sourced, "NIXL_TELEMETRY_ENABLE")
+	}
+	if prometheusOn && !strings.EqualFold(strings.TrimSpace(enabled.Value), "y") {
+		return nil
+	}
+
+	// Only the Prometheus exporter binds a port per rank, so activate on the
+	// same pair of variables nixl_prometheus_base_port() reads: an absent
+	// selection is the Prometheus default, any other literal selection needs no
+	// ports at all, and a sourced one joins an unreadable enable value in
+	// reserving a range this code cannot rule out.
+	exporter := findEnvVar(container.Env, "NIXL_TELEMETRY_EXPORTER")
+	if exporter != nil {
+		if exporter.ValueFrom != nil {
+			prometheusOn = false
+			sourced = append(sourced, "NIXL_TELEMETRY_EXPORTER")
+		} else if !strings.EqualFold(strings.TrimSpace(exporter.Value), "prometheus") {
+			return nil
+		}
+	}
+
+	containerGPUs, err := containerGPUCount()
+	if err != nil {
+		return fmt.Errorf("failed to resolve container GPUs: %w", err)
+	}
+
+	// Rank i binds NIXL_TELEMETRY_PROMETHEUS_PORT+i, so a literal override moves
+	// the whole range: realign `nixl` with it or it advertises a port rank 0
+	// never binds.
+	override := findEnvVar(container.Env, "NIXL_TELEMETRY_PROMETHEUS_PORT")
+	overridden, literal, err := literalPort(override)
+	switch {
+	case err != nil:
+		// A base that is present but unusable is the quietest way to lose the
+		// metrics: NIXL binds 0 as an ephemeral port and reports back no port to
+		// scrape, so the container starts while the ports declared here and the
+		// PodMonitor still name the default range. Say so at admission instead.
+		return fmt.Errorf(
+			"NIXL_TELEMETRY_PROMETHEUS_PORT is the base of the NIXL exporter range and %w, so the operator "+
+				"cannot declare the range it names and Prometheus would scrape ports no rank binds. Set "+
+				"NIXL_TELEMETRY_PROMETHEUS_PORT to a port between 1 and %d, or set NIXL_TELEMETRY_ENABLE=n",
+			err, maxTCPPort)
+	case literal:
+		basePort.ContainerPort = overridden
+	case override != nil && override.ValueFrom != nil:
+		// A sourced base has no conservative fallback the way a sourced enable
+		// value does: the container resolves it and binds that range, while the
+		// declared ports and the PodMonitor stay on the base written here, so
+		// the metrics disappear instead of merely being over-declared. That
+		// holds however the enable value is written, so an unreadable one is no
+		// reason to accept the base and declare a range nothing binds.
+		return fmt.Errorf(
+			"NIXL_TELEMETRY_PROMETHEUS_PORT is set through valueFrom, so the operator cannot declare the exporter "+
+				"range as %s container ports and Prometheus would scrape a range no rank binds. Set "+
+				"NIXL_TELEMETRY_PROMETHEUS_PORT to a literal port, or set NIXL_TELEMETRY_ENABLE=n",
+			commonconsts.DynamoNixlPortName)
+	}
+
+	// Every co-located rank needs a port of its own, and the runtime refuses a
+	// rank past the reserved range rather than share one: truncating the count
+	// here would fail startup on the ranks that lost their port. An unreadable
+	// telemetry setting is exempt, because refusing a deployment that may not
+	// use telemetry at all costs more than the over-declaration above.
+	colocatedRanks := containerGPUs
+	if colocatedRanks > int64(commonconsts.DynamoMaxNixlPorts) {
+		if prometheusOn {
+			return fmt.Errorf(
+				"%d co-located GPUs each need a NIXL exporter port, but only %d consecutive ports are declared and scraped, "+
+					"so the ranks past the %dth would fail to start. Run at most %d ranks per container, "+
+					"or set NIXL_TELEMETRY_ENABLE=n",
+				colocatedRanks, commonconsts.DynamoMaxNixlPorts, commonconsts.DynamoMaxNixlPorts, commonconsts.DynamoMaxNixlPorts)
+		}
+
+		// Admitting the deployment leaves one outcome admission cannot rule
+		// out, so say so here rather than let it surface as an unexplained
+		// startup failure: settings that resolve to an enabled Prometheus
+		// exporter give the ranks past the reserved range no port, and each of
+		// those refuses to start.
+		log.Log.WithName("sglang-backend").Info(
+			"co-located GPUs exceed the NIXL exporter ports the operator declares, and the settings named below are set through valueFrom, "+
+				"so the deployment is admitted with the supported range reserved; if they resolve to a Prometheus exporter, the ranks past it fail to start",
+			"colocatedGPUs", colocatedRanks,
+			"reservedPorts", commonconsts.DynamoMaxNixlPorts,
+			"unresolvedSettings", strings.Join(sourced, ", "))
+
+		colocatedRanks = int64(commonconsts.DynamoMaxNixlPorts)
+	}
+
+	if last := int64(basePort.ContainerPort) + colocatedRanks - 1; last > maxTCPPort {
+		return fmt.Errorf(
+			"NIXL_TELEMETRY_PROMETHEUS_PORT=%d with %d co-located ranks needs ports %d-%d, which exceeds the maximum port %d",
+			basePort.ContainerPort, colocatedRanks, basePort.ContainerPort, last, maxTCPPort)
+	}
+
+	// A rank port already on the pod template was written against whatever base
+	// was in effect then, so realign it rather than keep it: the PodMonitor
+	// scrapes these by name, and a stale number sends it to a port the rank
+	// never binds. Read the base once, because appending invalidates basePort.
+	base := basePort.ContainerPort
+	for rank := int64(1); rank < colocatedRanks; rank++ {
+		name := fmt.Sprintf("%s-%d", commonconsts.DynamoNixlPortName, rank)
+		rankPort := base + int32(rank)
+		if declared := findContainerPort(container, name); declared != nil {
+			declared.ContainerPort = rankPort
+			continue
+		}
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Protocol:      corev1.ProtocolTCP,
+			Name:          name,
+			ContainerPort: rankPort,
+		})
+	}
+
+	return nil
+}
+
+// literalPort reads a TCP port written inline on an environment variable. An
+// unset variable and one taken from valueFrom are both reported as absent,
+// because a value resolved in the container at startup cannot be turned into a
+// container port declaration here. A variable that is set inline to something
+// that is not a usable port is neither absent nor usable, so it is returned as
+// an error rather than folded into either.
+func literalPort(env *corev1.EnvVar) (int32, bool, error) {
+	if env == nil || env.ValueFrom != nil {
+		return 0, false, nil
+	}
+
+	value := strings.TrimSpace(env.Value)
+	port, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false, fmt.Errorf("is set to %q, which is not a number", env.Value)
+	}
+	if port < 1 || port > maxTCPPort {
+		return 0, false, fmt.Errorf("is set to %d, which is outside the port range 1-%d", port, maxTCPPort)
+	}
+	return int32(port), true, nil
 }
 
 func (b *SGLangBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {

--- a/deploy/operator/internal/dynamo/backend_sglang_test.go
+++ b/deploy/operator/internal/dynamo/backend_sglang_test.go
@@ -1,10 +1,15 @@
 package dynamo
 
 import (
+	"errors"
 	"reflect"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -640,6 +645,318 @@ func TestSGLangBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 					t.Errorf("Expected no environment variable changes, but env count changed from %d to %d", originalEnvCount, len(container.Env))
 				}
 			}
+		})
+	}
+}
+
+func TestSGLangBackend_ReservesOneNixlExporterPortPerColocatedRank(t *testing.T) {
+	backend := &SGLangBackend{}
+
+	workerPorts := []corev1.ContainerPort{
+		{Protocol: corev1.ProtocolTCP, Name: commonconsts.DynamoSystemPortName, ContainerPort: int32(commonconsts.DynamoSystemPort)},
+		{Protocol: corev1.ProtocolTCP, Name: commonconsts.DynamoNixlPortName, ContainerPort: int32(commonconsts.DynamoNixlPort)},
+	}
+	frontendPorts := []corev1.ContainerPort{
+		{Protocol: corev1.ProtocolTCP, Name: commonconsts.DynamoContainerPortName, ContainerPort: int32(commonconsts.DynamoServicePort)},
+	}
+	allEightPorts := map[string]int32{
+		"nixl": 19090, "nixl-1": 19091, "nixl-2": 19092, "nixl-3": 19093,
+		"nixl-4": 19094, "nixl-5": 19095, "nixl-6": 19096, "nixl-7": 19097,
+	}
+
+	tests := []struct {
+		name               string
+		ports              []corev1.ContainerPort
+		telemetryEnable    string
+		telemetryValueFrom *corev1.EnvVarSource
+		telemetryExporter  string
+		exporterAbsent     bool
+		exporterValueFrom  *corev1.EnvVarSource
+		telemetryPort      string
+		portEmpty          bool
+		portValueFrom      *corev1.EnvVarSource
+		containerGPUs      int64
+		expectedPorts      map[string]int32
+		expectedError      string
+	}{
+		{
+			name:            "one rank needs no extra port",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			containerGPUs:   1,
+			expectedPorts:   map[string]int32{"nixl": 19090},
+		},
+		{
+			name:            "eight co-located ranks reserve eight ports",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			containerGPUs:   8,
+			expectedPorts:   allEightPorts,
+		},
+		{
+			name:            "more ranks than the reserved range is rejected",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			containerGPUs:   16,
+			expectedError:   "16 co-located GPUs each need a NIXL exporter port",
+		},
+		{
+			name:            "the operator default of disabled telemetry reserves nothing",
+			ports:           workerPorts,
+			telemetryEnable: "n",
+			containerGPUs:   -1,
+			expectedPorts:   map[string]int32{"nixl": 19090},
+		},
+		{
+			name:            "a frontend shares the backend framework but declares no NIXL port",
+			ports:           frontendPorts,
+			telemetryEnable: "y",
+			containerGPUs:   -1,
+			expectedPorts:   map[string]int32{},
+		},
+		{
+			name:  "a sourced enable value reserves the range it cannot read",
+			ports: workerPorts,
+			telemetryValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-enable",
+				},
+			},
+			containerGPUs: 8,
+			expectedPorts: allEightPorts,
+		},
+		{
+			name:  "a sourced enable value reserves the whole range rather than refusing the deployment",
+			ports: workerPorts,
+			telemetryValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-enable",
+				},
+			},
+			containerGPUs: 16,
+			expectedPorts: allEightPorts,
+		},
+		{
+			name:            "a sourced base the operator cannot declare is rejected",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			portValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-port",
+				},
+			},
+			containerGPUs: 4,
+			expectedError: "cannot declare the exporter range",
+		},
+		{
+			name:  "a sourced base is rejected even when the enable value is unreadable too",
+			ports: workerPorts,
+			telemetryValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-enable",
+				},
+			},
+			portValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-port",
+				},
+			},
+			containerGPUs: 8,
+			expectedError: "cannot declare the exporter range",
+		},
+		{
+			name:            "an overridden base moves every declared port with it",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   "30500",
+			containerGPUs:   4,
+			expectedPorts: map[string]int32{
+				"nixl": 30500, "nixl-1": 30501, "nixl-2": 30502, "nixl-3": 30503,
+			},
+		},
+		{
+			name: "a rank port written against another base moves with it too",
+			ports: append(slices.Clone(workerPorts),
+				corev1.ContainerPort{Protocol: corev1.ProtocolTCP, Name: "nixl-1", ContainerPort: 19091}),
+			telemetryEnable: "y",
+			telemetryPort:   "30500",
+			containerGPUs:   4,
+			expectedPorts: map[string]int32{
+				"nixl": 30500, "nixl-1": 30501, "nixl-2": 30502, "nixl-3": 30503,
+			},
+		},
+		{
+			name:            "a base with no room for the range is rejected",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   strconv.Itoa(maxTCPPort),
+			containerGPUs:   4,
+			expectedError:   "exceeds the maximum port",
+		},
+		{
+			name:              "another exporter binds no port per rank, however many ranks there are",
+			ports:             workerPorts,
+			telemetryEnable:   "y",
+			telemetryExporter: "file",
+			containerGPUs:     -1,
+			expectedPorts:     map[string]int32{"nixl": 19090},
+		},
+		{
+			name:              "another exporter reads no base, so a sourced one is no obstacle",
+			ports:             workerPorts,
+			telemetryEnable:   "y",
+			telemetryExporter: "file",
+			portValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-port",
+				},
+			},
+			containerGPUs: -1,
+			expectedPorts: map[string]int32{"nixl": 19090},
+		},
+		{
+			name:            "no exporter selection is the Prometheus default",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			exporterAbsent:  true,
+			containerGPUs:   8,
+			expectedPorts:   allEightPorts,
+		},
+		{
+			name:            "a sourced exporter reserves the range it cannot read",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			exporterValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry"},
+					Key:                  "nixl-exporter",
+				},
+			},
+			containerGPUs: 16,
+			expectedPorts: allEightPorts,
+		},
+		{
+			name:            "a base padded with whitespace is still a port",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   " 19090 ",
+			containerGPUs:   4,
+			expectedPorts: map[string]int32{
+				"nixl": 19090, "nixl-1": 19091, "nixl-2": 19092, "nixl-3": 19093,
+			},
+		},
+		{
+			name:            "a base written as words is rejected",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   "nineteen thousand",
+			containerGPUs:   4,
+			expectedError:   `is set to "nineteen thousand", which is not a number`,
+		},
+		{
+			name:            "an empty base is rejected rather than read as the default",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			portEmpty:       true,
+			containerGPUs:   4,
+			expectedError:   `is set to "", which is not a number`,
+		},
+		{
+			name:            "a base of zero is rejected rather than bound as an ephemeral port",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   "0",
+			containerGPUs:   4,
+			expectedError:   "is set to 0, which is outside the port range",
+		},
+		{
+			name:            "a base past the maximum port is rejected",
+			ports:           workerPorts,
+			telemetryEnable: "y",
+			telemetryPort:   "70000",
+			containerGPUs:   4,
+			expectedError:   "is set to 70000, which is outside the port range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Render the container the way the component defaults do")
+			telemetryPort := tt.telemetryPort
+			switch {
+			case tt.portValueFrom != nil || tt.portEmpty:
+				// The API rejects a variable carrying both, so a sourced base has
+				// no inline value for the operator to fall back on.
+				telemetryPort = ""
+			case telemetryPort == "":
+				telemetryPort = strconv.Itoa(commonconsts.DynamoNixlPort)
+			}
+			telemetryExporter := tt.telemetryExporter
+			if telemetryExporter == "" && tt.exporterValueFrom == nil {
+				telemetryExporter = "prometheus"
+			}
+			env := []corev1.EnvVar{
+				{Name: "DYN_SYSTEM_PORT", Value: strconv.Itoa(commonconsts.DynamoSystemPort)},
+				{Name: "NIXL_TELEMETRY_ENABLE", Value: tt.telemetryEnable, ValueFrom: tt.telemetryValueFrom},
+			}
+			// An older deployment predating the exporter selection leaves the
+			// variable off entirely, which the runtime reads as Prometheus.
+			if !tt.exporterAbsent {
+				env = append(env, corev1.EnvVar{Name: "NIXL_TELEMETRY_EXPORTER", Value: telemetryExporter, ValueFrom: tt.exporterValueFrom})
+			}
+			env = append(env, corev1.EnvVar{Name: "NIXL_TELEMETRY_PROMETHEUS_PORT", Value: telemetryPort, ValueFrom: tt.portValueFrom})
+			container := &corev1.Container{
+				Ports: slices.Clone(tt.ports),
+				Env:   env,
+			}
+
+			t.Log("A negative GPU count marks the cases that must never resolve one")
+			containerGPUCount := staticContainerGPUCount(tt.containerGPUs)
+			if tt.containerGPUs < 0 {
+				containerGPUCount = func() (int64, error) {
+					return 0, errors.New("resolving the GPU count needs a Kubernetes client")
+				}
+			}
+
+			err := backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", &GroveMultinodeDeployer{}, containerGPUCount)
+			if tt.expectedError != "" {
+				t.Log("A range that cannot be declared is reported, not silently truncated")
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+
+			t.Log("Every co-located rank has a port of its own, and no rank shares one")
+			nixlPorts := map[string]int32{}
+			seen := map[int32]string{}
+			for _, port := range container.Ports {
+				if !strings.HasPrefix(port.Name, commonconsts.DynamoNixlPortName) {
+					continue
+				}
+				nixlPorts[port.Name] = port.ContainerPort
+				if other, duplicate := seen[port.ContainerPort]; duplicate {
+					t.Errorf("ports %q and %q both bind %d", other, port.Name, port.ContainerPort)
+				}
+				seen[port.ContainerPort] = port.Name
+			}
+			require.Equal(t, tt.expectedPorts, nixlPorts)
+
+			t.Log("Every port declared for something other than NIXL keeps its number")
+			// The NIXL ports move with an overridden base, so expectedPorts above is
+			// what pins them; here only the ports the reservation must not touch.
+			for _, port := range tt.ports {
+				if strings.HasPrefix(port.Name, commonconsts.DynamoNixlPortName) {
+					continue
+				}
+				require.Contains(t, container.Ports, port)
+			}
+			require.NotContains(t, seen, int32(commonconsts.DynamoSystemPort))
 		})
 	}
 }

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -52,15 +52,6 @@ func TestShellQuotePOSIX_ArgvRoundTrip(t *testing.T) {
 	}
 }
 
-func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
-	for i := range env {
-		if env[i].Name == name {
-			return &env[i]
-		}
-	}
-	return nil
-}
-
 func TestVLLMBackend_UpdateContainer(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/deploy/operator/internal/dynamo/utils.go
+++ b/deploy/operator/internal/dynamo/utils.go
@@ -73,6 +73,26 @@ func shellQuotePOSIX(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// findEnvVar returns the named environment variable entry, or nil when absent. The
+// entry, not its value, so a valueFrom variable is distinguishable from an absent one.
+func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == name {
+			return &env[i]
+		}
+	}
+	return nil
+}
+
+func findContainerPort(container *corev1.Container, name string) *corev1.ContainerPort {
+	for i := range container.Ports {
+		if container.Ports[i].Name == name {
+			return &container.Ports[i]
+		}
+	}
+	return nil
+}
+
 // containerHasArg reports whether the container already carries the given
 // flag/value pair in its Args (either as adjacent tokens "flag", "value" or
 // as a single token "flag=value" or "flag value" embedded inside a shell

--- a/docs/fern/pages/kubernetes/operations/observability.mdx
+++ b/docs/fern/pages/kubernetes/operations/observability.mdx
@@ -146,7 +146,10 @@ spec:
               value: "y"
 ```
 
-NIXL exposes these metrics on its telemetry port, which defaults to `19090`. See
+NIXL exposes these metrics on its telemetry port, which defaults to `19090`. A worker that runs
+several ranks in one container builds one NIXL agent per rank, so that value is the base of a
+range: SGLang gives node-local rank *i* the port `19090 + i` and the operator declares each one as
+a separate container port (`nixl`, `nixl-1`, …). See
 [Environment Variables](../../reference/observability/environment-variables.mdx#system-and-metrics)
 for the complete NIXL telemetry configuration.
 
@@ -155,6 +158,9 @@ for the complete NIXL telemetry configuration.
 
 Apply the updated DGD and send traffic through the transfer path. Then confirm the NIXL metric
 families appear in Prometheus. The series are created only after transfers occur.
+
+A multi-GPU SGLang worker produces one Prometheus target per rank rather than one per pod. If only
+one target appears for such a pod, the remaining ranks are not being scraped.
 
 </Step>
 </Steps>

--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -103,7 +103,13 @@ Every Dynamo process reads its own environment at startup, so set these on each 
 </ParamField>
 
 <ParamField path="NIXL_TELEMETRY_PROMETHEUS_PORT" type="integer" default="19090">
-  Port for NIXL's Prometheus exporter — a separate port from the Dynamo metrics port. Use distinct values per worker (e.g. `19090` prefill, `19091` decode) to avoid collisions.
+  Port for NIXL's Prometheus exporter — a separate port from the Dynamo metrics port. Each NIXL agent binds its own exporter, so every agent needs a port of its own; two agents pointed at the same port leave the second unable to bind and the process exits.
+
+  Give each worker a non-overlapping value when workers share a network namespace. Because each value is the base of an eight-port range (see below), `19090` for the prefill worker leaves `19098` as the next free base for the decode worker.
+
+  Within a single worker, treat this as the **base** of a range rather than one port. SGLang runs one scheduler process per node-local GPU and each builds its own NIXL agent, so Dynamo gives node-local rank *i* the port `base + i` and the operator declares the whole range on the pod as `nixl`, `nixl-1`, … so Prometheus scrapes every rank. Leave room for as many consecutive ports as the pod has GPUs (up to 8).
+
+  Set it to a literal port between 1 and 65535. The operator reads this value to declare the range as container ports, so while NIXL Prometheus telemetry is on it rejects a value taken from `valueFrom`, and one that is not a usable port, rather than let the exporters bind a range nothing scrapes.
 
   **Operator preset:** `19090` on worker, prefill, and decode pods.
 </ParamField>

--- a/recipes/glm-5-nvfp4/sglang/disagg/efa/deploy.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/efa/deploy.yaml
@@ -184,6 +184,8 @@ spec:
             - name: LD_LIBRARY_PATH
               value: /opt/amazon/efa/lib:/opt/amazon/efa/lib64:/opt/aws-ofi-nccl/lib:/opt/nvidia/nvda_nixl/lib64:/opt/nvidia/nvda_nixl/lib64/plugins:/opt/nvidia/nvda_nixl/lib/aarch64-linux-gnu:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:/usr/local/cuda/lib64:/usr/local/lib
             # === NIXL telemetry (use =y, _ENABLED=1 is a no-op) ===
+            # BASE of a range: this pod runs one SGLang scheduler per local GPU,
+            # and local rank i exports on 19090+i. The operator declares the range.
             - name: NIXL_TELEMETRY_ENABLE
               value: "y"
             - name: NIXL_TELEMETRY_EXPORTER


### PR DESCRIPTION
Cherry-pick of #14284 to `release/1.5.0`.

This backport prevents co-located SGLang ranks from contending for one NIXL Prometheus exporter port. It assigns a predictable per-rank port range, has the operator declare and scrape each rank's port, validates invalid or overlapping ranges, and updates focused tests, observability docs, and the GLM-5 EFA recipe.

Signed-off cherry-pick with `-x --signoff`.

Validation:
- Applied cleanly with no conflicts.
- Final change set matches the source PR: 15 files, +1382/-12.
- Stable patch ID exactly matches the source merge commit (`96da5b30df62e4824870f86b0f6d099184b3a78a`).
- Remote Git tree matches the locally verified cherry-pick tree (`7ba391e287020274977e7fc522e5d46c2d6bff99`).
- `git diff --check release/1.5.0...HEAD` passed.
- Python syntax compilation passed for all five touched Python modules/tests.
- `python3 docs/fern/scripts/docs_lint.py --scan docs` passed with 0 errors; its 8 advisory warnings are pre-existing and outside this diff.
- Focused pytest, Go/gofmt, Helm, Fern, pre-commit, and uv checks were not run because those tools/dependencies are unavailable in this environment. The source PR reports its focused Go, Python, Helm, and pre-commit validations passed.