### PR TITLE
fix(llm): report KServe datatypes by their wire names, not protobuf variants

### DIFF
--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -681,10 +681,11 @@ impl GrpcInferenceService for KserveService {
                                 .iter()
                                 .map(|input| inference::model_metadata_response::TensorMetadata {
                                     name: input.name.clone(),
-                                    datatype: match inference::DataType::try_from(input.data_type) {
-                                        Ok(dt) => dt.as_str_name().to_string(),
-                                        Err(_) => "TYPE_INVALID".to_string(),
-                                    },
+                                    datatype: inference::DataType::try_from(input.data_type)
+                                        .ok()
+                                        .and_then(|dt| dt.oip_name())
+                                        .unwrap_or("TYPE_INVALID")
+                                        .to_string(),
                                     shape: input.dims.clone(),
                                 })
                                 .collect(),
@@ -694,12 +695,11 @@ impl GrpcInferenceService for KserveService {
                                 .map(
                                     |output| inference::model_metadata_response::TensorMetadata {
                                         name: output.name.clone(),
-                                        datatype: match inference::DataType::try_from(
-                                            output.data_type,
-                                        ) {
-                                            Ok(dt) => dt.as_str_name().to_string(),
-                                            Err(_) => "TYPE_INVALID".to_string(),
-                                        },
+                                        datatype: inference::DataType::try_from(output.data_type)
+                                            .ok()
+                                            .and_then(|dt| dt.oip_name())
+                                            .unwrap_or("TYPE_INVALID")
+                                            .to_string(),
                                         shape: output.dims.clone(),
                                     },
                                 )

--- a/lib/llm/src/grpc/service/tensor.rs
+++ b/lib/llm/src/grpc/service/tensor.rs
@@ -805,6 +805,36 @@ impl tensor::DataType {
     }
 }
 
+impl DataType {
+    /// The OIP wire name this datatype must be reported as in KServe v2
+    /// `ModelMetadata`, or `None` for `TYPE_INVALID`, which has no wire name.
+    ///
+    /// Not `as_str_name()`, which returns the `model_config.proto` variant name
+    /// (`TYPE_FP32`). That is the config spelling, not the wire spelling the
+    /// `datatype` field carries. Stripping the `TYPE_` prefix is not enough
+    /// either: `TYPE_STRING` is `BYTES` on the wire, the same pairing
+    /// [`tensor::DataType::to_kserve`] already encodes in the other direction.
+    pub fn oip_name(&self) -> Option<&'static str> {
+        Some(match self {
+            DataType::TypeInvalid => return None,
+            DataType::TypeBool => "BOOL",
+            DataType::TypeUint8 => "UINT8",
+            DataType::TypeUint16 => "UINT16",
+            DataType::TypeUint32 => "UINT32",
+            DataType::TypeUint64 => "UINT64",
+            DataType::TypeInt8 => "INT8",
+            DataType::TypeInt16 => "INT16",
+            DataType::TypeInt32 => "INT32",
+            DataType::TypeInt64 => "INT64",
+            DataType::TypeFp16 => "FP16",
+            DataType::TypeFp32 => "FP32",
+            DataType::TypeFp64 => "FP64",
+            DataType::TypeString => "BYTES",
+            DataType::TypeBf16 => "BF16",
+        })
+    }
+}
+
 impl std::fmt::Display for tensor::DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
@@ -1019,5 +1049,70 @@ mod tests {
             tensor::DataType::BFloat16.to_kserve(),
             inference::DataType::TypeBf16 as i32
         );
