### PR TITLE
fix(planner): treat an unreadable request count as unknown, not zero

### DIFF
--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -408,16 +408,12 @@ class PrometheusAPIClient:
                 )
                 return None
             return completed_count
-        except (
-            PrometheusApiClientException,
-            RequestsConnectionError,
-            RequestsTimeout,
-        ) as e:
-            logger.error("Error getting avg request count; demand is UNKNOWN: %s", e)
-            return None
         except Exception:
-            logger.exception("Unexpected error getting avg request count")
-            raise
+            # Never propagate: the tick loop catches only GPUShapeUnavailableError
+            # (core/base.py:1042), so anything else here shuts the planner down.
+            # An unreadable metric must degrade to unknown demand, not to no planner.
+            logger.exception("Error getting avg request count; demand is UNKNOWN")
+            return None
 
     def get_avg_input_sequence_tokens(self, interval: str, model_name: str):
         if self.metrics_source == "router":

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -397,10 +397,27 @@ class PrometheusAPIClient:
                 query=f"increase({requests_total_metric}[{interval}])"
             )
             completed_count = self._sum_frontend_metric(completed_res, model_name)
-            return completed_count or 0
-        except Exception as e:
-            logger.error(f"Error getting avg request count: {e}")
-            return 0
+            if completed_count is None:
+                logger.warning(
+                    "No prometheus metric data available for %s or %s with model "
+                    "%s and dynamo namespace %s; demand is UNKNOWN, not zero",
+                    requests_started_metric,
+                    requests_total_metric,
+                    model_name,
+                    self.dynamo_namespace,
+                )
+                return None
+            return completed_count
+        except (
+            PrometheusApiClientException,
+            RequestsConnectionError,
+            RequestsTimeout,
+        ) as e:
+            logger.error("Error getting avg request count; demand is UNKNOWN: %s", e)
+            return None
+        except Exception:
+            logger.exception("Unexpected error getting avg request count")
+            raise
 
     def get_avg_input_sequence_tokens(self, interval: str, model_name: str):
         if self.metrics_source == "router":

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -461,7 +461,6 @@ def test_get_avg_request_count_returns_none_when_no_data():
 
 
 def test_get_avg_request_count_returns_none_when_prometheus_is_unreachable():
-    """A refused connection is UNKNOWN demand, not zero demand."""
     client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
 
     with patch.object(client.prom, "custom_query") as mock_query:
@@ -472,34 +471,20 @@ def test_get_avg_request_count_returns_none_when_prometheus_is_unreachable():
     assert result is None
 
 
-def test_get_avg_request_count_reraises_unexpected_errors():
-    """An unexpected error propagates rather than becoming a demand of zero.
+def test_get_avg_request_count_returns_none_on_unexpected_errors():
+    """A malformed response is unknown demand, and must not kill the planner.
 
