### PR TITLE
fix(ci): fail test jobs whose pytest stage was cut off mid-run

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -176,9 +176,14 @@ runs:
         # Artifacts go to the GitHub Actions checkout so the per-job upload in
         # shared-test.yml can find them.
         TEST_RESULTS_DIR="${GITHUB_WORKSPACE}/test-results"
-        mkdir -p "${TEST_RESULTS_DIR}"
+        mkdir -p "${TEST_RESULTS_DIR}/status"
         chmod 777 "${TEST_RESULTS_DIR}"
         echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
+
+        # Cleared up front so the file read at the end of the job can only have
+        # come from this run of this stage.
+        STATUS_FILE="${TEST_RESULTS_DIR}/status/${STR_TEST_TYPE}.exitcode"
+        rm -f "${STATUS_FILE}"
 
         # NVMe guard: GPU runners mount ${NVME_DIR} (nvme-scratch emptyDir, NVMe-backed via
         # instanceStorePolicy: RAID0). CPU/ARM runners have no ${NVME_DIR} mount.
@@ -302,6 +307,12 @@ runs:
         elif [[ "${DRY_RUN}" != "true" ]]; then
           echo "⚠️  JUnit XML file not found - test results may not be available for upload"
         fi
+
+        # Checked by "Verify test stages completed" in shared-test.yml, which
+        # cannot use the exit below or $GITHUB_ENV: a truncated script is still
+        # reported as a successful step and its $GITHUB_ENV writes are dropped.
+        # Keep this last - its absence is what proves the script was truncated.
+        echo "${TEST_EXIT_CODE}" > "${STATUS_FILE}"
 
         exit ${TEST_EXIT_CODE}
 

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -238,6 +238,7 @@ jobs:
           fi
 
       - name: Run CPU-only tests (parallelized)
+        id: cpu-only-tests
         if: ${{ inputs.run_cpu_only_tests }}
         timeout-minutes: ${{ inputs.cpu_only_test_timeout_minutes }}
         uses: $/.github/actions/pytest-local
@@ -253,6 +254,7 @@ jobs:
           enable_coverage: ${{ inputs.enable_coverage }}
           gpu_tests: 'false'
       - name: Run CPU end-to-end tests (isolated)
+        id: cpu-e2e-tests
         # Long-lived deployment tests should not compete with the xdist unit
         # pool or retry until the parent step kills the runner container.
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' && inputs.run_cpu_e2e_tests }}
@@ -271,6 +273,7 @@ jobs:
           gpu_tests: 'false'
           dd_flaky_retry_enabled: 'false'
       - name: Run GPU tests (parallel)
+        id: gpu-parallel-tests
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
         if: ${{ matrix.platform == 'amd64' && inputs.run_gpu_tests && inputs.run_gpu_parallel_tests }}
         uses: $/.github/actions/pytest-local
@@ -290,6 +293,7 @@ jobs:
           gpu_tests: 'true'
           verify_gpu: ${{ inputs.verify_gpu }}
       - name: Run GPU tests (sequential)
+        id: gpu-sequential-tests
         timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
         # !cancelled() so a parallel-stage failure doesn't hide sequential results,
         # but require checkout to have succeeded so an infra/prereq failure (e.g. the
@@ -324,3 +328,65 @@ jobs:
           path: test-results/pytest_test_report_*.xml
           retention-days: 7
           if-no-files-found: warn
