### PR TITLE
fix(trtllm): return 4xx for client-fault embedding load failures

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -267,7 +267,7 @@ class MultimodalRequestProcessor:
                     )
                     raise HttpStatusError(
                         500,
-                        "Passed in path is a local file path, but allowed_local_media_path is not configured."
+                        "Passed in path is a local file path, but allowed_local_media_path is not configured. "
                         "Please configure an allowed path for local media.",
                         path,
                     )
@@ -485,13 +485,14 @@ class MultimodalRequestProcessor:
                             if isinstance(item, dict):
                                 emb = item.get("mm_embeddings")
                                 if emb is None:
+                                    source = describe_media_source(path)
                                     logging.error(
                                         f"Dictionary embeddings missing 'mm_embeddings' key: {path}"
                                     )
                                     raise HttpStatusError(
                                         400,
-                                        f"Malformed embedding file {path}: missing 'mm_embeddings' key",
-                                        str(path),
+                                        f"Malformed embedding file {path}: missing 'mm_embeddings' key.",
+                                        source,
                                     )
                                 loaded_embeddings.append(emb)
                             else:

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -208,13 +208,11 @@ class MultimodalRequestProcessor:
                 400,
                 "Unsafe tensor format: .pt/.pth/.bin files are not allowed. "
                 "Use .safetensors format instead.",
-                path
+                path,
             )
         if not lower_path.endswith(".safetensors"):
             raise HttpStatusError(
-                400,
-                "Only .safetensors embedding files are supported.",
-                path
+                400, "Only .safetensors embedding files are supported.", path
             )
 
         if self.is_url(path):
@@ -222,7 +220,7 @@ class MultimodalRequestProcessor:
                 raise HttpStatusError(
                     400,
                     f"Unsupported URL scheme: {parsed.scheme}. Only http and https are allowed.",
-                    path
+                    path,
                 )
             try:
                 with httpx.Client(timeout=300.0) as client:
@@ -238,7 +236,7 @@ class MultimodalRequestProcessor:
                                 f"File size exceeds limit: "
                                 f"{int(content_length) // (1024*1024)}MB > "
                                 f"{self.max_file_size_mb}MB",
-                                path
+                                path,
                             )
                         chunks = []
                         downloaded = 0
@@ -250,7 +248,7 @@ class MultimodalRequestProcessor:
                                     f"File size exceeds limit: "
                                     f"{downloaded // (1024*1024)}MB > "
                                     f"{self.max_file_size_mb}MB",
-                                    path
+                                    path,
                                 )
                             chunks.append(chunk)
                         content = b"".join(chunks)
@@ -271,7 +269,7 @@ class MultimodalRequestProcessor:
                         500,
                         "Passed in path is a local file path, but allowed_local_media_path is not configured."
                         "Please configure an allowed path for local media.",
-                        path
+                        path,
                     )
 
                 local_path = path.removeprefix("file://")
@@ -287,22 +285,18 @@ class MultimodalRequestProcessor:
                     raise HttpStatusError(
                         400,
                         "Access to file outside allowed path is not permitted.",
-                        path
+                        path,
                     )
 
                 if not resolved_path.exists():
-                    raise HttpStatusError(
-                        400,
-                        "Embedding file not found.",
-                        path
-                    )
+                    raise HttpStatusError(400, "Embedding file not found.", path)
                 file_size = resolved_path.stat().st_size
                 if file_size > self.max_file_size_bytes:
                     raise HttpStatusError(
                         400,
                         f"File size ({file_size // (1024*1024)}MB) exceeds "
                         f"maximum allowed size ({self.max_file_size_bytes // (1024*1024)}MB)",
-                        path
+                        path,
                     )
                 data = safetensors_load_file(str(resolved_path))
                 return self._unwrap_safetensors(data)
