### PR TITLE
fix(frontend): integrate Kimi dynamic tools from frontend-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dynamo-llm",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-rl",
  "dynamo-runtime",
  "futures",
@@ -2559,7 +2559,7 @@ dependencies = [
  "dashmap",
  "dynamo-kv-router",
  "dynamo-llm",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-runtime",
  "futures",
  "hyper-util",
@@ -2687,7 +2687,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2851,7 +2851,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols",
+ "dynamo-protocols 5.4.3",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2884,9 +2884,26 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.1"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
+checksum = "b1cdacfc1398779cf173d5ff54438d9f14682f76875b6879853a84cc7d646228"
+dependencies = [
+ "async-openai",
+ "derive_builder",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "dynamo-protocols"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c0b1eda0a7bfc732f825f8e831edad058b917fd43b5ecf9a3eb674340e9cd5"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2901,13 +2918,13 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "5.1.2"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2eaa139651c535aeaad8856c5546709608931ccd4d24d3a529f6c5233c4b6"
+checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-tokenizers",
  "either",
  "minijinja",
@@ -3076,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed232a9d254149a4e2e14f0a7d77f59bd64161964c0ba55267beea3955650faa"
+checksum = "aa6031ec0ca72092e6469ff659ddf9dbf5034110aa9de387ffbfb17e24a4d5d7"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dynamo-llm",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-rl",
  "dynamo-runtime",
  "futures",
@@ -2559,7 +2559,7 @@ dependencies = [
  "dashmap",
  "dynamo-kv-router",
  "dynamo-llm",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-runtime",
  "futures",
  "hyper-util",
@@ -2687,7 +2687,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2844,14 +2844,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
+checksum = "e316d4d0f5082257f1629ca61973eafc17cee3e6ee0c24f7a55a61beeff40d97"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols 5.4.3",
+ "dynamo-protocols",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2884,23 +2884,6 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cdacfc1398779cf173d5ff54438d9f14682f76875b6879853a84cc7d646228"
-dependencies = [
- "async-openai",
- "derive_builder",
- "futures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "dynamo-protocols"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c0b1eda0a7bfc732f825f8e831edad058b917fd43b5ecf9a3eb674340e9cd5"
@@ -2924,7 +2907,7 @@ checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-tokenizers",
  "either",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ aisimulate-core = { version = "=0.1.0-dev.2" }
 dynamo-runtime = { path = "lib/runtime", version = "1.5.0" }
 dynamo-llm = { path = "lib/llm", version = "1.5.0" }
 dynamo-rl = { path = "lib/rl", version = "1.5.0" }
-dynamo-tokenizers = { version = "=1.8.1" }
-dynamo-renderer = { version = "=5.1.2" }
+dynamo-tokenizers = { version = "=1.8.2" }
+dynamo-renderer = { version = "=5.3.0" }
 dynamo-tokens = { path = "lib/tokens", version = "1.5.0" }
 dynamo-truthy = { path = "lib/truthy", version = "1.5.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.5.0" }
@@ -71,7 +71,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.5.0" }
 dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
-dynamo-protocols = { version = "=5.4.1" }
+dynamo-protocols = { version = "=6.0.0" }
 dynamo-parsers = { version = "8.1.0" }
 
 # Published on crates.io. To see all available versions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
 dynamo-protocols = { version = "=6.0.0" }
-dynamo-parsers = { version = "8.1.0" }
+dynamo-parsers = { version = "9.0.0" }
 
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2265,14 +2265,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
+checksum = "e316d4d0f5082257f1629ca61973eafc17cee3e6ee0c24f7a55a61beeff40d97"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols 5.4.1",
+ "dynamo-protocols",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2305,23 +2305,6 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
-dependencies = [
- "async-openai",
- "derive_builder",
- "futures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "dynamo-protocols"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c0b1eda0a7bfc732f825f8e831edad058b917fd43b5ecf9a3eb674340e9cd5"
@@ -2345,7 +2328,7 @@ checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-tokenizers",
  "either",
  "minijinja",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2272,7 +2272,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols",
+ "dynamo-protocols 5.4.1",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2321,14 +2321,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "dynamo-renderer"
-version = "5.1.2"
+name = "dynamo-protocols"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2eaa139651c535aeaad8856c5546709608931ccd4d24d3a529f6c5233c4b6"
+checksum = "78c0b1eda0a7bfc732f825f8e831edad058b917fd43b5ecf9a3eb674340e9cd5"
+dependencies = [
+ "async-openai",
+ "derive_builder",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "dynamo-renderer"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-tokenizers",
  "either",
  "minijinja",
@@ -2432,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed232a9d254149a4e2e14f0a7d77f59bd64161964c0ba55267beea3955650faa"
+checksum = "aa6031ec0ca72092e6469ff659ddf9dbf5034110aa9de387ffbfb17e24a4d5d7"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dynamo-llm",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-rl",
  "dynamo-runtime",
  "futures",
@@ -2202,7 +2202,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2325,14 +2325,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
+checksum = "e316d4d0f5082257f1629ca61973eafc17cee3e6ee0c24f7a55a61beeff40d97"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols 5.4.1",
+ "dynamo-protocols",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2360,23 +2360,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tracing",
- "uuid",
-]
-
-[[package]]
-name = "dynamo-protocols"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
-dependencies = [
- "async-openai",
- "derive_builder",
- "futures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "url",
  "uuid",
 ]
 
@@ -2451,7 +2434,7 @@ checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols 6.0.0",
+ "dynamo-protocols",
  "dynamo-tokenizers",
  "either",
  "minijinja",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dynamo-llm",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-rl",
  "dynamo-runtime",
  "futures",
@@ -2202,7 +2202,7 @@ dependencies = [
  "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-parsers-v2",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-renderer",
  "dynamo-rl",
  "dynamo-runtime",
@@ -2332,7 +2332,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "async-stream",
- "dynamo-protocols",
+ "dynamo-protocols 5.4.1",
  "futures",
  "num-traits",
  "openai-harmony",
@@ -2368,6 +2368,23 @@ name = "dynamo-protocols"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbaf3179de1accba21fcad16eb22b5e113722084265e0315e808e32150088ee7"
+dependencies = [
+ "async-openai",
+ "derive_builder",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "dynamo-protocols"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c0b1eda0a7bfc732f825f8e831edad058b917fd43b5ecf9a3eb674340e9cd5"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2428,13 +2445,13 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "5.1.2"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2eaa139651c535aeaad8856c5546709608931ccd4d24d3a529f6c5233c4b6"
+checksum = "9bc2e88ca65967e191f32002da61b0e079f97a0e3f4b992cbfd70182c4bd5975"
 dependencies = [
  "anyhow",
  "chrono",
- "dynamo-protocols",
+ "dynamo-protocols 6.0.0",
  "dynamo-tokenizers",
  "either",
  "minijinja",
@@ -2576,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed232a9d254149a4e2e14f0a7d77f59bd64161964c0ba55267beea3955650faa"
+checksum = "aa6031ec0ca72092e6469ff659ddf9dbf5034110aa9de387ffbfb17e24a4d5d7"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -63,7 +63,7 @@ request-trace-s3 = ["dynamo-llm/request-trace-s3"]
 aisimulate-core = { version = "=0.1.0-dev.2", optional = true, features = ["python"] }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "8.1.0" }
+dynamo-parsers = { version = "9.0.0" }
 dynamo-backend-common = { path = "../../backend-common" }
 dynamo-sidecar-common = { path = "../../sidecar/common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -61,8 +61,8 @@ fn apply_request_tool_call_parsing_options(
         .as_ref()
         .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
     let converted_tool_choice = crate::preprocessor::tool_choice::convert_tool_choice(tool_choice);
-    let tools = request.inner.tools.as_deref().unwrap_or(&[]);
-    let converted_tools = crate::preprocessor::tool_choice::convert_tools(tools);
+    let converted_tools =
+        crate::preprocessor::tool_choice::effective_tool_definitions(&request.inner)?;
     let uses_structural_tag = crate::preprocessor::structural_tag::structural_tag_decision(
         parsing_options.tool_call_parser.as_deref(),
         &converted_tool_choice,
@@ -109,6 +109,94 @@ mod tests {
             }]
         });
         serde_json::from_value(value).expect("request must deserialize")
+    }
+
+    fn dynamic_request(tool_choice: Option<Value>) -> NvCreateChatCompletionRequest {
+        let mut value = json!({
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "",
+                    "tools": [{
+                        "name": "lookup",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}}
+                        },
+                        "strict": true
+                    }]
+                },
+                {"role": "user", "content": "test"}
+            ]
+        });
+        if let Some(tool_choice) = tool_choice {
+            value["tool_choice"] = tool_choice;
+        }
+        serde_json::from_value(value).expect("dynamic request must deserialize")
+    }
+
+    #[test]
+    fn kimi_k3_dynamic_tools_enable_response_parsing_without_a_top_level_sentinel() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k3".to_string()),
+            ..Default::default()
+        };
+        let result =
+            apply_request_tool_call_parsing_options(parsing_options, &dynamic_request(None))
+                .expect("dynamic tools must configure parsing");
+
+        assert!(!result.suppress_tool_calls);
+        assert_eq!(result.tools.len(), 1);
+        assert_eq!(result.tools[0].name, "lookup");
+        assert_eq!(result.tools[0].strict, Some(true));
+    }
+
+    #[test]
+    fn kimi_k3_forced_dynamic_tools_use_native_xtml_policies() {
+        for (tool_choice, expected) in [
+            (json!("required"), GuidedToolConstraint::None),
+            (
+                json!({"type": "function", "function": {"name": "lookup"}}),
+                GuidedToolConstraint::StructuralTag,
+            ),
+        ] {
+            let parsing_options = ParsingOptions {
+                tool_call_parser: Some("kimi_k3".to_string()),
+                ..Default::default()
+            };
+            let result = apply_request_tool_call_parsing_options(
+                parsing_options,
+                &dynamic_request(Some(tool_choice)),
+            )
+            .expect("forced dynamic tool choice must configure parsing");
+
+            assert!(!result.suppress_tool_calls);
+            assert_eq!(result.guided_tool_constraint, expected);
+            assert_eq!(result.tools.len(), 1);
+            assert_eq!(result.tools[0].name, "lookup");
+        }
+    }
+
+    #[test]
+    fn dynamic_tools_with_tool_choice_none_still_suppress_calls() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k3".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(
+            parsing_options,
+            &dynamic_request(Some(json!("none"))),
+        )
+        .expect("tool_choice none must remain valid");
+
+        assert!(result.suppress_tool_calls);
+        assert_eq!(result.guided_tool_constraint, GuidedToolConstraint::None);
+        assert_eq!(
+            result.tools.len(),
+            1,
+            "declarations remain available to parsers"
+        );
     }
 
     // A Kimi K2 pair with a forced/named tool_choice must resolve to the real

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2959,11 +2959,7 @@ impl OpenAIPreprocessor {
         request: &R,
         hidden_stop_token_ids: &mut Vec<TokenIdType>,
     ) -> Result<Vec<TokenIdType>> {
-        let has_tools = request
-            .tools()
-            .as_ref()
-            .and_then(|tools| tools.len())
-            .is_some_and(|len| len > 0);
+        let has_tools = Self::request_has_effective_tools(request);
         let tool_choice_none = request
             .tool_choice()
             .as_ref()
@@ -3011,6 +3007,23 @@ impl OpenAIPreprocessor {
         }
 
         Ok(visible_stop_token_ids)
+    }
+
+    fn request_has_effective_tools<R: OAIChatLikeRequest>(request: &R) -> bool {
+        request
+            .tools()
+            .as_ref()
+            .and_then(|tools| tools.len())
+            .is_some_and(|len| len > 0)
+            || request.typed_messages().is_some_and(|messages| {
+                messages.iter().any(|message| {
+                    matches!(
+                        message,
+                        dynamo_protocols::types::ChatCompletionRequestMessage::System(system)
+                            if system.tools.as_ref().is_some_and(|tools| !tools.is_empty())
+                    )
+                })
+            })
     }
 
     fn should_keep_tool_parser_end_tokens_visible(has_tools: bool, tool_choice_none: bool) -> bool {
@@ -4569,11 +4582,7 @@ impl OpenAIPreprocessor {
             .as_deref()
             .is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"));
         let tool_call_parsing_enabled = Self::tool_call_parsing_enabled(request);
-        let has_tools = request
-            .inner
-            .tools
-            .as_ref()
-            .is_some_and(|tools| !tools.is_empty());
+        let has_tools = request.inner.has_effective_tools();
         let should_jail = if tool_call_parsing_enabled || parser_unwraps_all_kimi_k3_responses {
             Self::should_apply_tool_jail(
                 effective_tool_call_parser.as_ref(),
@@ -4680,16 +4689,9 @@ impl OpenAIPreprocessor {
         // it does not need the same entry gate.
         //
         if let ToolProcessingRoute::MuseUnified(family) = &tool_processing_route {
-            let tool_definitions = request.inner.tools.as_ref().map(|tools| {
-                tools
-                    .iter()
-                    .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
-                        name: tool.function.name.clone(),
-                        parameters: tool.function.parameters.clone(),
-                        strict: tool.function.strict,
-                    })
-                    .collect()
-            });
+            let tool_definitions =
+                crate::preprocessor::tool_choice::effective_tool_definitions(&request.inner)?;
+            let tool_definitions = (!tool_definitions.is_empty()).then_some(tool_definitions);
             let unified: Pin<Box<dyn Stream<Item = _> + Send>> =
                 Box::pin(tool_parser_v2::apply_unified_stream(
                     stream,
@@ -4705,16 +4707,9 @@ impl OpenAIPreprocessor {
         }
 
         if let ToolProcessingRoute::QwenUnified(family) = &tool_processing_route {
-            let tool_definitions = request.inner.tools.as_ref().map(|tools| {
-                tools
-                    .iter()
-                    .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
-                        name: tool.function.name.clone(),
-                        parameters: tool.function.parameters.clone(),
-                        strict: tool.function.strict,
-                    })
-                    .collect()
-            });
+            let tool_definitions =
+                crate::preprocessor::tool_choice::effective_tool_definitions(&request.inner)?;
+            let tool_definitions = (!tool_definitions.is_empty()).then_some(tool_definitions);
             let unified: Pin<Box<dyn Stream<Item = _> + Send>> =
                 Box::pin(unified_parser::apply_stream_with_constraint(
                     stream,
@@ -4838,16 +4833,9 @@ impl OpenAIPreprocessor {
         let tool_call_parsing_enabled = Self::tool_call_parsing_enabled(request);
 
         // Convert OpenAI tools to parser ToolDefinition format before applying jail
-        let tool_definitions = request.inner.tools.as_ref().map(|tools| {
-            tools
-                .iter()
-                .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
-                    name: tool.function.name.clone(),
-                    parameters: tool.function.parameters.clone(),
-                    strict: tool.function.strict,
-                })
-                .collect()
-        });
+        let tool_definitions =
+            crate::preprocessor::tool_choice::effective_tool_definitions(&request.inner)?;
+        let tool_definitions = (!tool_definitions.is_empty()).then_some(tool_definitions);
 
         let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> =
             match tool_processing_route {
@@ -7755,6 +7743,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hidden_stop_policy_recognizes_dynamic_system_tools() {
+        let dynamic: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "system", "content": "", "tools": [{"name": "lookup"}]},
+                {"role": "user", "content": "test"}
+            ]
+        }))
+        .unwrap();
+        let none: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [{"role": "user", "content": "test"}]
+        }))
+        .unwrap();
+
+        assert!(OpenAIPreprocessor::request_has_effective_tools(&dynamic));
+        assert!(!OpenAIPreprocessor::request_has_effective_tools(&none));
+        assert!(
+            OpenAIPreprocessor::should_keep_tool_parser_end_tokens_visible(
+                OpenAIPreprocessor::request_has_effective_tools(&dynamic),
+                false,
+            )
+        );
+        assert!(
+            !OpenAIPreprocessor::should_keep_tool_parser_end_tokens_visible(
+                OpenAIPreprocessor::request_has_effective_tools(&dynamic),
+                true,
+            )
+        );
+    }
+
     async fn apply_kimi_k3_no_tools(
         leaked_reasoning: &str,
     ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
@@ -7772,6 +7792,53 @@ mod tests {
             None,
             false,
             // No tools and no forced choice, so no JSON grammar was installed.
+            false,
+            stream::iter(vec![
+                kimi_k3_reasoning_chunk(leaked_reasoning),
+                terminal_chat_stream_chunk(),
+            ]),
+        );
+
+        OpenAIPreprocessor::apply_tool_call_response_policy(jailed, tool_call_parsing_enabled)
+            .collect()
+            .await
+    }
+
+    async fn apply_kimi_k3_dynamic_tools(
+        leaked_reasoning: &str,
+    ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "",
+                    "tools": [{
+                        "name": "lookup",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"]
+                        }
+                    }]
+                },
+                {"role": "user", "content": "test"}
+            ]
+        }))
+        .unwrap();
+        let tool_call_parsing_enabled = OpenAIPreprocessor::tool_call_parsing_enabled(&request);
+        assert!(
+            tool_call_parsing_enabled,
+            "dynamic system tools grant tool-call response permission"
+        );
+        let tool_definitions =
+            crate::preprocessor::tool_choice::effective_tool_definitions(&request.inner).unwrap();
+
+        let jailed = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("kimi_k3".to_string()),
+            request.inner.tool_choice.clone(),
+            Some(tool_definitions),
+            false,
             false,
             stream::iter(vec![
                 kimi_k3_reasoning_chunk(leaked_reasoning),
@@ -7894,6 +7961,57 @@ mod tests {
             choice.message.reasoning_content.as_deref(),
             Some("Use the calculator.")
         );
+    }
+
+    #[tokio::test]
+    async fn test_kimi_k3_dynamic_only_tools_survive_stream_and_batch_response_policy() {
+        let responses = apply_kimi_k3_dynamic_tools(concat!(
+            "Use the dynamic lookup tool.",
+            "<|open|>tools<|sep|>",
+            "<|open|>call tool=\"lookup\" index=\"1\"<|sep|>",
+            "<|open|>argument key=\"query\" type=\"string\"<|sep|>weather",
+            "<|close|>argument<|sep|>",
+            "<|close|>call<|sep|>",
+            "<|close|>tools<|sep|>",
+            "<|close|>message<|sep|>",
+            "<|end_of_msg|>"
+        ))
+        .await;
+
+        let choices: Vec<_> = responses
+            .iter()
+            .flat_map(|response| response.data.iter())
+            .flat_map(|data| data.inner.choices.iter())
+            .collect();
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "streaming output must retain a dynamically declared tool call"
+        );
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.finish_reason == Some(FinishReason::ToolCalls)),
+            "streaming finish reason must remain tool_calls"
+        );
+
+        let response =
+            crate::protocols::openai::chat_completions::aggregator::DeltaAggregator::apply(
+                stream::iter(responses),
+                crate::protocols::openai::ParsingOptions::new(None, None),
+            )
+            .await
+            .unwrap();
+        let choice = &response.inner.choices[0];
+        let calls = choice
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("batch output must retain the dynamic call");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "lookup");
+        assert_eq!(choice.finish_reason, Some(FinishReason::ToolCalls));
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -11,8 +11,12 @@ use crate::protocols::openai::tools::{
 };
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
-use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption, ResponseFormat};
+use dynamo_protocols::types::{
+    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType,
+    CreateChatCompletionRequest, FunctionObject, ResponseFormat,
+};
 use dynamo_runtime::error::{DynamoError, ErrorType};