+    }
+}
+
+#[cfg(test)]
+mod oip_datatype_tests {
+    use super::*;
+
+    /// The two branches of `model_metadata` must name a datatype the same way.
+    ///
+    /// The Dynamo branch emits `tensor::DataType`'s `Display`; the Triton branch
+    /// emits `oip_name`. `to_kserve` already pairs the two enums, so composing it
+    /// with `oip_name` has to land back on the same string. This is what fails if
+    /// `oip_name` is ever written as "strip the `TYPE_` prefix": `TYPE_STRING`
+    /// would become `STRING`, but the wire name is `BYTES`.
+    #[test]
+    fn both_metadata_branches_agree_on_every_datatype_name() {
+        for dt in [
+            tensor::DataType::Bool,
+            tensor::DataType::Uint8,
+            tensor::DataType::Uint16,
+            tensor::DataType::Uint32,
+            tensor::DataType::Uint64,
+            tensor::DataType::Int8,
+            tensor::DataType::Int16,
+            tensor::DataType::Int32,
+            tensor::DataType::Int64,
+            tensor::DataType::Float32,
+            tensor::DataType::Float64,
+            tensor::DataType::Bytes,
+        ] {
+            let triton = DataType::try_from(dt.to_kserve())
+                .expect("to_kserve must yield a valid model_config DataType");
+            let expected = dt.to_string();
+            assert_eq!(
+                triton.oip_name(),
+                Some(expected.as_str()),
+                "{dt} reports a different name through the Triton branch"
+            );
+        }
+    }
+
+    /// `datatype` carries the OIP wire name, never the `model_config.proto`
+    /// variant name that `as_str_name()` returns.
+    #[test]
+    fn oip_names_are_wire_names_not_protobuf_variant_names() {
+        assert_eq!(DataType::TypeString.oip_name(), Some("BYTES"));
+        assert_eq!(DataType::TypeFp32.oip_name(), Some("FP32"));
+        assert_eq!(DataType::TypeBf16.oip_name(), Some("BF16"));
+        assert_eq!(DataType::TypeInvalid.oip_name(), None);
+
+        for dt in [
+            DataType::TypeBool,
+            DataType::TypeUint8,
+            DataType::TypeInt64,
+            DataType::TypeFp16,
+            DataType::TypeFp64,
+            DataType::TypeString,
+            DataType::TypeBf16,
+        ] {
+            let name = dt.oip_name().expect("a valid datatype has a wire name");
+            assert!(
+                !name.starts_with("TYPE_"),
+                "{name} is the model_config spelling, not the wire spelling"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #14520.

The KServe v2 gRPC `ModelMetadata` RPC built each tensor's `datatype` from
`inference::DataType::as_str_name()`. That returns the `model_config.proto` variant name, so for a Triton-registered tensor model the RPC answered `TYPE_FP32`, `TYPE_INT32`, `TYPE_STRING` where the [KServe v2 predict protocol](https://github.com/kserve/open-inference-protocol) specifies the `datatype` field carries `FP32`, `INT32`, `BYTES`. `kserve.proto`'s own doc comment on `bytes_contents` refers to "BYTES data type" for the same reason.

Every datatype was wrong, not an edge case, so a spec-conforming client reading metadata for one of these models cannot parse any tensor it describes. The Dynamo branch of the same function was already correct, which is why this only shows up for `Config::Triton` models.

**The obvious fix is also wrong**, which is what makes this worth a test. Dropping the `TYPE_` prefix gets thirteen of the fourteen right and leaves `TYPE_STRING` as `STRING`, but the wire name is `BYTES`. The codebase already encoded that pairing, only in the other direction: `tensor::DataType::to_kserve` maps `Bytes` to `TypeString`, and the `Display` impl directly beneath it spells that same type `BYTES`. The Triton branch of `model_metadata` was the one consumer not going through it.

So `oip_name` sits next to `to_kserve` rather than becoming a second source of truth. It covers all fifteen proto variants, including `TYPE_FP16` and `TYPE_BF16`, which `tensor::DataType` cannot represent and which composing through `Display` would have silently dropped. `TYPE_INVALID` returns `None`, leaving the existing `"TYPE_INVALID"` sentinel on the unrepresentable path unchanged.

## Validation

Reproduced on current `main` (`4a3943c766`) before changing anything: `as_str_name()` at `kserve.rs:685` and `:700`.

- `cargo test -p dynamo-llm --no-default-features --lib`: **2552 passed, 2 failed**.
- Baseline on clean `main`, same command: **2550 passed, 2 failed**. Identical failure set (`test_oversized_body_returns_json_413`, `metrics_bind_failure_shuts_down_dynamic_and_in_process_runtimes`), so both are pre-existing and unrelated. The delta of exactly +2 passing is the two tests added here.
- `cargo clippy -p dynamo-llm --no-default-features --lib`: clean, no warnings on either changed file.
- `cargo fmt --check`: clean.
- `pre-commit` over both changed files: all hooks pass except `pytest-marker-report`, which fails identically on a clean tree because vLLM is not installed in this environment.

The new tests fail on the plausible wrong implementation. Changing `oip_name` to return `STRING` for `TypeString`, which is what stripping the prefix produces:

```
test both_metadata_branches_agree_on_every_datatype_name ... FAILED
test oip_names_are_wire_names_not_protobuf_variant_names ... FAILED

assertion `left == right` failed: BYTES reports a different name through the Triton branch
```

`both_metadata_branches_agree_on_every_datatype_name` composes the existing `to_kserve()` with `oip_name()` across all twelve datatypes Dynamo serves and asserts the result equals `Display`, so the two branches of `model_metadata` cannot drift apart again.

Not covered here: this is a CPU-only change to metadata string construction, so no GPU, NIXL or live-engine path was exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tensor metadata now reports data types using standardized OIP wire names, improving compatibility with KServe model configurations and downstream clients.
  - Unsupported or invalid data types continue to be represented as `TYPE_INVALID`, preserving existing fallback behavior.

- **Tests**
  - Added coverage to verify consistent metadata generation and correct wire-format data type names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->