@@ -497,7 +491,7 @@ class MultimodalRequestProcessor:
                                     raise HttpStatusError(
                                         400,
                                         f"Malformed embedding file {path}: missing 'mm_embeddings' key",
-                                        str(path)
+                                        str(path),
                                     )
                                 loaded_embeddings.append(emb)
                             else:

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -487,11 +487,11 @@ class MultimodalRequestProcessor:
                                 if emb is None:
                                     source = describe_media_source(path)
                                     logging.error(
-                                        f"Dictionary embeddings missing 'mm_embeddings' key: {path}"
+                                        f"Dictionary embeddings missing 'mm_embeddings' key: {source}"
                                     )
                                     raise HttpStatusError(
                                         400,
-                                        f"Malformed embedding file {path}: missing 'mm_embeddings' key.",
+                                        f"Malformed embedding file {source}: missing 'mm_embeddings' key.",
                                         source,
                                     )
                                 loaded_embeddings.append(emb)

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -204,16 +204,26 @@ class MultimodalRequestProcessor:
         parsed = urlparse(path)
         lower_path = parsed.path.lower()
         if lower_path.endswith((".pt", ".pth", ".bin")):
-            raise RuntimeError(
+            raise HttpStatusError(
+                400,
                 "Unsafe tensor format: .pt/.pth/.bin files are not allowed. "
-                "Use .safetensors format instead."
+                "Use .safetensors format instead.",
+                path
             )
         if not lower_path.endswith(".safetensors"):
-            raise RuntimeError("Only .safetensors embedding files are supported.")
+            raise HttpStatusError(
+                400,
+                "Only .safetensors embedding files are supported.",
+                path
+            )
 
         if self.is_url(path):
             if parsed.scheme not in ("http", "https"):
-                raise RuntimeError(f"Unsupported URL scheme: {parsed.scheme}")
+                raise HttpStatusError(
+                    400,
+                    f"Unsupported URL scheme: {parsed.scheme}. Only http and https are allowed.",
+                    path
+                )
             try:
                 with httpx.Client(timeout=300.0) as client:
                     with client.stream("GET", path) as resp:
@@ -223,26 +233,30 @@ class MultimodalRequestProcessor:
                             content_length
                             and int(content_length) > self.max_file_size_bytes
                         ):