+use serde_json::Value;
 
 fn invalid_argument(message: impl Into<String>) -> DynamoError {
     DynamoError::builder()
@@ -26,11 +30,13 @@ impl OpenAIPreprocessor {
     ///
     /// A configured parser describes the model's wire format; it does not grant
     /// every request permission to return tool calls. Permission depends only on
-    /// whether the request supplies tools and whether `tool_choice` forbids them.
+    /// whether the request supplies effective tools and whether `tool_choice`
+    /// forbids them. Effective tools include both the OpenAI top-level list and
+    /// Kimi-style dynamic declarations carried by system messages.
     /// Assistant-output constraints apply to assistant content and do not revoke
     /// an `auto` request's ability to choose a tool call.
     pub(crate) fn tool_call_parsing_enabled(request: &NvCreateChatCompletionRequest) -> bool {
-        if request.inner.tools.as_ref().is_none_or(Vec::is_empty) {
+        if !request.inner.has_effective_tools() {
             return false;
         }
 
@@ -67,7 +73,7 @@ impl OpenAIPreprocessor {
             .tool_choice
             .as_ref()
             .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
-        let tools = request.inner.tools.as_deref().unwrap_or(&[]);
+        let tools = effective_tools(&request.inner)?;
         let is_forced_tool_choice = matches!(
             tool_choice,
             ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_)
@@ -100,7 +106,7 @@ impl OpenAIPreprocessor {
 
         if self.apply_tool_choice_structural_tag(
             &convert_tool_choice(tool_choice),
-            &convert_tools(tools),
+            &convert_tools(&tools),
             request.inner.parallel_tool_calls,
             prompt_injected_reasoning,
             common_request,
@@ -129,7 +135,7 @@ impl OpenAIPreprocessor {
 
         match get_tool_choice_guidance_from_tools(
             Some(tool_choice),
-            Some(tools),
+            Some(&tools),
             request.inner.parallel_tool_calls,
         ) {
             Ok(Some(guidance)) => {
@@ -200,6 +206,118 @@ pub(crate) fn convert_tools(tools: &[ChatCompletionTool]) -> Vec<ToolDefinition>
         .collect()
 }
 
+/// Normalize all tools visible to the model without rewriting the request.
+///
+/// Top-level OpenAI tools remain first. Kimi-style tools declared on system
+/// messages follow in message order and may use either the wrapped OpenAI form
+/// or Kimi's bare function-schema form. This view is used only by validation,
+/// parser, and guided-decoding policy; dynamic declarations stay at their
+/// original message positions for prompt rendering and KV-cache correctness.
+pub(crate) fn effective_tools(
+    request: &CreateChatCompletionRequest,
+) -> Result<Vec<ChatCompletionTool>, DynamoError> {
+    let dynamic_tools = request
+        .dynamic_system_tools()
+        .enumerate()
+        .map(|(index, tool)| normalize_dynamic_system_tool(tool, index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut tools = request.tools.clone().unwrap_or_default();
+    tools.extend(dynamic_tools);
+    Ok(tools)
+}
+
+/// Parser-facing form of [`effective_tools`].
+pub(crate) fn effective_tool_definitions(
+    request: &CreateChatCompletionRequest,
+) -> Result<Vec<ToolDefinition>, DynamoError> {
+    effective_tools(request).map(|tools| convert_tools(&tools))
+}
+
+fn normalize_dynamic_system_tool(
+    tool: &Value,
+    index: usize,
+) -> Result<ChatCompletionTool, DynamoError> {
+    let object = tool.as_object().ok_or_else(|| {
+        invalid_argument(format!(
+            "dynamic system tool at index {index} must be a JSON object"
+        ))
+    })?;
+    let function = match (object.get("type"), object.get("function")) {
+        (Some(Value::String(kind)), Some(Value::Object(function))) if kind == "function" => {
+            function
+        }
+        (Some(kind), _) if kind.as_str() != Some("function") => {
+            return Err(invalid_argument(format!(
+                "dynamic system tool at index {index} must have type=\"function\""
+            )));
+        }
+        (Some(_), _) => {
+            return Err(invalid_argument(format!(
+                "dynamic system tool at index {index} with type=\"function\" needs a function object"
+            )));
+        }
+        (None, Some(_)) => {
+            return Err(invalid_argument(format!(
+                "dynamic system tool at index {index} with a function field needs type=\"function\""
+            )));
+        }
+        (None, None) => object,
+    };
+
+    let name = function
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            invalid_argument(format!(
+                "dynamic system tool at index {index} needs a non-empty string name"
+            ))
+        })?;
+    let description = optional_string(function.get("description"), "description", index)?;
+    let parameters = match function.get("parameters") {
+        None | Some(Value::Null) => None,
+        Some(parameters @ Value::Object(_)) => Some(parameters.clone()),
+        Some(_) => {
+            return Err(invalid_argument(format!(
+                "dynamic system tool at index {index} parameters must be a JSON Schema object"
+            )));
+        }
+    };
+    let strict = match function.get("strict") {
+        None | Some(Value::Null) => None,
+        Some(Value::Bool(strict)) => Some(*strict),
+        Some(_) => {
+            return Err(invalid_argument(format!(
+                "dynamic system tool at index {index} strict must be a boolean"
+            )));
+        }
+    };
+
+    Ok(ChatCompletionTool {
+        r#type: ChatCompletionToolType::Function,
+        function: FunctionObject {
+            name: name.to_string(),
+            description,
+            parameters,
+            strict,
+        },
+    })
+}
+
+fn optional_string(
+    value: Option<&Value>,
+    field: &str,
+    index: usize,
+) -> Result<Option<String>, DynamoError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(invalid_argument(format!(
+            "dynamic system tool at index {index} {field} must be a string"
+        ))),
+    }
+}
+
 /// The guided-tool constraint a request implies, given what the structural-tag stage
 /// already decided.
 ///
@@ -222,7 +340,8 @@ pub(crate) fn guided_tool_constraint(
         .tool_choice
         .as_ref()
         .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
-    validate_openai_tool_choice(Some(tool_choice), request.inner.tools.as_deref())
+    let tools = effective_tools(&request.inner)?;
+    validate_openai_tool_choice(Some(tool_choice), Some(&tools))
         .map_err(|error| invalid_argument(error.to_string()))?;
     let is_forced_tool_choice = matches!(
         tool_choice,
@@ -246,10 +365,9 @@ pub(crate) fn guided_tool_constraint(
     // `apply_tool_choice_guided_decoding` does, instead of blindly installing a
     // constraint for a `tool_choice` that names a tool absent from `tools` (or an
     // empty `tools` list under `tool_choice: "required"`).
-    let tools = request.inner.tools.as_deref().unwrap_or(&[]);
     match get_tool_choice_guidance_from_tools(
         Some(tool_choice),
-        Some(tools),
+        Some(&tools),
         request.inner.parallel_tool_calls,
     ) {
         Ok(Some(_)) => Ok(installed_json_constraint(tool_choice)),
@@ -346,6 +464,118 @@ mod tests {
                 OpenAIPreprocessor::tool_call_parsing_enabled(&request(extra)),
                 expected,
             );
+        }
+    }
+
+    #[test]
+    fn dynamic_system_tools_enable_parsing_and_honor_tool_choice_none() {
+        for (tool_choice, expected) in [
+            (None, true),
+            (Some(json!("none")), false),
+            (Some(json!("auto")), true),
+            (Some(json!("required")), true),
+            (
+                Some(json!({
+                    "type": "function",
+                    "function": {"name": "lookup"}
+                })),
+                true,
+            ),
+        ] {
+            let mut extra = json!({
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "",
+                        "tools": [{"name": "lookup", "parameters": {"type": "object"}}]
+                    },
+                    {"role": "user", "content": "look it up"}
+                ]
+            });
+            if let Some(tool_choice) = tool_choice {
+                extra["tool_choice"] = tool_choice;
+            }
+            assert_eq!(
+                OpenAIPreprocessor::tool_call_parsing_enabled(&request(extra)),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn effective_tools_preserve_order_and_normalize_wrapped_and_bare_shapes() {
+        let request = request(json!({
+            "tools": [{
+                "type": "function",
+                "function": {"name": "static_tool", "parameters": {"type": "object"}}
+            }],
+            "messages": [
+                {"role": "user", "content": "start"},
+                {
+                    "role": "system",
+                    "content": "",
+                    "tools": [{
+                        "type": "function",
+                        "function": {
+                            "name": "wrapped_dynamic",
+                            "parameters": {"type": "object", "properties": {"x": {"type": "integer"}}},
+                            "strict": true
+                        }
+                    }]
+                },
+                {
+                    "role": "system",
+                    "content": "",
+                    "tools": [{
+                        "name": "bare_dynamic",
+                        "description": "bare form",
+                        "parameters": {"type": "object", "properties": {}},
+                        "strict": false,
+                        "vendor_hint": "kept only in the original message"
+                    }]
+                },
+                {"role": "user", "content": "continue"}
+            ]
+        }));
+
+        let normalized = effective_tools(&request.inner).expect("dynamic tools must normalize");
+        assert_eq!(
+            normalized
+                .iter()
+                .map(|tool| tool.function.name.as_str())
+                .collect::<Vec<_>>(),
+            ["static_tool", "wrapped_dynamic", "bare_dynamic"]
+        );
+        assert_eq!(normalized[1].function.strict, Some(true));
+        assert_eq!(normalized[2].function.strict, Some(false));
+        assert_eq!(
+            normalized[2].function.description.as_deref(),
+            Some("bare form")
+        );
+        let original = serde_json::to_value(&request.inner.messages).unwrap();
+        assert_eq!(
+            original[2]["tools"][0]["vendor_hint"], "kept only in the original message",
+            "normalization must not rewrite dynamic message declarations"
+        );
+    }
+
+    #[test]
+    fn effective_tools_reject_invalid_dynamic_schema_fields() {
+        for (field, value) in [
+            ("strict", json!("yes")),
+            ("parameters", json!([])),
+            ("description", json!(7)),
+        ] {
+            let mut tool = json!({"name": "lookup"});
+            tool[field] = value;
+            let request = request(json!({
+                "messages": [
+                    {"role": "system", "content": "", "tools": [tool]},
+                    {"role": "user", "content": "go"}
+                ]
+            }));
+            let error = effective_tools(&request.inner).expect_err("invalid field must fail");
+            assert!(error.to_string().contains(field), "{field}: {error}");
         }
     }
 
@@ -505,6 +735,32 @@ mod tests {
             assert!(
                 result.is_err(),
                 "Kimi K3 required must reject both missing and empty tools"
+            );
+        }
+    }
+
+    #[test]
+    fn kimi_k3_forced_choices_accept_dynamic_system_tools() {
+        for tool_choice in [
+            json!("required"),
+            json!({"type": "function", "function": {"name": "lookup"}}),
+        ] {
+            let request = request(json!({
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "",
+                        "tools": [{"name": "lookup", "parameters": {"type": "object"}}]
+                    },
+                    {"role": "user", "content": "go"}
+                ],
+                "tool_choice": tool_choice
+            }));
+            assert_eq!(
+                guided_tool_constraint(&request, Some("kimi_k3"), None, false)
+                    .expect("dynamic forced choice must validate"),
+                GuidedToolConstraint::None,
+                "K3 forced choices use native XTML rather than guided JSON"
             );
         }
     }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -38,6 +38,7 @@ fn push_system_message(content: String, messages: &mut Vec<ChatCompletionRequest
         ChatCompletionRequestSystemMessage {
             content: ChatCompletionRequestSystemMessageContent::Text(content),
             name: None,
+            tools: None,
         },
     ));
 }
@@ -100,6 +101,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                             audio: None,
                             tool_calls: None,
                             function_call: None,
+                            partial: None,
                         },
                     ));
                 }
@@ -474,6 +476,7 @@ fn convert_assistant_blocks(
             tool_calls: tc,
             #[allow(deprecated)]
             function_call: None,
+            partial: None,
         },
     ));
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -625,7 +625,7 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         validate::validate_temperature(self.inner.temperature)?;
         validate::validate_top_p(self.inner.top_p)?;
         validate::validate_tools(&self.inner.tools.as_deref())?;
