### PR TITLE
fix(recipes): preserve benchmark AIPerf pins for reproducibility

### DIFF
--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
@@ -32,7 +32,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install aiperf==0.12.0;
+          pip install aiperf==0.10.0;
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/perf/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/perf/README.md
@@ -93,7 +93,7 @@ kubectl wait --for=condition=Complete job/dsv4-pro-0813-bench \
 ```
 
 The Job runs on `python:3.12-slim` and installs AIPerf at startup, pinned
-by the `AIPERF_VERSION` environment variable (default `0.12.0`).
+by the `AIPERF_VERSION` environment variable (default `0.10.0`).
 
 ### 4. Fetch artifacts
 

--- a/recipes/deepseek-v4/deepseek-v4-pro-0813/perf/perf.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro-0813/perf/perf.yaml
@@ -125,7 +125,7 @@ spec:
         - name: REQUEST_TIMEOUT_SECONDS
           value: "3600"
         - name: AIPERF_VERSION
-          value: "0.12.0"
+          value: "0.10.0"
         - name: AIPERF_API_PORT
           value: "18090"
         - name: JOB_NAME

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/perf.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/perf.yaml
@@ -65,7 +65,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
-          pip install -q aiperf==0.12.0 transformers==4.57.3 tokenizers==0.22.2
+          pip install -q aiperf==0.10.0 transformers==4.57.3 tokenizers==0.22.2
 
           echo "Waiting for model at http://$ENDPOINT/v1/models..."
           python3 - <<'PY'

--- a/recipes/deepseek-v4/perf/README.md
+++ b/recipes/deepseek-v4/perf/README.md
@@ -103,7 +103,7 @@ validated for the deployed frontend/backend path.
 | `TRACE_FILE` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | Mooncake JSONL on PVC |
 | `CONCURRENCY` | `16` | Single value per Job |
 | `REQUEST_TIMEOUT_SECONDS` | `1200` | Long enough for long-context requests |
-| `AIPERF_VERSION` | `0.12.0` | Match local benchmark runs unless updated intentionally |
+| `AIPERF_VERSION` | `0.10.0` | Match local benchmark runs unless updated intentionally |
 
 ## Required Evidence for a Result Row
 

--- a/recipes/deepseek-v4/perf/perf.yaml
+++ b/recipes/deepseek-v4/perf/perf.yaml
@@ -118,7 +118,7 @@ spec:
         - name: REQUEST_TIMEOUT_SECONDS
           value: "1200"
         - name: AIPERF_VERSION
-          value: "0.12.0"
+          value: "0.10.0"
         - name: AIPERF_API_PORT
           value: "18090"
         - name: JOB_NAME

--- a/recipes/glm-5-nvfp4/sglang/disagg/efa/perf.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/efa/perf.yaml
@@ -71,7 +71,7 @@ spec:
           # GLM-5 NVFP4 tokenizer uses the `TokenizersBackend` auto-tokenizer
           # class introduced in transformers 5.x — pin to match the runtime
           # image (see `pip show transformers` inside the sglang decode pod).
-          pip install aiperf==0.12.0 transformers==5.3.0 tokenizers==0.22.2
+          pip install aiperf==0.10.0 transformers==5.3.0 tokenizers==0.22.2
 
           # Pre-save tokenizer to a flat directory once, then point aiperf at
           # that path. Avoids each of aiperf's N record-processor subprocesses

--- a/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/perf.yaml
@@ -57,7 +57,7 @@ spec:
           apt-get update && apt-get install -y --no-install-recommends build-essential && apt-get clean
           # GLM-5's tokenizer_config.json uses tokenizer_class=TokenizersBackend,
           # which is supported by Transformers v5.
-          pip install -q aiperf==0.12.0 transformers==5.8.0 tokenizers==0.22.2
+          pip install -q aiperf==0.10.0 transformers==5.8.0 tokenizers==0.22.2
 
           echo "Waiting for model at http://$ENDPOINT/v1/models..."
           python3 - <<'PY'

--- a/recipes/gpt-oss-120b/perf/perf.yaml
+++ b/recipes/gpt-oss-120b/perf/perf.yaml
@@ -47,7 +47,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
-          pip install "aiperf==0.12.0" "transformers==4.57.3" "tiktoken==0.13.0" "blobfile"
+          pip install "aiperf==0.10.0" "transformers==4.57.3" "tiktoken==0.13.0" "blobfile"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
@@ -31,7 +31,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/gpt-oss-120b/trtllm/disagg/perf.yaml
+++ b/recipes/gpt-oss-120b/trtllm/disagg/perf.yaml
@@ -31,7 +31,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-round-robin/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/perf.yaml
+++ b/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/perf.yaml
@@ -53,7 +53,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" protobuf "transformers==4.57.3"
+          pip install "aiperf==0.10.0" protobuf "transformers==4.57.3"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/kimi-k2.6/perf/perf.yaml
+++ b/recipes/kimi-k2.6/perf/perf.yaml
@@ -63,7 +63,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          pip install "aiperf==0.10.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/nemotron-3-super/perf/perf.yaml
+++ b/recipes/nemotron-3-super/perf/perf.yaml
@@ -65,7 +65,7 @@ spec:
           set -euo pipefail
           ulimit -n 600000
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          pip install "aiperf==0.10.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200
           EPOCH=$(date +%s)

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b-fp8/vllm/disagg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/vllm/disagg/perf.yaml
@@ -19,7 +19,7 @@ spec:
         - -c
         - |
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
-          pip install "aiperf==0.12.0";
+          pip install "aiperf==0.10.0";
           echo "aiperf installation completed";
           sysctl -w net.ipv4.ip_local_port_range="1024 65000"
           cat /proc/sys/net/ipv4/ip_local_port_range

--- a/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
+++ b/recipes/qwen3-32b/vllm/agg-round-robin/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq build-essential -y
 
         # Install benchmarking tool
-        pip install aiperf==0.12.0
+        pip install aiperf==0.10.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/perf.yaml
@@ -20,7 +20,7 @@ spec:
         apt update && apt install tmux wget curl jq build-essential -y
 
         # Install benchmarking tool
-        pip install aiperf==0.12.0
+        pip install aiperf==0.10.0
 
         # Wait for model to be ready
         echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."

--- a/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
+++ b/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/perf.yaml
@@ -21,7 +21,7 @@ spec:
           # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
           # GB200 benchmark pods need build tools to compile it from source.
           apt update && apt install -y tmux curl jq build-essential
-          pip install aiperf==0.12.0
+          pip install aiperf==0.10.0
 
           echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
           until curl -s "http://${FRONTEND}:8000/v1/models" | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do

--- a/recipes/qwen3-vl-32b-fp8/benchmark/perf.yaml
+++ b/recipes/qwen3-vl-32b-fp8/benchmark/perf.yaml
@@ -28,7 +28,7 @@ spec:
           set -e
           apt-get update && apt-get install -y curl jq procps git build-essential && apt-get clean
 
-          pip install aiperf==0.12.0
+          pip install aiperf==0.10.0
           echo "aiperf installation completed"
 
           export COLUMNS=200

--- a/recipes/qwen3.6-35b/README.md
+++ b/recipes/qwen3.6-35b/README.md
@@ -159,7 +159,7 @@ nodes live in a different AZ.
 
 ## aiperf install
 
-We install `aiperf==0.12.0` from PyPI. This release includes
+We install `aiperf==0.10.0` from PyPI. This release includes
 [PR 824](https://github.com/ai-dynamo/aiperf/pull/824)
 (`feat(dataset): add session_id to single-turn for causal ordering`),
 which makes `single_turn` mode honor `session_id` ordering so

--- a/recipes/qwen3.6-35b/perf.yaml
+++ b/recipes/qwen3.6-35b/perf.yaml
@@ -41,7 +41,7 @@ spec:
           # GB200 benchmark pods need build tools to compile it from source.
           apt update && apt install -y --no-install-recommends curl jq git build-essential
 
-          pip install --no-cache-dir "aiperf==0.12.0"
+          pip install --no-cache-dir "aiperf==0.10.0"
           python -c "import aiperf; print('aiperf', aiperf.__version__, 'OK')"
 
           echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models ..."


### PR DESCRIPTION
## Overview

### Summary
Restore recipe-specific AIPerf pins to 0.10.0 pending model-specific benchmark revalidation. This partially reverts #14492: benchmark reproduction instructions should continue to use the original load-generator version until results are validated on the new version.

## Details

- Reverse only the AIPerf version changes in 27 recipe perf.yaml manifests and three matching README references.
- Keep the general AIPerf 0.12.0 upgrade, Python compatibility changes, zstandard updates, EPD version gate, and regression tests.
- Preserve all workload parameters, deployment configuration, and unrelated changes landed since #14492.
- This is a reproducibility precaution, not a claim of a measured performance regression.

## Where should the reviewer start?

Review the recipe-only diff: each of the 30 files has one version replacement from 0.12.0 to 0.10.0. The DeepSeek-V4 jobs use AIPERF_VERSION environment variables; the other jobs pin their install commands.

## Validation

- `pytest --noconftest -o addopts="" -o filterwarnings="" tests/dependencies/test_aiperf_consistency.py -q`: 9 passed; one environment warning for the unavailable asyncio_mode plugin configuration.
- `pre-commit run`: all applicable hooks passed, including YAML checks and instruction-pair validation. Commit hooks also passed.
- `git diff --cached --check`: passed before commit.
- Programmatic diff audit: all 30 changes exactly reverse the recipe-version edits in merge commit 712d21cedf7ff49b7ef719bd8bef5ebc9383a9ac, with no edits outside recipes/.
- `python3 docs/fern/scripts/docs_lint.py --no-nav recipes/deepseek-v4/perf/README.md recipes/deepseek-v4/deepseek-v4-pro-0813/perf/README.md recipes/qwen3.6-35b/README.md`: one pre-existing missing SPDX header in the Qwen3.6 README, left unchanged to keep this rollback scoped.
- No GPU benchmarks were rerun; this restores the original recipe pins rather than validating 0.12.0 results.

## Related Issues

- [x] Confirmed — no related issue.
- Partially reverts #14492.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Benchmark configurations now use AIPerf version 0.10.0 instead of 0.12.0 across supported recipes.
  - Documentation has been updated to reflect the AIPerf 0.10.0 default and installation version.
  - Other benchmark dependencies and execution settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->