+
+      # A stage cut off mid-run is still reported as a successful step, so real
+      # test failures go green. Take the verdict only from the status file
+      # pytest-local writes last, never from the step outcome. Placed after the
+      # upload so results survive a failure here, and once per job rather than
+      # per stage to avoid three more container-hook round trips.
+      - name: Verify test stages completed
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        shell: bash
+        env:
+          STAGE_OUTCOMES: |
+            pre_merge_cpu ${{ steps.cpu-only-tests.outcome }}
+            pre_merge_cpu_e2e ${{ steps.cpu-e2e-tests.outcome }}
+            pre_merge_gpu_parallel ${{ steps.gpu-parallel-tests.outcome }}
+            pre_merge_gpu ${{ steps.gpu-sequential-tests.outcome }}
+        run: |
+          set -uo pipefail
+          status_dir="${GITHUB_WORKSPACE}/test-results/status"
+          failed=0
+          checked=""
+
+          while read -r stage outcome; do
+            [[ -z "${stage}" ]] && continue
+            exitcode_file="${status_dir}/${stage}.exitcode"
+
+            case "${outcome}" in
+              ''|skipped)
+                echo "⏭️  ${stage}: did not run"
+                ;;
+              success)
+                if [[ ! -f "${exitcode_file}" ]]; then
+                  echo "❌ ${stage}: reported success but wrote no status file."
+                  echo "   Its script did not run to completion, so the result is"
+                  echo "   unknown and cannot be treated as a pass."
+                  failed=1
+                elif [[ "$(cat "${exitcode_file}")" != "0" ]]; then
+                  echo "❌ ${stage}: pytest exited $(cat "${exitcode_file}")"
+                  failed=1
+                else
+                  echo "✅ ${stage}: pytest exited 0"
+                fi
+                ;;
+              *)
+                echo "❌ ${stage}: step outcome '${outcome}'"
+                failed=1
+                ;;
+            esac
+            checked+=" ${stage}"
+          done <<< "${STAGE_OUTCOMES}"
+
+          # A stage added above but not listed here would escape this check.
+          shopt -s nullglob
+          for f in "${status_dir}"/*.exitcode; do
+            stage=$(basename "${f}" .exitcode)
+            if [[ " ${checked} " != *" ${stage} "* ]]; then
+              echo "❌ ${stage}: ran but is not listed in STAGE_OUTCOMES, so its"
+              echo "   result is unverified. Add it to this step."
+              failed=1
+            fi
+          done
+
+          exit "${failed}"


### PR DESCRIPTION
## Overview:

### Summary

A pytest stage can be reported as a **successful step when its script never reached
the end**. When that happens the runner also drops the step's `$GITHUB_ENV` updates,
so `TEST_EXIT_CODE` is never set and the action's final `exit ${TEST_EXIT_CODE}`
expands to a bare `exit` — which returns the status of the preceding command, zero.
Real test failures are reported green.

[Job 103364334832](https://github.com/ai-dynamo/dynamo/actions/runs/34534220040/job/103364334832)
(`dynamo-runtime / test / sequential cuda13.0, arm64`) is a clean example:

| | |
|---|---|
| Test result | `test_kv_router_propagates_stream_errors[100] FAILED [ 89%]` |
| Step end | cut off at 95%, mid-line, as `test_mocker_router_soak[nats-random]` started |
| Step outcome | `success`, `duration_ms=585358` |
| Next step's `env:` block | contains `STR_TEST_TYPE`, `HF_HOME`, `XDG_CACHE_HOME` — **no `TEST_EXIT_CODE`** |
| `Process Test Results` | printed `⚠️ JUnit XML file not found`, set `FAILED_TESTS=1  # Treat missing XML as failure`, **discarded it**, ran `exit ${TEST_EXIT_CODE}` → `exit` → 0 |
| Job conclusion | `success` — the PR got a green check |

**This is not a regression from #14352.** That job predates the step collapse and
runs the multi-step action, on the standard `k8s` hook rather than `k8s-novolume`,
on CPU arm64 rather than GPU. Truncation is specific to none of those. The
pre-collapse action had the identical hole, because it also read `TEST_EXIT_CODE`
from `$GITHUB_ENV` written by the long step.

### Approach

Judge each stage by a **status file** rather than by the step's exit status or an
env round trip. `pytest-local` clears `test-results/status/<test_type>.exitcode` when
the stage starts and writes the pytest exit code there as its very last action, so
absence of the file means the script did not finish. A new job-level step in
`shared-test.yml` reads one file per stage that ran and fails the job on a missing
file or a non-zero code.

The filesystem is the only channel here that a truncated step cannot corrupt: it
never crosses the container/runner boundary, unlike `$GITHUB_ENV` and the step exit
status. Both hooks keep the workspace across steps, which the existing cross-stage
`test-results/` accumulation already relies on.

Two deliberate choices:

- **Per job, not per stage** — one container-hook round trip instead of four, so
  this does not give back what #14352 bought on the critical path. The step names
  the offending stage in its output, so attribution is not lost.
- **After the JUnit upload** — results are still collected when the check fails.

It also fails when a stage writes a status file that is not in its list, so a stage
added later cannot silently opt out of the check that exists to stop silent passes.

### Scope — what this does not fix

**What truncates the script is still unknown.** The stdin-drain theory I floated on
the sibling issue does not survive this job: its hook runs the step from a *file*
(`sh -e /__w/_temp/<uuid>.sh`), not from stdin, so a child draining stdin cannot eat
the script. Candidates now point at the exec stream dropping — #14352's own
description mentions a "cluster-wide runner exec drop" — which would need the runner
administrators to confirm.

Making the truncation **visible and loud** is the prerequisite for measuring how
often it happens. Expect this step to turn some currently-green jobs red; those jobs
were already not proving what they claimed.

## Details:

`.github/actions/pytest-local/action.yml` — `mkdir -p` now creates `status/`;
`STATUS_FILE` is cleared at stage start so the value read later can only have come
from this run of this stage; the exit code is written immediately before `exit`.

`.github/workflows/shared-test.yml` — `id:` on the four stage steps, and the
`Verify test stages completed` step. Stage outcomes are passed through `env:` rather
than interpolated into the script body, matching the convention #14352 established.

## Where should the reviewer start?

The `Verify test stages completed` step at the end of `shared-test.yml`, then the
two small hunks in `action.yml` that bracket the stage with the status file.

### Validation

- `pre-commit` passes on both files, including `check yaml` and the action-pin hook.
- `bash -n` accepts both the action's `run:` script and the verification script
  extracted from the workflow.
- Replayed the verification logic against seven scenarios, all as expected:

  | scenario | expected | got |
  |---|---|---|
  | job 103364334832: stage truncated, reported success, no status file | fail | fail |
  | job 103046830380: two GPU stages truncated after two CPU stages passed | fail | fail, names both |
  | healthy four-stage amd64 job | pass | pass |
  | recorded non-zero pytest exit | fail | fail |
  | arm64 job, GPU stages skipped | pass | pass |
  | stage step failed outright | fail | fail |
  | status file from an unlisted stage | fail | fail |

- End-to-end simulation of the sentinel lifecycle: a stage `SIGKILL`ed mid-run
  leaves no status file and is caught; a stage that completes passes.
- `shared-test.yml` is still the only caller of `pytest-local`, with the same four
  stages, and all four ids match the names the verification step checks.
- [ ] Full CI: `Verify test stages completed` reports ✅ for every stage that ran and
  ⏭️ for skipped ones, on both an amd64 and an arm64 test job.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Follow-up to #14670, which fixed the artifact-name collision caused by the same
truncation. That collision was the only reason these jobs ever went red; with it
fixed, this check is what keeps a truncated stage from passing silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added completion and result tracking for test stages.
  - Added verification to detect failed or incomplete CPU and GPU test stages.
  - Jobs now fail when test results are missing, unsuccessful, or contain unexpected status records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->