-        validate::validate_tool_choice(&self.inner.tool_choice, self.inner.tools.as_deref())?;
+        validate::validate_effective_tool_choice(&self.inner)?;
         // none for parallel_tool_calls
         validate::validate_user(self.inner.user.as_deref())?;
         // none for function call
@@ -1030,6 +1030,96 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("tool named \"search\" in tool_choice is not present in tools")
+        );
+    }
+
+    #[test]
+    fn test_kimi_extensions_survive_nv_request_roundtrip() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {"role": "system", "tools": [{"name": "lookup"}]},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "The answer is", "partial": true}
+            ],
+            "prompt_cache_key": "session-key"
+        }))
+        .expect("Kimi extensions must deserialize through the Dynamo wrapper");
+
+        assert!(request.unsupported_fields.is_empty());
+        ValidateRequest::validate(&request).expect("Kimi extensions must pass request validation");
+        assert!(request.inner.has_effective_tools());
+        assert!(request.inner.effective_tool_contains("lookup"));
+
+        // This checks protocol preservation, not cache routing or continuation parsing.
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert_eq!(serialized["messages"][0]["tools"][0]["name"], "lookup");
+        assert_eq!(serialized["messages"][2]["partial"], true);
+        assert_eq!(serialized["messages"][2]["content"], "The answer is");
+        assert_eq!(serialized["prompt_cache_key"], "session-key");
+    }
+
+    #[test]
+    fn test_system_message_without_content_or_tools_is_still_rejected() {
+        let request = serde_json::from_value::<NvCreateChatCompletionRequest>(json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "system"},
+                {"role": "user", "content": "Hello"}
+            ]
+        }));
+        assert!(request.is_err());
+    }
+
+    #[test]
+    fn test_validate_forced_tool_choice_accepts_dynamic_system_tools() {
+        for tool_choice in [
+            json!("required"),
+            json!({"type": "function", "function": {"name": "lookup"}}),
+        ] {
+            let request_json = json!({
+                "model": "test-model",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "",
+                        "tools": [{"name": "lookup", "parameters": {"type": "object"}}]
+                    },
+                    {"role": "user", "content": "Hello"}
+                ],
+                "tool_choice": tool_choice
+            });
+            let request: NvCreateChatCompletionRequest = serde_json::from_value(request_json)
+                .expect("dynamic-tool request must deserialize");
+            ValidateRequest::validate(&request)
+                .expect("dynamic tools must satisfy forced tool_choice validation");
+        }
+    }
+
+    #[test]
+    fn test_validate_named_tool_choice_rejects_absent_dynamic_tool() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "",
+                    "tools": [{"name": "lookup"}]
+                },
+                {"role": "user", "content": "Hello"}
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "missing"}
+            }
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("request must deserialize");
+        let error = ValidateRequest::validate(&request).expect_err("missing tool must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("tool named \"missing\" in tool_choice is not present in tools")
         );
     }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -373,25 +373,6 @@ fn convert_input_content_to_text(content: &[InputContent]) -> String {
         .join("")
 }
 
