### PR TITLE
fix(ci): pass framework to Triton test workflows

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -643,6 +643,7 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: triton
+      framework: triton
       test_type: CPU Test
       amd_runner: prod-tester-amd-v2
       target_tag_plain: ${{ needs.triton-build.outputs.target_tag_plain }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -940,6 +940,7 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: triton
+      framework: triton
       test_type: CPU Test
       amd_runner: prod-tester-amd-v2
       target_tag_plain: ${{ needs.triton-build.outputs.target_tag_plain }}


### PR DESCRIPTION
## Overview

The Triton test jobs added in #13774 call `shared-test.yml` without its required `framework` input.

Because `framework` is a required `workflow_call` input, the affected workflows fail during workflow validation before any jobs are created.

This affects both full PR CI and post-merge CI.

## Details

Pass `framework: triton` to the Triton test jobs in:

* `.github/workflows/pr.yaml`
* `.github/workflows/post-merge-ci.yml`

The existing vLLM, SGLang, TRT-LLM, and Dynamo callers already pass the corresponding `framework` value.

After #13774 merged, its post-merge workflow ended immediately with `startup_failure` and created no jobs. PR branches using the updated workflow have also failed to start the full `PR` workflow or reported `startup_failure`.

This change only supplies the missing required input and does not change Triton test selection or execution behavior.

## Where should the reviewer start?

* `.github/workflows/pr.yaml`: `triton-test`
* `.github/workflows/post-merge-ci.yml`: `triton-test`

## Related Issues

**🚫 This PR is NOT linked to an issue**:

* [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflows to explicitly identify Triton tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->