### PR TITLE
fix(ci): pass required framework input to triton-test (unblock PR workflow)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -940,6 +940,7 @@ jobs:
     uses: $/.github/workflows/shared-test.yml
     with:
       test_suite_name: triton
+      framework: triton  # matches the framework passed to triton-build
       test_type: CPU Test
       amd_runner: prod-tester-amd-v2
       target_tag_plain: ${{ needs.triton-build.outputs.target_tag_plain }}


### PR DESCRIPTION
## Summary

Fixes a **repo-wide** `PR`-workflow `startup_failure` that has blocked heavy CI on every PR based on main since ~2026-09-11 23:00 UTC.

`shared-test.yml` declares `framework` as a **required** input, but the `triton-test` job (added in #13774) does not pass it. A reusable-workflow call missing a required input fails **workflow startup validation**, which aborts the entire `PR` workflow before any job runs — so this is not triton-specific, it breaks CI for all PRs.

**Root cause — merge skew:** #14688 made `framework` required in `shared-test.yml`; #13774 added `triton-test` in parallel without it. Neither PR re-ran against the other (triton jobs are path-filtered to `skipped` on unrelated diffs), so the break only surfaced once both landed on main.

Every other `shared-test` caller (vllm / sglang / trtllm / planner) already passes `framework`. This adds the missing `framework: triton` to match — a one-line change.

## Validation

- `pr.yaml` parses as valid YAML.
- All `shared-test.yml` callers now pass the required `framework` input (verified per-job; `triton-test` was the only one missing it).

Regression from #13774 (× #14688).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Triton test workflow configuration to ensure tests run with the correct framework setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->