-/// Counterpart to `convert_input_content_to_text` for upstream's
-/// `InputContent`. Reachable only via `FunctionCallOutput::Content`, which is
-/// not Dynamo-owned and therefore carries upstream variants. The sibling
-/// `EasyInputContent::ContentList` is Dynamo-owned and routed through
-/// `convert_input_content_to_text` / `convert_input_content_to_user_content`.
-fn convert_upstream_input_content_to_text(
-    content: &[dynamo_protocols::types::responses::UpstreamInputContent],
-) -> String {
-    use dynamo_protocols::types::responses::UpstreamInputContent;
-    content
-        .iter()
-        .filter_map(|p| match p {
-            UpstreamInputContent::InputText(t) => Some(t.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
 /// Accumulator for consecutive assistant-side items (OutputMessage, FunctionCall,
 /// Reasoning, assistant EasyMessage). Chat Completions represents an assistant
 /// turn as a single message carrying `content`, `tool_calls`, and
@@ -561,9 +542,7 @@ fn convert_input_items_to_messages(
                     std::mem::take(&mut pending).flush_into(&mut messages);
                     let output_text = match &fco.output {
                         FunctionCallOutput::Text(text) => text.clone(),
-                        FunctionCallOutput::Content(parts) => {
-                            convert_upstream_input_content_to_text(parts)
-                        }
+                        FunctionCallOutput::Content(parts) => convert_input_content_to_text(parts),
                     };
                     messages.push(ChatCompletionRequestMessage::Tool(
                         ChatCompletionRequestToolMessage {
@@ -1913,7 +1892,14 @@ mod tests {
                     })),
                     InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
                         call_id: "call_123".into(),
-                        output: FunctionCallOutput::Text(r#"{"temp":"72F"}"#.into()),
+                        output: FunctionCallOutput::Content(vec![
+                            InputContent::InputText(InputTextContent {
+                                text: "{\"temp\":\"".into(),
+                            }),
+                            InputContent::InputText(InputTextContent {
+                                text: "72F\"}".into(),
+                            }),
+                        ]),
                         id: None,
                         status: None,
                     })),
@@ -1933,7 +1919,17 @@ mod tests {
             messages[1],
             ChatCompletionRequestMessage::Assistant(_)
         ));
-        assert!(matches!(messages[2], ChatCompletionRequestMessage::Tool(_)));
+        match &messages[2] {
+            ChatCompletionRequestMessage::Tool(tool) => {
+                assert_eq!(tool.tool_call_id, "call_123");
+                assert!(matches!(
+                    &tool.content,
+                    ChatCompletionRequestToolMessageContent::Text(text)
+                        if text == r#"{"temp":"72F"}"#
+                ));
+            }
+            other => panic!("expected tool message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -483,6 +483,7 @@ impl PendingAssistant {
                 },
                 #[allow(deprecated)]
                 function_call: None,
+                partial: None,
             },
         ));
     }