-    Matches the router branch of this same method, which already re-raises.
+    The tick loop catches only GPUShapeUnavailableError (core/base.py:1042), so
+    anything raised here would shut the planner down instead of skipping a tick.
     """
     client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
 
     with patch.object(client.prom, "custom_query") as mock_query:
         mock_query.side_effect = ValueError("malformed payload")
 
-        with pytest.raises(ValueError):
-            client.get_avg_request_count("30s", "target_model")
+        result = client.get_avg_request_count("30s", "target_model")
 
-
-def test_metrics_with_unknown_num_req_are_not_valid():
-    """Unknown demand must fail is_valid(), so the planner holds instead of resizing.
-
-    This is the consequence of the three tests above: num_req is what
-    normalize_idle_nans() treats as proof of a "confirmed idle window", so a
-    fabricated zero there also zeroes the latency fields and lets a failed read
-    look like a healthy idle one.
-    """
-    metrics = Metrics(
-        ttft=0.1, itl=0.01, isl=100, osl=10, num_req=None, request_duration=0.5
-    )
-
-    assert metrics.is_valid() is False
-    assert metrics.normalize_idle_nans() == []
+    assert result is None
 
 
 def test_vllm_spec_decode_accept_length_query_derives_from_counters():

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from prometheus_api_client import PrometheusApiClientException
+from requests import ConnectionError as RequestsConnectionError
 
 from dynamo import prometheus_names
 from dynamo.planner.core.throughput_scaling import ThroughputScalingMixin
@@ -439,6 +440,66 @@ def test_get_avg_request_count_falls_back_to_completed_when_started_missing():
     queries = [call.kwargs["query"] for call in mock_query.call_args_list]
     assert "dynamo_frontend_requests_started_total" in queries[0]
     assert "dynamo_frontend_requests_total" in queries[1]
+
+
+def test_get_avg_request_count_returns_none_when_no_data():
+    """No data is UNKNOWN demand, not zero demand.
+
+    A frontend whose metrics are not being scraped -- a PodMonitor pointing at the
+    wrong path, say -- looks exactly like a frontend nobody is sending requests to.
+    Returning 0 makes the planner size the pools for no traffic while traffic is
+    flowing; only min_endpoint then stands between a busy pool and its floor.
+    """
+    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+
+    with patch.object(client.prom, "custom_query") as mock_query:
+        mock_query.side_effect = [[], []]
+
+        result = client.get_avg_request_count("30s", "target_model")
+
+    assert result is None
+
+
+def test_get_avg_request_count_returns_none_when_prometheus_is_unreachable():
+    """A refused connection is UNKNOWN demand, not zero demand."""
+    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+
+    with patch.object(client.prom, "custom_query") as mock_query:
+        mock_query.side_effect = RequestsConnectionError("connection refused")
+
+        result = client.get_avg_request_count("30s", "target_model")
+
+    assert result is None
+
+
+def test_get_avg_request_count_reraises_unexpected_errors():
+    """An unexpected error propagates rather than becoming a demand of zero.
+
+    Matches the router branch of this same method, which already re-raises.
+    """
+    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+
+    with patch.object(client.prom, "custom_query") as mock_query:
+        mock_query.side_effect = ValueError("malformed payload")
+
+        with pytest.raises(ValueError):
+            client.get_avg_request_count("30s", "target_model")
+
+
+def test_metrics_with_unknown_num_req_are_not_valid():
+    """Unknown demand must fail is_valid(), so the planner holds instead of resizing.
+
+    This is the consequence of the three tests above: num_req is what
+    normalize_idle_nans() treats as proof of a "confirmed idle window", so a
+    fabricated zero there also zeroes the latency fields and lets a failed read
+    look like a healthy idle one.
+    """
+    metrics = Metrics(
+        ttft=0.1, itl=0.01, isl=100, osl=10, num_req=None, request_duration=0.5
+    )
+
+    assert metrics.is_valid() is False
+    assert metrics.normalize_idle_nans() == []
 
 
 def test_vllm_spec_decode_accept_length_query_derives_from_counters():


### PR DESCRIPTION
Fixes #14765.

`get_avg_request_count`'s frontend branch returns `0` both when Prometheus reports no requests and when it could not be read at all, so the planner cannot tell "nobody is asking" from "I could not find out".

That matters because `Metrics.normalize_idle_nans` replaces undefined averages *"only for a confirmed idle window"*, and the confirmation is `num_req == 0`. A failed read fabricates one: the NaN latencies get zeroed, `is_valid()` passes, and the planner sizes pools for no traffic while traffic flows. Only `min_endpoint` stops the collapse.

### What changed

Every failure in the frontend branch now returns `None` — no data, transport errors, and malformed responses alike — logged with a traceback.

Nothing propagates, on purpose: the tick loop catches only `GPUShapeUnavailableError` (`core/base.py:1042`) and its `finally` calls `_shutdown_runtime`, so a raised exception here would stop all future planning rather than skip one tick.

`None` is not a new convention: `_sum_frontend_metric` already returns `Optional[float]` and `None` for no data (`:145-147`), and `Metrics.num_req` is already `Optional[float]` (`:57`). The `or 0` between them discards it.

Nothing downstream changes. `normalize_idle_nans` already declines to call `None` idle, and `is_valid()` already requires `v is not None`. **A genuinely idle deployment still reports `0` and still scales down.**

### What this does not solve

On a *sustained* outage the provider skips every tick (`prometheus_traffic_provider.py:90`), so the planner holds its current sizing indefinitely — #6985's symptom. This PR fixes the primitive: stop reporting a number that was never read. A complete answer needs a caller-side policy on top, e.g. #7427's idea of falling back to the floor after N consecutive unknown reads. The two compose; this one has to land first, because a counter cannot count what `0` has already hidden.

### Scope

The router branch has the same conflation (`:363-369` returns `0` on a refused connection), but `test_router_request_count_returns_zero_when_completed_query_fails` asserts that. Changing it is your call — happy to extend here or in a follow-up.

The open question is the **no-data** case. I return `None` because that is how we hit this: a NIM frontend serves `/v1/metrics` while the PodMonitor defaults to `/metrics`, so every scrape 404s and the series is simply absent. If you would rather keep `completed_count or 0` and change only the exception handling, say so and I will trim it.

### Testing

3 tests added. `53 passed` with the fix; `3 failed, 50 passed` with it reverted — the three that exercise the change fail without it. The fourth documents the downstream consequence and passes either way.

All 49 existing tests pass unchanged; the `assert result == 0` cases all use `router_client`.