-                            raise RuntimeError(
+                            raise HttpStatusError(
+                                400,
                                 f"File size exceeds limit: "
                                 f"{int(content_length) // (1024*1024)}MB > "
-                                f"{self.max_file_size_mb}MB"
+                                f"{self.max_file_size_mb}MB",
+                                path
                             )
                         chunks = []
                         downloaded = 0
                         for chunk in resp.iter_bytes():
                             downloaded += len(chunk)
                             if downloaded > self.max_file_size_bytes:
-                                raise RuntimeError(
+                                raise HttpStatusError(
+                                    400,
                                     f"File size exceeds limit: "
                                     f"{downloaded // (1024*1024)}MB > "
-                                    f"{self.max_file_size_mb}MB"
+                                    f"{self.max_file_size_mb}MB",
+                                    path
                                 )
                             chunks.append(chunk)
                         content = b"".join(chunks)
                     data = safetensors_load(content)
                     return self._unwrap_safetensors(data)
-            except RuntimeError:
+            except HttpStatusError:
                 raise
             except Exception as e:
                 logging.error(f"Failed to download or load tensor from URL: {e}")
@@ -253,7 +267,12 @@ class MultimodalRequestProcessor:
                     logging.warning(
                         "Local file access attempted but no allowed path configured"
                     )
-                    raise RuntimeError("Failed to load tensor")
+                    raise HttpStatusError(
+                        500,
+                        "Passed in path is a local file path, but allowed_local_media_path is not configured."
+                        "Please configure an allowed path for local media.",
+                        path
+                    )
 
                 local_path = path.removeprefix("file://")
                 resolved_path = Path(local_path).resolve()
@@ -265,19 +284,29 @@ class MultimodalRequestProcessor:
                     logging.warning(
                         f"Blocked access to file outside {self.allowed_local_media_path}: {path}"
                     )
-                    raise RuntimeError("Failed to load tensor")
+                    raise HttpStatusError(
+                        400,
+                        "Access to file outside allowed path is not permitted.",
+                        path
+                    )
 
                 if not resolved_path.exists():
-                    raise RuntimeError(f"Embedding file not found: {resolved_path}")
+                    raise HttpStatusError(
+                        400,
+                        "Embedding file not found.",
+                        path
+                    )
                 file_size = resolved_path.stat().st_size
                 if file_size > self.max_file_size_bytes:
-                    raise RuntimeError(
+                    raise HttpStatusError(
+                        400,
                         f"File size ({file_size // (1024*1024)}MB) exceeds "
-                        f"maximum allowed size ({self.max_file_size_bytes // (1024*1024)}MB)"
+                        f"maximum allowed size ({self.max_file_size_bytes // (1024*1024)}MB)",
+                        path
                     )
                 data = safetensors_load_file(str(resolved_path))
                 return self._unwrap_safetensors(data)
-            except RuntimeError:
+            except HttpStatusError:
                 raise
             except Exception as e:
                 logging.error(f"Failed to load tensor from local path: {e}")
@@ -458,14 +487,18 @@ class MultimodalRequestProcessor:
                             for path in embedding_paths
                         ]
                         loaded_embeddings = []
-                        for item in raw_loaded:
+                        for item, path in zip(raw_loaded, embedding_paths):
                             if isinstance(item, dict):
                                 emb = item.get("mm_embeddings")
                                 if emb is None:
                                     logging.error(
-                                        "Dictionary embeddings missing 'mm_embeddings' key"
+                                        f"Dictionary embeddings missing 'mm_embeddings' key: {path}"
                                     )
-                                    return None
+                                    raise HttpStatusError(
+                                        400,
+                                        f"Malformed embedding file {path}: missing 'mm_embeddings' key",
+                                        str(path)
+                                    )
                                 loaded_embeddings.append(emb)
                             else:
                                 loaded_embeddings.append(item)
@@ -473,6 +506,10 @@ class MultimodalRequestProcessor:
                             logging.info(
                                 f"Loaded {len(loaded_embeddings)} embedding file(s) from paths: {embedding_paths}"
                             )
+                    except HttpStatusError:
+                        # Typed HTTP errors: let them reach the frontend with their status
+                        # instead of the generic catch below swallowing them to None.
+                        raise
                     except Exception as e:
                         logging.error(f"Failed to load embeddings: {e}")
                         return None

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -41,6 +41,7 @@ pytestmark = [
 def _embedding_processor(
     allowed_local_media_path: str = "",
 ) -> MultimodalRequestProcessor:
+    """Build a processor with a mocked tokenizer and the given allowed local media path."""
     return MultimodalRequestProcessor(
         model_type="multimodal",
         model_dir="unused",
@@ -559,8 +560,10 @@ async def test_cached_path_rejects_non_object_kwargs_on_hit() -> None:
 
 
 def _embedding_request(url: str) -> dict:
-    # A URL ending in .safetensors routes to the embedding loader, which needs
-    # the frontend's formatted prompt once the embeddings have loaded.
+    """Build a request whose .safetensors URL routes to the embedding loader.
+
+    The formatted prompt is required once the embeddings have loaded.
+    """
     return {
         "multi_modal_data": {"image_url": [{"Url": url}]},
         "token_ids": [1],
@@ -571,10 +574,12 @@ def _embedding_request(url: str) -> dict:
 # Each setup receives a processor whose allowed_local_media_path is tmp_path,
 # prepares one failure, and returns the URL the client would send.
 def _missing_file(tmp_path, processor):
+    """Return a URL for a file that does not exist inside the allowed directory."""
     return f"file://{tmp_path / 'missing.safetensors'}"
 
 
 def _outside_allowed_dir(tmp_path, processor):
+    """Restrict the allowed directory to a subfolder and return a file outside it."""
     allowed = tmp_path / "allowed"
     allowed.mkdir()
     processor.allowed_local_media_path = str(allowed)
@@ -584,6 +589,7 @@ def _outside_allowed_dir(tmp_path, processor):
 
 
 def _file_too_large(tmp_path, processor):
+    """Lower the size limit to 1 byte and return a valid file that exceeds it."""
     processor.max_file_size_bytes = 1
     path = tmp_path / "large.safetensors"
     save_file({"emb": torch.zeros(2)}, str(path))
@@ -591,13 +597,14 @@ def _file_too_large(tmp_path, processor):
 
 
 def _missing_mm_embeddings_key(tmp_path, processor):
-    # Two keys, so the file is returned as a dict and must name mm_embeddings.
+    """Return a two-key file, loaded as a dict, that lacks the mm_embeddings key."""
     path = tmp_path / "two_keys.safetensors"
     save_file({"a": torch.zeros(2), "b": torch.zeros(2)}, str(path))
     return f"file://{path}"
 
 
 def _unsupported_scheme(tmp_path, processor):
+    """Return a .safetensors URL with a scheme other than http or https."""
     return "ftp://example.invalid/emb.safetensors"
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""process_openai_request must let client-error types from image loading
-propagate (so the frontend returns a 4xx) instead of swallowing them to None."""
+"""process_openai_request must let client-error types from image and embedding
+loading propagate (so the frontend returns a 4xx) instead of swallowing them to None."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock
@@ -19,6 +19,8 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 
+from safetensors.torch import save_file
+
 from dynamo.common.http import HttpStatusError
 from dynamo.common.http.url_validator import UrlValidationError
 from dynamo.trtllm import multimodal_processor as mmp
@@ -34,6 +36,19 @@ pytestmark = [
 
 # Intentionally unprofiled: these import-heavy, zero-VRAM tests run in the
 # sequential GPU stage so TensorRT-LLM initialization is shared.
+
+
+def _embedding_processor(
+    allowed_local_media_path: str = "",
+) -> MultimodalRequestProcessor:
+    # Factory for a processor with a mocked tokenizer and the given allowed_local_media_path.
+    return MultimodalRequestProcessor(
+        model_type="multimodal",
+        model_dir="unused",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+        allowed_local_media_path=allowed_local_media_path,
+    )
 
 
 @pytest.mark.asyncio
@@ -542,3 +557,152 @@ async def test_cached_path_rejects_non_object_kwargs_on_hit() -> None:
 
     assert excinfo.value.status == 400
     cache.get.assert_not_called()
+
+
+def _embedding_request(url: str) -> dict:
+    # A URL ending in .safetensors routes to the embedding loader, which needs
+    # the frontend's formatted prompt once the embeddings have loaded.
+    return {
+        "multi_modal_data": {"image_url": [{"Url": url}]},
+        "token_ids": [1],
+        "extra_args": {"formatted_prompt": "describe"},
+    }
+
+
+# Each setup receives a processor whose allowed_local_media_path is tmp_path,
+# prepares one failure, and returns the URL the client would send.
+def _missing_file(tmp_path, processor):
+    return f"file://{tmp_path / 'missing.safetensors'}"
+
+
+def _outside_allowed_dir(tmp_path, processor):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    processor.allowed_local_media_path = str(allowed)
+    outside = tmp_path / "outside.safetensors"
+    save_file({"emb": torch.zeros(2)}, str(outside))
+    return f"file://{outside}"
+
+
+def _file_too_large(tmp_path, processor):
+    processor.max_file_size_bytes = 1
+    path = tmp_path / "large.safetensors"
+    save_file({"emb": torch.zeros(2)}, str(path))
+    return f"file://{path}"
+
+
+def _missing_mm_embeddings_key(tmp_path, processor):
+    # Two keys, so the file is returned as a dict and must name mm_embeddings.
+    path = tmp_path / "two_keys.safetensors"
+    save_file({"a": torch.zeros(2), "b": torch.zeros(2)}, str(path))
+    return f"file://{path}"
+
+
+def _unsupported_scheme(tmp_path, processor):
+    return "ftp://example.invalid/emb.safetensors"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup, expected_in_message",
+    [
+        pytest.param(_missing_file, "not found", id="missing-file"),
+        pytest.param(_outside_allowed_dir, "outside allowed path", id="outside-dir"),
+        pytest.param(_file_too_large, "exceeds", id="too-large"),
+        pytest.param(_missing_mm_embeddings_key, "mm_embeddings", id="missing-key"),
+        pytest.param(_unsupported_scheme, "ftp", id="unsupported-scheme"),
+    ],
+)
+async def test_embedding_client_errors_return_400(
+    setup, expected_in_message, tmp_path
+) -> None:
+    """A bad embedding URL is the client's fault: 400 with a reason, not a
+    swallowed None that the handler turns into a sanitized 500."""
+    processor = _embedding_processor(str(tmp_path))
+    url = setup(tmp_path, processor)
+
+    with pytest.raises(HttpStatusError) as exc_info:
+        await processor.process_openai_request(
+            _embedding_request(url), embeddings=None, ep_disaggregated_params=None
+        )
+
+    assert exc_info.value.status == 400
+    # Every case is a 400, so the message is what proves the intended check fired.
+    assert expected_in_message in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_embedding_outside_allowed_dir_does_not_leak_it(tmp_path) -> None:
+    """The 400 message reaches the client directly, so it must not name the
+    server's allowed directory."""
+    processor = _embedding_processor()
+    url = _outside_allowed_dir(tmp_path, processor)
+
+    with pytest.raises(HttpStatusError) as exc_info:
+        await processor.process_openai_request(
+            _embedding_request(url), embeddings=None, ep_disaggregated_params=None
+        )
+
+    assert processor.allowed_local_media_path not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_embedding_local_path_unconfigured_is_server_error(tmp_path) -> None:
+    """Local media access unconfigured is the operator's problem, so it
+    should throw a 5xx error, which the frontend sanitizes."""
+    processor = _embedding_processor()
+    path = tmp_path / "emb.safetensors"
+    save_file({"emb": torch.zeros(2)}, str(path))
+
+    with pytest.raises(HttpStatusError) as exc_info:
+        await processor.process_openai_request(
+            _embedding_request(f"file://{path}"),
+            embeddings=None,
+            ep_disaggregated_params=None,
+        )
+
+    assert exc_info.value.status == 500
+
+
+@pytest.mark.asyncio
+async def test_embedding_valid_file_loads(tmp_path) -> None:
+    """The new error paths must leave a valid embedding file loading as before."""
+    processor = _embedding_processor(str(tmp_path))
+    emb = torch.ones(2, 3)
+    path = tmp_path / "emb.safetensors"
+    save_file({"emb": emb}, str(path))
+
+    processed = await processor.process_openai_request(
+        _embedding_request(f"file://{path}"),
+        embeddings=None,
+        ep_disaggregated_params=None,
+    )
+
+    assert processed["prompt"] == "describe"
+    loaded = processed["multi_modal_embeddings"]["image"]
+    assert len(loaded) == 1
+    assert torch.equal(loaded[0], emb)
+
+
+@pytest.mark.asyncio
+async def test_epd_embedding_load_error_propagates() -> None:
+    """The encode worker calls load_tensor_from_path_or_url; its typed
+    error must propagate, not be swallowed into a yielded error dict."""
+    from dynamo.trtllm.encode_helper import EncodeHelper
+
+    url = "file:///missing.safetensors"
+    processor = MagicMock()
+    processor.extract_prompt_and_media.return_value = ("", [], [url])
+    processor.load_tensor_from_path_or_url.side_effect = HttpStatusError(
+        400, "Embedding file not found.", url
+    )
+
+    with pytest.raises(HttpStatusError) as excinfo:
+        async for _ in EncodeHelper.process_encode_request(
+            request={"messages": []},
+            multimodal_processor=processor,
+            connector=MagicMock(),  # the embedding flow requires a connector
+        ):
+            pass
+
+    assert excinfo.value.status == 400

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -41,7 +41,6 @@ pytestmark = [
 def _embedding_processor(
     allowed_local_media_path: str = "",
 ) -> MultimodalRequestProcessor:
-    # Factory for a processor with a mocked tokenizer and the given allowed_local_media_path.
     return MultimodalRequestProcessor(
         model_type="multimodal",
         model_dir="unused",
@@ -682,27 +681,3 @@ async def test_embedding_valid_file_loads(tmp_path) -> None:
     loaded = processed["multi_modal_embeddings"]["image"]
     assert len(loaded) == 1
     assert torch.equal(loaded[0], emb)
-
-
-@pytest.mark.asyncio
-async def test_epd_embedding_load_error_propagates() -> None:
-    """The encode worker calls load_tensor_from_path_or_url; its typed
-    error must propagate, not be swallowed into a yielded error dict."""
-    from dynamo.trtllm.encode_helper import EncodeHelper
-
-    url = "file:///missing.safetensors"
-    processor = MagicMock()
-    processor.extract_prompt_and_media.return_value = ("", [], [url])
-    processor.load_tensor_from_path_or_url.side_effect = HttpStatusError(
-        400, "Embedding file not found.", url
-    )
-
-    with pytest.raises(HttpStatusError) as excinfo:
-        async for _ in EncodeHelper.process_encode_request(
-            request={"messages": []},
-            multimodal_processor=processor,
-            connector=MagicMock(),  # the embedding flow requires a connector
-        ):
-            pass
-
-    assert excinfo.value.status == 400

--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
@@ -574,12 +574,10 @@ def _embedding_request(url: str) -> dict:
 # Each setup receives a processor whose allowed_local_media_path is tmp_path,
 # prepares one failure, and returns the URL the client would send.
 def _missing_file(tmp_path, processor):
-    """Return a URL for a file that does not exist inside the allowed directory."""
     return f"file://{tmp_path / 'missing.safetensors'}"
 
 
 def _outside_allowed_dir(tmp_path, processor):
-    """Restrict the allowed directory to a subfolder and return a file outside it."""
     allowed = tmp_path / "allowed"
     allowed.mkdir()
     processor.allowed_local_media_path = str(allowed)
@@ -589,7 +587,6 @@ def _outside_allowed_dir(tmp_path, processor):
 
 
 def _file_too_large(tmp_path, processor):
-    """Lower the size limit to 1 byte and return a valid file that exceeds it."""
     processor.max_file_size_bytes = 1
     path = tmp_path / "large.safetensors"
     save_file({"emb": torch.zeros(2)}, str(path))
@@ -604,7 +601,6 @@ def _missing_mm_embeddings_key(tmp_path, processor):
 
 
 def _unsupported_scheme(tmp_path, processor):
-    """Return a .safetensors URL with a scheme other than http or https."""
     return "ftp://example.invalid/emb.safetensors"
 
 
@@ -668,23 +664,3 @@ async def test_embedding_local_path_unconfigured_is_server_error(tmp_path) -> No
         )
 
     assert exc_info.value.status == 500
-
-
-@pytest.mark.asyncio
-async def test_embedding_valid_file_loads(tmp_path) -> None:
-    """The new error paths must leave a valid embedding file loading as before."""
-    processor = _embedding_processor(str(tmp_path))
-    emb = torch.ones(2, 3)
-    path = tmp_path / "emb.safetensors"
-    save_file({"emb": emb}, str(path))
-
-    processed = await processor.process_openai_request(
-        _embedding_request(f"file://{path}"),
-        embeddings=None,
-        ep_disaggregated_params=None,
-    )
-
-    assert processed["prompt"] == "describe"
-    loaded = processed["multi_modal_embeddings"]["image"]
-    assert len(loaded) == 1
-    assert torch.equal(loaded[0], emb)


### PR DESCRIPTION
## Summary:

A multimodal request on trtllm whose pre-computed embedding file (`.safetensors`) could not be loaded got a sanitized HTTP `500`, even when the client's URL was the problem. In `components/src/dynamo/trtllm/multimodal_processor.py`, `load_tensor_from_path_or_url()` raised `RuntimeError`, `process_openai_request()` swallowed it into `return None`, and `handler_base.py`  raised a generic `RuntimeError`. That maps to `Backend(Unknown)`, so the frontend gets a `500 "Internal server error"` and the reason is not propagated.

This PR classifies each failure by who caused it. Client-fault cases raise `HttpStatusError(400, ...)` and reach the frontend as a `400` with an actionable message. The server-configuration case stays a `5xx`.

## Details:

**`load_tensor_from_path_or_url`** (`components/src/dynamo/trtllm/multimodal_processor.py`)
- `RuntimeError` → `HttpStatusError(400)` for the client-related error cases:
  - embedding file not found
  - file outside `allowed_local_media_path`
  - file over the size limit
  - unsupported URL scheme
  - not `.safetensors` / unsafe tensor format
- Client-facing messages only shows the client's own input, never the server's path or the allowed directory. The containment check still runs before the existence check, so sending a "not found" file cannot be used to list files outside the allowed directory.
- `allowed_local_media_path` unset → `HttpStatusError(500)`. The issue [#14749](https://github.com/ai-dynamo/dynamo/issues/14749) leans towards this case being ambiguous, but I kept it `5xx` as proposed in the issue because it is the server's configuration causing it, not the client's request.

**`process_openai_request`**
- The embedding block now re-raises `HttpStatusError` before its generic `except Exception`, mirroring the existing image logic. Previously every embedding error just did `return None`.
- Dict embeddings missing the `mm_embeddings` key → `400`. The echoed path is bounded via `describe_media_source`.

**Scope notes**
- `load_tensor_from_path_or_url` is also called by the EPD encode worker (`encode_helper.py`), so its errors now carry a status there too. The encode→prefill hop is not verified end-to-end.
- As [#14467](https://github.com/ai-dynamo/dynamo/pull/14467) notes, `stream: true` clients still see `200` followed by an SSE error frame unless `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS` is set. The `4xx` reaches non-streaming clients.

## Validation:

- Ran `components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py` in `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.4.2`, with this branch mounted over the image via `PYTHONPATH=/src/components/src`, on an RTX 3050 Ti: **26 tests passed**.
- Negative control: with `multimodal_processor.py` reverted to `main` branch, **6 of the new tests fail**. These are the five `400` cases and the unconfigured `500` case, which confirms the tests catch the original behaviour. `test_embedding_valid_file_loads` pass either way, as expected, since they test existing behaviour.
- `pre-commit run` on the changed files, all hooks pass.
- **Not run:** the end-to-end serve tests because they need a larger GPU and I don't have one. In CI, `raw_embeddings_epd` sends a real `file://…safetensors` request. Then, the file is loaded by process_openai_request on that worker, so it covers the success path this PR touches only and not the new error statuses.

### Commands:

```
pre-commit run --files components/src/dynamo/trtllm/multimodal_processor.py \
  components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py
```
```
docker run --rm --gpus all -v "$PWD":/src -w /src -e PYTHONPATH=/src/components/src \
  nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.4.2 \
  bash -c 'pip install -q pytest==9.0.3 pytest-asyncio==1.3.0 pytest-benchmark==5.2.3 && \
    python -m pytest -p no:cacheprovider -v components/src/dynamo/trtllm/tests/test_trtllm_multimodal_processor.py'
```

New tests:
- `test_embedding_client_errors_return_400`, parametrized over: missing file, outside the allowed dir, too large, missing `mm_embeddings` key, unsupported scheme.
- `test_embedding_outside_allowed_dir_does_not_leak_it`
- `test_embedding_local_path_unconfigured_is_server_error`
- `test_embedding_valid_file_loads`

## Where should the reviewer start?

- `multimodal_processor.py`: `load_tensor_from_path_or_url`, and the embedding `try`/`except` block in `process_openai_request`.
- The status-code choices

## Related Issues

- Closes [#14749](https://github.com/ai-dynamo/dynamo/issues/14749)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when loading tensor and embedding files, including clearer validation, size, path, format, and missing-file errors.
  - Added safer handling for local media access and unsupported sources.
  - Prevented sensitive source details from being exposed in error messages.
  - Ensured typed loading errors are correctly surfaced to the frontend while unexpected failures retain generic handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->