@@ -510,6 +511,7 @@ fn convert_input_items_to_messages(
                                             text,
                                         ),
                                         name: None,
+                                        tools: None,
                                     },
                                 )
                             }
@@ -623,6 +625,7 @@ fn convert_input_items_to_messages(
                             ChatCompletionRequestSystemMessage {
                                 content: ChatCompletionRequestSystemMessageContent::Text(text),
                                 name: None,
+                                tools: None,
                             },
                         ));
                     }
@@ -807,6 +810,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                 ChatCompletionRequestSystemMessage {
                     content: ChatCompletionRequestSystemMessageContent::Text(instructions.clone()),
                     name: None,
+                    tools: None,
                 },
             ));
         }
@@ -867,6 +871,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                     ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
                         content: ChatCompletionRequestSystemMessageContent::Text(combined),
                         name: None,
+                        tools: None,
                     }),
                 );
             }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -615,6 +615,36 @@ pub fn validate_tool_choice(
     }
 }
 
+/// Validate a forced tool choice against every tool visible to the model.
+///
+/// Kimi-style dynamic tools remain inside system messages so prompt ordering
+/// and prefix-cache semantics are preserved. They still participate in the
+/// request's tool-choice contract, alongside the ordinary top-level list.
+pub fn validate_effective_tool_choice(
+    request: &dynamo_protocols::types::CreateChatCompletionRequest,
+) -> Result<(), anyhow::Error> {
+    use dynamo_protocols::types::ChatCompletionToolChoiceOption;
+
+    match request.tool_choice.as_ref() {
+        None
+        | Some(ChatCompletionToolChoiceOption::None)
+        | Some(ChatCompletionToolChoiceOption::Auto) => Ok(()),
+        Some(ChatCompletionToolChoiceOption::Required) if !request.has_effective_tools() => {
+            anyhow::bail!("tool_choice is \"required\" but tools is empty")
+        }
+        Some(ChatCompletionToolChoiceOption::Named(named))
+            if !request.effective_tool_contains(&named.function.name) =>
+        {
+            anyhow::bail!(
+                "tool named \"{}\" in tool_choice is not present in tools",
+                named.function.name
+            )
+        }
+        Some(ChatCompletionToolChoiceOption::Required)
+        | Some(ChatCompletionToolChoiceOption::Named(_)) => Ok(()),
+    }
+}
+
 /// Validates reasoning effort parameter
 pub fn validate_reasoning_effort(
     _reasoning_effort: &Option<dynamo_protocols::types::ReasoningEffort>,

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -29,6 +29,7 @@ fn create_mock_chat_completion_request() -> NvCreateChatCompletionRequest {
                     "You MUST use two tools in parallel to resolve the user request: call get_current_weather for each city AND call is_holiday_today to check if today is a holiday. Do not answer without using both tools.".to_string()
                 ),
                 name: None,
+                tools: None,
             }
         ),
         dynamo_protocols::types::ChatCompletionRequestMessage::User(


### PR DESCRIPTION
## Overview:

### Summary

This is the Dynamo-side pickup for [frontend-crates PR #205](https://github.com/ai-dynamo/frontend-crates/pull/205). It accepts Kimi K3 message extensions and closes the extra integration gap we found: tools declared only in `system.tools` must be treated like top-level OpenAI tools throughout Dynamo, including the final response policy.

The design keeps these extensions optional. Requests that only use the standard top-level `tools` field, or do not use tools at all, retain their existing behavior; no model-specific command-line switch is added.

## Details:

- Pick up `dynamo-protocols 6.0.1`, `dynamo-renderer 5.3.1`, `dynamo-tokenizers 1.8.2`, and the protocols-6-compatible `dynamo-parsers 9.0.0`; regenerate the affected lockfiles without retaining a protocols 5.x copy.
- Build one validated *effective tool set* from top-level `tools` plus message-level `system.tools`. The same view now drives request validation, tool-choice handling, guided decoding, parser definitions, stop-token behavior, and response gating.
- Preserve dynamic declarations at their original message positions instead of rewriting the request. This maintains Kimi prompt ordering and prefix-cache behavior.
- Validate the combined tool set once, including name syntax/length, schema metadata, named choices, and the total tool-count limit. Invalid dynamic declarations fail as client errors before preprocessing.
- Update request-construction and conversion sites for the new protocol types. `assistant.partial` is preserved, rendered as an open Kimi response prefix, and decoded as suffix-only content by the native Dynamo K3 path. `prompt_cache_key` is accepted and preserved; using it for cache routing remains separate follow-up work.

### Validation

- `cargo fmt --all -- --check` and `git diff --check` pass on final head `a7b60af193f37dc81c76b10aae5ff92b8109b2b7`. Per the requested workflow, compilation and tests for this review-fix head are delegated to PR CI rather than run locally.
- Core logic head `99b3fdb469483753b11e0648b5df2c7679691382` built successfully as an aarch64 Python/Rust wheel on a Grace GB300 node. Four focused `dynamo-llm` tests passed for invalid dynamic names, combined tool-count overflow, malformed dynamic metadata, and `tool_choice: none` behavior. Later review fixes remove redundant comments and coverage, avoid cloning top-level tools when no dynamic declarations exist, reuse validated effective tools in the HTTP path, pin the generic effective-tool predicate to the protocol definition, and directly test the production hidden-stop path.
- A live two-node/8×GB300 TP8 Kimi K3 deployment passed the full directed suite: dynamic-only tools in unary and streaming responses, named dynamic choice, top-level tools as a control, final `assistant.partial` in unary and streaming modes, `prompt_cache_key`, and the expected K3 shape rejections.
- Two additional live validation cases returned HTTP 400 before inference: an invalid bare dynamic function name, and 1536 valid top-level tools plus one dynamic tool (`1537 > MAX_TOOLS`).
- Kimi Code 0.41 completed a real four-request streaming tool loop through this deployment, wrote and read the requested file, and returned the expected result. The captured client requests used 26 standard top-level tools and a stable `prompt_cache_key`; Kimi Code did not emit `system.tools` or `assistant.partial`, so those extensions are covered by the directed suite above.
- GitHub CI for the latest review-fix head is still running; no current check has failed.

### Change size

Line counts include comments and blank lines. Tests inside production `.rs` files under `#[cfg(test)]` are counted as test code.

| Category | Added | Removed |
| --- | ---: | ---: |
| Production Rust | 209 | 82 |
| Test code and fixtures | 684 | 2 |
| Dependency manifests and generated lockfiles | 29 | 29 |
| **Total** | **922** | **113** |

<details>
<summary>Changed files (13)</summary>

| File | Added | Removed | Breakdown |
| --- | ---: | ---: | --- |
| `Cargo.lock` | 8 | 8 | Dependency lockfile |
| `Cargo.toml` | 4 | 4 | Dependency manifest |
| `lib/bindings/kvbm/Cargo.lock` | 8 | 8 | Dependency lockfile |
| `lib/bindings/python/Cargo.lock` | 8 | 8 | Dependency lockfile |
| `lib/bindings/python/Cargo.toml` | 1 | 1 | Dependency manifest |
| `lib/llm/src/http/service.rs` | 95 | 8 | Production `+10/-8`; tests `+85/-0` |
| `lib/llm/src/preprocessor.rs` | 311 | 40 | Production `+31/-40`; tests `+280/-0` |
| `lib/llm/src/preprocessor/tool_choice.rs` | 204 | 9 | Production `+56/-9`; tests `+148/-0` |
| `lib/llm/src/protocols/anthropic/types.rs` | 3 | 0 | Production `+3/-0` |
| `lib/llm/src/protocols/openai/chat_completions.rs` | 153 | 2 | Production `+2/-2`; tests `+151/-0` |
| `lib/llm/src/protocols/openai/responses/mod.rs` | 25 | 24 | Production `+6/-22`; tests `+19/-2` |
| `lib/llm/src/protocols/openai/validate.rs` | 101 | 1 | Production `+101/-1` |
| `lib/llm/tests/parallel_tool_call_integration.rs` | 1 | 0 | Tests `+1/-0` |

</details>

## Where should the reviewer start?

1. `lib/llm/src/protocols/openai/validate.rs` — shared normalization and validation of the combined effective tool set.
2. `lib/llm/src/preprocessor/tool_choice.rs` — parser and tool-choice policy built on that validated set.
3. `lib/llm/src/preprocessor.rs` and `lib/llm/src/http/service.rs` — stop-token and response-policy integration.
4. `lib/llm/src/protocols/openai/chat_completions.rs` — request validation and protocol-extension regression coverage.
5. Root and Python manifests/lockfiles — frontend-crate release pickup.

## Related Issues

- Relates to [frontend-crates issue #159](https://github.com/ai-dynamo/frontend-crates/issues/159)
- Picks up [frontend-crates PR #205](https://github.com/ai-dynamo/frontend-crates/pull/205)
- Includes the DeepSeek V4.1 guard fix released from [frontend-crates PR #240](https://github.com/ai-dynamo/frontend-crates/pull/240)
- Uses the protocols-6 parser release from [frontend-crates PR #233](https://github.com/ai-dynamo/frontend-crates/pull/233)
